### PR TITLE
CRAYSAT-1486: Fix unit tests in PyCharm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Fixed unit tests that failed when run in PyCharm.
+
 ## [3.17.1] - 2022-07-05
 
 ### Changed

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -158,6 +158,7 @@ class TestGenerateDefaultConfig(unittest.TestCase):
         }
         mock.patch('sat.config.SAT_CONFIG_SPEC', self.fake_config_spec).start()
         self.mock_open = mock.patch('builtins.open').start()
+        self.mock_fchmod = mock.patch('sat.config.os.fchmod').start()
         self.mock_output_stream = self.mock_open.return_value
         self.mock_isdir = mock.patch('sat.config.os.path.isdir', return_value=True).start()
         self.mock_isfile = mock.patch('sat.config.os.path.isfile', return_value=False).start()
@@ -199,6 +200,7 @@ class TestGenerateDefaultConfig(unittest.TestCase):
         generate_default_config(DEFAULT_CONFIG_PATH)
         self.mock_open.assert_called_with(DEFAULT_CONFIG_PATH, 'w')
         self.mock_output_stream.write.assert_called_once_with(self.expected_config)
+        self.mock_fchmod.assert_called_once_with(self.mock_output_stream.fileno.return_value, 0o600)
         self.mock_makedirs.assert_not_called()
 
     def test_generate_alternate_location(self):
@@ -206,6 +208,7 @@ class TestGenerateDefaultConfig(unittest.TestCase):
         generate_default_config('/mock/path.toml')
         self.mock_open.assert_called_once_with('/mock/path.toml', 'w')
         self.mock_output_stream.write.assert_called_once_with(self.expected_config)
+        self.mock_fchmod.assert_called_once_with(self.mock_output_stream.fileno.return_value, 0o600)
         self.mock_makedirs.assert_not_called()
 
     def test_generate_create_directory(self):
@@ -214,6 +217,7 @@ class TestGenerateDefaultConfig(unittest.TestCase):
         generate_default_config('/etc/opt/cray/sat.toml')
         self.mock_open.assert_called_once_with('/etc/opt/cray/sat.toml', 'w')
         self.mock_output_stream.write.assert_called_once_with(self.expected_config)
+        self.mock_fchmod.assert_called_once_with(self.mock_output_stream.fileno.return_value, 0o600)
         self.mock_makedirs.assert_called_once_with('/etc/opt/cray', mode=0o700, exist_ok=True)
 
     def test_generate_with_username(self):
@@ -222,6 +226,7 @@ class TestGenerateDefaultConfig(unittest.TestCase):
         generate_default_config(DEFAULT_CONFIG_PATH, username='sat_user')
         self.mock_open.assert_called_with(DEFAULT_CONFIG_PATH, 'w')
         self.mock_output_stream.write.assert_called_once_with(self.expected_config)
+        self.mock_fchmod.assert_called_once_with(self.mock_output_stream.fileno.return_value, 0o600)
         self.mock_makedirs.assert_not_called()
 
     def test_generate_file_exists(self):
@@ -234,6 +239,7 @@ class TestGenerateDefaultConfig(unittest.TestCase):
             generate_default_config(DEFAULT_CONFIG_PATH)
         self.mock_open.assert_not_called()
         self.mock_output_stream.write.assert_not_called()
+        self.mock_fchmod.assert_not_called()
         self.mock_makedirs.assert_not_called()
 
     def test_generate_file_exists_force(self):
@@ -242,6 +248,7 @@ class TestGenerateDefaultConfig(unittest.TestCase):
         generate_default_config(DEFAULT_CONFIG_PATH, force=True)
         self.mock_open.assert_called_with(DEFAULT_CONFIG_PATH, 'w')
         self.mock_output_stream.write.assert_called_once_with(self.expected_config)
+        self.mock_fchmod.assert_called_once_with(self.mock_output_stream.fileno.return_value, 0o600)
         self.mock_makedirs.assert_not_called()
 
 


### PR DESCRIPTION
## Summary and Scope

This commit changes the unit tests for generate_default_config
so that os.fchmod is mocked out, and the tests assert it is called
as expected.

## Issues and Related PRs

CRAYSAT-1487

## Testing

Ran unit tests

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

