### PR TITLE
CRAYSAT-1456: Change creation-time permissions of config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Whenever `sat` is invoked, the permissions of the `~/.config/sat/sat.toml`
+  file will be set to `0600`, and the permissions of the `~/.config/sat/tokens`
+  and `~/.config/sat` directories will be set to `0700`.
+
 ## [3.17.0] - 2022-06-27
 
 ### Added

--- a/sat/config.py
+++ b/sat/config.py
@@ -35,6 +35,7 @@ import toml
 
 from sat.cli.bootsys.parser import TIMEOUT_SPECS
 
+
 DEFAULT_CONFIG_PATH = f'{os.getenv("HOME", "/root")}/.config/sat/sat.toml'
 LOGGER = logging.getLogger(__name__)
 CONFIG = None
@@ -434,7 +435,7 @@ def generate_default_config(path, username=None, force=False):
     config_file_dir = os.path.dirname(path)
     if not os.path.isdir(config_file_dir):
         try:
-            os.makedirs(config_file_dir, exist_ok=True)
+            os.makedirs(config_file_dir, mode=0o700, exist_ok=True)
         except OSError as e:
             LOGGER.error(f'Unable to create directory {config_file_dir}: {e}')
             raise SystemExit(1)
@@ -454,6 +455,8 @@ def generate_default_config(path, username=None, force=False):
 
     try:
         output_stream = open(path, 'w')
+        os.fchmod(output_stream.fileno(), 0o600)
+
         with output_stream:
             toml_str = toml.dumps(config_spec)
             output_stream.write(process_toml_output(toml_str))

--- a/sat/session.py
+++ b/sat/session.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -132,7 +132,7 @@ class SATSession:
             os.fchmod(f.fileno(), 0o600)
             json.dump(token, f)
 
-        LOGGER.info('Saved auth token to: %s', self.token_filename)
+        print(f'INFO: Saved auth token to: {self.token_filename}')
 
     @property
     def token_url(self):
@@ -157,10 +157,11 @@ class SATSession:
             self._token = self.session.fetch_token(token_url=self.token_url,
                                                    username=username, password=password, **opts)
         except (MissingTokenError, UnauthorizedClientError, InvalidGrantError) as err:
-            LOGGER.error("Authorization of user '%s' failed: %s.", username, err)
+            # Avoid recording the authenticated user in the log file
+            print(f"ERROR: Authorization of user '{username}' failed: {err}.")
             self._token = None
         else:
-            LOGGER.info("Acquired new auth token for user '%s'.", username)
+            print(f"INFO: Acquired new auth token for user '{username}'.")
 
     @cached_property
     def session_opts(self):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -214,7 +214,7 @@ class TestGenerateDefaultConfig(unittest.TestCase):
         generate_default_config('/etc/opt/cray/sat.toml')
         self.mock_open.assert_called_once_with('/etc/opt/cray/sat.toml', 'w')
         self.mock_output_stream.write.assert_called_once_with(self.expected_config)
-        self.mock_makedirs.assert_called_once_with('/etc/opt/cray', exist_ok=True)
+        self.mock_makedirs.assert_called_once_with('/etc/opt/cray', mode=0o700, exist_ok=True)
 
     def test_generate_with_username(self):
         """Test generating config with a username will write a config file with a username"""

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -25,12 +25,13 @@
 Unit tests for sat/util.py.
 """
 from collections import OrderedDict
-from itertools import combinations, product
+from itertools import combinations, repeat
 import logging
 import os
 from textwrap import dedent
 from unittest import mock
 import unittest
+from unittest.mock import patch
 
 from sat import util
 from tests.common import ExtendedTestCase
@@ -598,6 +599,58 @@ class TestSubsequenceMatching(unittest.TestCase):
         for needle in ['zabraboof', 'nothing', 'ofoarbazb',
                        'foobarbax', 'bff', 'egads']:
             self.assertFalse(util.is_subsequence(needle, haystack))
+
+
+class TestEnsurePermissions(unittest.TestCase):
+    """Tests for the ensure_permissions() function"""
+    def setUp(self):
+        self.mock_chmod = patch('sat.util.os.chmod').start()
+
+        def mock_is_file(path):
+            return path == self.path
+        self.mock_is_file = patch('sat.util.os.path.isfile',
+                                  side_effect=mock_is_file).start()
+
+        def mock_is_dir(path):
+            return path == self.dirname
+        self.mock_is_dir = patch('sat.util.os.path.isdir',
+                                 side_effect=mock_is_dir).start()
+
+        self.dirname = '/foo/bar/baz'
+        self.filename = 'quux.toml'
+        self.path = os.path.join(self.dirname, self.filename)
+
+    def tearDown(self):
+        patch.stopall()
+
+    def test_file_and_dir_chmodded(self):
+        """Test that the target file and containing directory are chmodded"""
+        util.ensure_permissions(self.path)
+        self.mock_chmod.assert_any_call(self.dirname, 0o700)
+        self.mock_chmod.assert_any_call(self.path, 0o600)
+
+    def test_directory_chmodded_when_file_missing(self):
+        """Test that the containing directory is chmodded when the file is missing"""
+        # Using `side_effect = repeat(...)` is essentially the same as using
+        # `return_value`, but since `side_effect` is set in `setUp()`, it
+        # overrides `return_value`.
+        self.mock_is_file.side_effect = repeat(False)
+
+        util.ensure_permissions(self.path)
+        self.mock_chmod.assert_called_once_with(self.dirname, 0o700)
+
+    def test_nothing_chmodded_when_directory_missing(self):
+        """Test that chmod() is not called when file and directory are missing"""
+        self.mock_is_file.side_effect = repeat(False)
+        self.mock_is_dir.side_effect = repeat(False)
+        util.ensure_permissions(self.path)
+        self.mock_chmod.assert_not_called()
+
+    def test_directory_chmod_when_path_is_dir(self):
+        """Test changing the permissions on a directory path"""
+        self.mock_is_file.side_effect = repeat(False)
+        util.ensure_permissions(self.dirname)
+        self.mock_chmod.assert_called_once_with(self.dirname, 0o700)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION


Test Description:

## Summary and Scope

This change sets the permissions of the config directory to 0700 and the
config file to 0600 at creation time. Additionally, the tokens directory
and config file and directory will have their permissions set to 0700
and 0600, respectively, at each invocation of `sat`.

## Issues and Related PRs

* Resolves [CRAYSAT-1456](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1456)

## Testing

### Tested on:

  * `baldar`

### Test description:

* Run sat init command with non-existent config directory and make sure
  that the config directory and files are created with the proper
  permissions
* Change permissions of `.config/sat/{,tokens}` and run a `sat` command.
  Make sure that permissions were changed back to 600 and 700.


## Risks and Mitigations
None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

