### PR TITLE
CRAYSAT-79: Add BOS boot status to `sat status`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   BOS API to use.
 - Added BOS v2 support to `sat bootprep`.
 - Added BOS v2 support to `sat bootsys`.
+- Added BOS v2 support to `sat status`, and added fields to `sat status` output
+  listing the most recent BOS session, template, booted image, and boot status
+  for nodes when BOS v2 is in use. Added a `--bos-fields` option to limit
+  output to these fields.
 
 ## [3.16.1] - 2022-06-07
 

--- a/sat/apiclient/bos.py
+++ b/sat/apiclient/bos.py
@@ -164,6 +164,28 @@ class BOSClientCommon(APIGatewayClient):
                            f'getting session status for session {session_id}: '
                            f'{err}')
 
+    def get_session(self, session_id):
+        """Get information about a given session.
+
+        Args:
+            session_id (str): the ID of the session
+
+        Returns:
+            dict: session information for the given session from BOS
+
+        Raises:
+            APIError: if there is a problem retrieving the session from BOS, or
+                if the returned JSON is invalid.
+        """
+
+        try:
+            return self.get(self.session_path, session_id).json()
+        except APIError as err:
+            raise APIError(f'Failed to get BOS session {session_id}: {err}')
+        except ValueError as err:
+            raise APIError(f'Failed to parse JSON in response from BOS when '
+                           f'getting session {session_id}: {err}')
+
     def get_sessions(self):
         """Get a list of all sessions.
 
@@ -255,3 +277,21 @@ class BOSV2Client(BOSClientCommon):
         del session_template_data['name']
 
         self.put(self.session_template_path, name, json=session_template_data)
+
+    def get_components(self):
+        """Get the full collection of components from BOS v2.
+
+        Returns:
+            list of dict: components managed by BOS v2
+
+        Raises:
+            APIError: if an error occurs while retrieving components from BOS
+                v2
+        """
+        try:
+            return self.get('components').json()
+        except APIError as err:
+            raise APIError(f'Failed to get BOS components: {err}')
+        except ValueError as err:
+            raise APIError(f'Failed to parse JSON in response from BOS when '
+                           f'getting components: {err}')

--- a/sat/cli/status/main.py
+++ b/sat/cli/status/main.py
@@ -184,7 +184,14 @@ def do_status(args):
         for module_name in args.status_module_names:
             if module_name in seen_module_names:
                 continue
-            modules.append(getattr(sat.cli.status.status_module, module_name))
+
+            module_cls = getattr(sat.cli.status.status_module, module_name)
+            can_use, err_reason = module_cls.can_use()
+            if not can_use:
+                LOGGER.warning('Cannot retrieve status information from %s: %s',
+                               module_cls.source_name, err_reason)
+            else:
+                modules.append(module_cls)
             seen_module_names.add(module_name)
 
     types = COMPONENT_TYPES if 'all' in args.types else args.types

--- a/sat/cli/status/parser.py
+++ b/sat/cli/status/parser.py
@@ -53,7 +53,7 @@ def add_status_subparser(subparsers):
 
     status_parser.add_argument(
         '--all-fields', dest='status_module_names',
-        action='store_const', const=['SLSStatusModule', 'HSMStatusModule', 'CFSStatusModule'],
+        action='store_const', const=['SLSStatusModule', 'HSMStatusModule', 'CFSStatusModule', 'BOSStatusModule'],
         help='Display all status fields. This is the default behavior when no other '
         '--*-fields options are specified.'
     )
@@ -77,6 +77,12 @@ def add_status_subparser(subparsers):
     )
 
     status_parser.add_argument(
+        '--bos-fields', dest='status_module_names',
+        action='append_const', const='BOSStatusModule',
+        help='Display all fields for BOS boot state.'
+    )
+
+    status_parser.add_argument(
         '--bos-template',
         help='Only show nodes specified in the node list, roles, and groups in '
              'the boot sets contained in the given BOS session template.'
@@ -84,6 +90,6 @@ def add_status_subparser(subparsers):
 
     status_parser.add_argument(
         '--bos-version',
-        choices=['v1'],  # TODO (CRAYSAT-79): Add v2
+        choices=['v1', 'v2'],
         help='The version of the BOS API to use for BOS operations',
     )

--- a/tests/cli/status/test_status_module.py
+++ b/tests/cli/status/test_status_module.py
@@ -26,15 +26,22 @@ import inspect
 import unittest
 from unittest.mock import MagicMock, patch
 
+from sat.apiclient.gateway import APIError
 import sat.cli.status.status_module as status_module_module
-from sat.cli.status.status_module import StatusModule, StatusModuleException
+from sat.cli.status.status_module import (
+    BOSStatusModule,
+    StatusModule,
+    StatusModuleException,
+)
 from sat.constants import MISSING_VALUE
 
 
 class BaseStatusModuleTestCase(unittest.TestCase):
     def setUp(self):
         self.modules = []
-        patch.object(StatusModule, 'modules', self.modules).start()
+        patch.object(StatusModule, '_modules', self.modules).start()
+
+        self.mock_get_config_value = patch('sat.cli.status.status_module.get_config_value').start()
 
     def tearDown(self):
         patch.stopall()
@@ -48,17 +55,17 @@ class TestStatusModuleSubclassing(BaseStatusModuleTestCase):
         class TestStatusModule(StatusModule, ABC):
             pass  # Don't need to define methods, no instances are created.
 
-        self.assertIn(TestStatusModule, StatusModule.modules)
+        self.assertIn(TestStatusModule, StatusModule._modules)
 
     def test_status_modules_class_attr_isolated(self):
-        """Test that we aren't accidentally modifying the real StatusModule.modules and impacting other tests."""
-        self.assertEqual(0, len(StatusModule.modules))
+        """Test that we aren't accidentally modifying the real StatusModule._modules and impacting other tests."""
+        self.assertEqual(0, len(StatusModule._modules))
         patch.stopall()
         implemented_submodules = [
             module for _, module in inspect.getmembers(status_module_module, inspect.isclass)
             if issubclass(module, StatusModule) and module is not StatusModule
         ]
