### PR TITLE
CRAYSAT-1388: Remove unnecessary Rust dependencies from build container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@
 #
 # The multi-stage Dockerfile is somewhat more complex than the original
 # Dockerfile, but it provides significant reductions in image size and build time
-# when cached builds are present. 
+# when cached builds are present.
 
 
 # The venv_base sets up the environment variables for the virtualenv which are
@@ -51,7 +51,7 @@ FROM base as build
 
 RUN apk update && \
     apk add bash bash-completion openssl-dev libffi-dev openssh curl musl-dev \
-            git make gcc mandoc ipmitool ceph-common rust cargo && \
+            git make gcc mandoc ipmitool ceph-common && \
     python3 -m venv $VIRTUAL_ENV
 
 COPY requirements.lock.txt requirements.txt
@@ -67,7 +67,7 @@ COPY sat sat
 COPY docs/man docs/man
 COPY tools tools
 
-RUN pip3 install --no-cache-dir 'pip < 22.0' && \
+RUN pip3 install --no-cache-dir pip && \
     pip3 install --no-cache-dir --timeout=300 . && \
     ./config-docker-sat.sh
 


### PR DESCRIPTION
## Summary and Scope

This change removes the no-longer-needed `rust` and `cargo` dependencies
from our build containers. These were previously needed for building
the `cryptography` wheel for alpine.

## Issues and Related PRs

* Resolves [CRAYSAT-1388](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1388)

## Testing


### Tested on:

  * Local development environment

### Test description:

`docker build -t sat-docker:latest .` in project root

## Risks and Mitigations

None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

