### PR TITLE
CRAYSAT-79: Remove warning when session is empty string

### DIFF
--- a/sat/cli/status/status_module.py
+++ b/sat/cli/status/status_module.py
@@ -527,8 +527,9 @@ class BOSStatusModule(StatusModule):
             try:
                 session_id = raw_component.get('session')
                 if not session_id:
-                    LOGGER.warning('"session" key missing from BOS response for component %s',
-                                   component_xname)
+                    if session_id is None:
+                        LOGGER.warning('"session" key missing from BOS response for component %s',
+                                       component_xname)
                     continue
 
                 try:


### PR DESCRIPTION
## Summary and Scope

This change removes a warning message printed when a given component's
session is the empty string. This can happen when a node hasn't been
booted by a BOS session, and is not necessarily a problem. A warning is
still printed if the "session" key is not present.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Changes [issue id](issue link)

## Testing

### Tested on:

  * `baldar`

### Test description:

Test on internal system and ensure that no warnings are printed for
components which have `.session == ""`.

## Risks and Mitigations

None.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