-        self.assertEqual(len(implemented_submodules), len(StatusModule.modules))
+        self.assertCountEqual(implemented_submodules, StatusModule._modules)
 
 
 class TestStatusModuleGettingModules(BaseStatusModuleTestCase):
@@ -257,3 +264,188 @@ class TestGettingRows(BaseStatusModuleTestCase):
 
         if not row_had_missing_config:
             self.fail('Rows with missing "state" field were omitted')
+
+
+class TestBOSStatusModule(BaseStatusModuleTestCase):
+    """Tests for the BOSStatusModule class"""
+
+    def setUp(self):
+        super().setUp()
+
+        self.xname = 'x1000c0s0b1n0'
+        self.img_id = '12345678-abcd-efef-abcd-1234567890ab'
+        self.img_name = 'some-image'
+        self.bos_session = 'abcdef01-abcd-abcd-abcd-12345abcdefa'
+        self.bos_sessiontemplate = 'some-session-template'
+        self.bos_component = {
+            'actual_state': {
+                'boot_artifacts': {
+                    'initrd': f's3://boot-images/{self.img_id}/initrd',
+                    'kernel': f's3://boot-images/{self.img_id}/kernel',
+                    'kernel_parameters': 'console=ttyS0'
+                },
+                'configuration': '',
+                'last_updated': '2022-01-01T00:00:00'
+            },
+            'desired_state': {
+                'boot_artifacts': {
+                    'initrd': 's3://boot-images/9c80b8fb-190c-4adc-bef6-895928f4f262/initrd',
+                    'kernel': 's3://boot-images/9c80b8fb-190c-4adc-bef6-895928f4f262/kernel',
+                    'kernel_parameters': 'console=ttyS0'
+                },
+                'configuration': '',
+                'last_updated': '2022-01-01T00:00:00'
+            },
+            'enabled': False,
+            'error': '',
+            'id': self.xname,
+            'last_action': {
+                'action': 'powering_on',
+                'last_updated': '2022-01-01T00:00:00',
+                'num_attempts': 1
+            },
+            'session': self.bos_session,
+            'staged_state': {
+                'last_updated': '2022-01-01T00:00:00'
+            },
+            'status': {
+                'phase': '',
+                'status': 'stable',
+                'status_override': ''
+            }
+        }
+
+        self.mock_bos_client = MagicMock()
+        self.mock_bos_client.get_session.return_value = {
+            'components': self.xname,
+            'limit': '',
+            'name': self.bos_session,
+            'operation': 'boot',
+            'stage': False,
+            'status': {
+                'end_time': '2022-01-01T00:00:00',
+                'error': None,
+                'start_time': '2022-01-01T00:01:00',
+                'status': 'complete',
+            },
+            'template_name': self.bos_sessiontemplate,
+        }
+        self.mock_bos_client.get_session_template.return_value = {
+            'name': self.bos_sessiontemplate
+        }
+
+        self.mock_bos_client.get_components.return_value = [self.bos_component]
+        patch('sat.cli.status.status_module.BOSClientCommon.get_bos_client',
+              return_value=self.mock_bos_client).start()
+
+        self.mock_ims_client = MagicMock()
+        self.mock_ims_client.get_image.return_value = {
+            'created': '2022-01-01T00:00:00',
+            'id': self.img_id,
+            'link': {
+                'etag': 'abcdef123456789abcdef12345678909',
+                'path': f's3://boot-images/{self.img_id}/manifest.json',
+                'type': 's3',
+            },
+            'name': self.img_name,
+        }
+        patch('sat.cli.status.status_module.IMSClient', return_value=self.mock_ims_client).start()
+
+        self.session = MagicMock()
+
+    def test_can_use_in_bos_v1(self):
+        """Test checking if BOSStatusModule can be used with BOS v1"""
+        self.mock_get_config_value.return_value = 'v1'
+        can_use, err_msg = BOSStatusModule.can_use()
+        self.assertFalse(can_use)
+        self.assertIsInstance(err_msg, str)
+
+    def test_can_use_in_bos_v2(self):
+        """Test checking if BOSStatusModule can be used with BOS v2"""
+        self.mock_get_config_value.return_value = 'v2'
+        can_use, err_msg = BOSStatusModule.can_use()
+        self.assertTrue(can_use)
+        self.assertIsNone(err_msg)
+
+    def test_retrieving_component_sessions_can_be_retrieved(self):
+        """Test that component status can be retrieved from BOS v2"""
+        rows = BOSStatusModule(session=self.session).rows
+
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0], {
+            'xname': self.xname,
+            'Boot Status': 'stable',
+            'Most Recent BOS Session': self.bos_session,
+            'Most Recent Image': self.img_name,
+            'Most Recent Session Template': self.bos_sessiontemplate,
+        })
+
+    def test_empty_session_for_component(self):
+        """Test retrieving component status if session field is empty"""
+        self.bos_component['session'] = ''
+        rows = BOSStatusModule(session=self.session).rows
+
+        self.assertEqual(rows[0], {
+            'xname': self.xname,
+            'Boot Status': 'stable',
+            'Most Recent BOS Session': MISSING_VALUE,
+            'Most Recent Image': self.img_name,
+        })
+
+    def test_no_session_key_for_component(self):
+        """Test retrieving component status if there is no "session" key"""
+        del self.bos_component['session']
+        rows = BOSStatusModule(session=self.session).rows
+
+        self.assertEqual(rows[0], {
+            'xname': self.xname,
+            'Boot Status': 'stable',
+            'Most Recent BOS Session': MISSING_VALUE,
+            'Most Recent Image': self.img_name,
+        })
+
+    def test_session_key_empty_string(self):
+        """Test retrieving component status the "session" key is empty"""
+        self.bos_component['session'] = ''
+        rows = BOSStatusModule(session=self.session).rows
+        self.assertEqual(rows[0], {
+            'xname': self.xname,
+            'Boot Status': 'stable',
+            'Most Recent BOS Session': MISSING_VALUE,
+            'Most Recent Image': self.img_name,
+        })
+
+    def test_get_session_apierror(self):
+        """Test retrieving component boot status when no session is found"""
+        self.mock_bos_client.get_session.side_effect = APIError
+        rows = BOSStatusModule(session=self.session).rows
+
+        self.assertEqual(rows[0], {
+            'xname': self.xname,
+            'Boot Status': 'stable',
+            'Most Recent BOS Session': self.bos_session,
+            'Most Recent Image': self.img_name,
+        })
+
+    def test_get_sessiontemplate_apierror(self):
+        """Test retrieving component boot status when no sessiontemplate found"""
+        self.mock_bos_client.get_session_template.side_effect = APIError
+        rows = BOSStatusModule(session=self.session).rows
+
+        self.assertEqual(rows[0], {
+            'xname': self.xname,
+            'Boot Status': 'stable',
+            'Most Recent BOS Session': self.bos_session,
+            'Most Recent Image': self.img_name,
+        })
+
+    def test_get_sessiontemplate_keyerror(self):
+        """Test retrieving component boot status when sessiontemplate missing "name" key"""
+        self.mock_bos_client.get_session_template.return_value = {}
+        rows = BOSStatusModule(session=self.session).rows
+        self.assertEqual(rows[0], {
+            'xname': self.xname,
+            'Boot Status': 'stable',
+            'Most Recent BOS Session': self.bos_session,
+            'Most Recent Image': self.img_name,
+        })


### PR DESCRIPTION
## Summary and Scope

This change adds support for querying the BOS boot status of nodes to
`sat status` output. This is implemented by querying the `/components`
endpoint from BOS v2. The following information is gathered and
displayed:
  * BOS boot status
  * Most recent BOS session
  * Session template used by the most recent session
  * Reported image name

## Issues and Related PRs

* Resolves [CRAYSAT-79](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-79)

## Testing

### Tested on:

  * `baldar`

### Test description:

Boot compute nodes on an internal system with BOS v2 to populate BOS
component status fields. Run `sat status --bos-fields --bos-version=v2`
and verify that displayed status fields contain correct information.
Test with BOS v1 and verify that v1 is not supported.

## Risks and Mitigations

None.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

