### PR TITLE
CRAYSAT-1128: Change logging to print in sat init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- Fixed an issue causing `sat init` to not print a message when a new config was created.
+
 ### Removed
 - Removed unused `docker` python package from requirements files.
 

--- a/sat/cli/init/main.py
+++ b/sat/cli/init/main.py
@@ -1,7 +1,7 @@
 """
 The main entry point for the init subcommand.
 
-(C) Copyright 2020-2021 Hewlett Packard Enterprise Development LP.
+(C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP.
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -40,6 +40,6 @@ def do_init(args):
     config_file_path = args.output or os.getenv('SAT_CONFIG_FILE', DEFAULT_CONFIG_PATH)
     try:
         generate_default_config(config_file_path, username=args.username, force=args.force)
-        LOGGER.info(f'Configuration file "{config_file_path}" generated.')
+        print(f'INFO: Configuration file "{config_file_path}" generated.')
     except ConfigFileExistsError as err:
         LOGGER.warning(err)


### PR DESCRIPTION
## Summary and Scope

This change uses `print()` to display logging messages in `sat init`
since logging is not configured while running `sat init`. This change
allows informational messages to be displayed to the user.

## Issues and Related PRs

* Resolves [CRAYSAT-1128](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1128)

## Testing

### Tested on:

  * `baldar`

### Test description:

Run `sat init -o /tmp/config.toml` and ensure the INFO message is
printed. Run `sat init -o /tmp/config.toml` again and ensure a WARNING
message is printed. Run unit tests.

## Risks and Mitigations

None.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

