### PR TITLE
CRAYSAT-1387: Declare new version of SAT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.16.0] - 2022-05-31
 
 ### Changed
 - Began using a separate ``cray_product_catalog`` package to query the product


### PR DESCRIPTION
This commit declares a new version of the SAT container image
in the CHANGELOG.

Test Description: I looked through the recent commits to verify
that everything was contained in the change log.