### PR TITLE
CRAYSAT-1376: Document --bos-version in relevant man pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added information regarding the `--bos-version` command line argument to man
+  pages for relevant subcommands.
+
 ### Fixed
 - Fixed unit tests that failed when run in PyCharm.
 

--- a/docs/man/sat-bootsys.8.rst
+++ b/docs/man/sat-bootsys.8.rst
@@ -7,7 +7,7 @@ Shut down or boot the entire system gracefully
 ----------------------------------------------
 
 :Author: Hewlett Packard Enterprise Development LP.
-:Copyright: Copyright 2020-2021 Hewlett Packard Enterprise Development LP.
+:Copyright: Copyright 2020-2022 Hewlett Packard Enterprise Development LP.
 :Manual section: 8
 
 SYNOPSIS
@@ -93,7 +93,7 @@ These options apply to both the ``shutdown`` and ``boot`` actions.
         Certain actions can be disruptive to the system, and so require
         interactive user confirmation to proceed. Using the ``--disruptive``
         option skips any interactive user prompts. If ``--disruptive`` is used
-        with a stage which is not disruptive, it is ignored. The following 
+        with a stage which is not disruptive, it is ignored. The following
         shutdown stages are considered disruptive:
 
         * bos-operations
@@ -114,6 +114,9 @@ These options apply to both the ``shutdown`` and ``boot`` actions.
         precedence over ``--cle-bos-template`` and ``--uan-bos-template``
         (below). This overrides the option ``bootsys.bos_templates`` in the
         config file.
+
+**--bos-version BOS_VERSION**
+        The version of the BOS API to use when launching BOS sessions.
 
 **--cle-bos-template** *CLE_BOS_TEMPLATE*
         The name of the BOS session template for shutdown or boot of

--- a/docs/man/sat-status.8.rst
+++ b/docs/man/sat-status.8.rst
@@ -57,6 +57,13 @@ These options must be specified after the subcommand.
         Count fields will be shown. May be combined with **--hsm-fields** and
         **--sls-fields**.
 
+**--bos-fields**
+        Only query and display information from BOS about nodes' boot status,
+        recent BOS sessions, booted session templates, and booted images.
+        **--bos-fields** requires BOS v2, so the **bos.api_version**
+        configuration file setting or the **--bos-version** command line option
+        must be set to "v2".
+
 **--bos-template**
         Specify a BOS session template to filter against. Only nodes specified
         in the node list, node groups, and roles in this session template's
@@ -70,6 +77,10 @@ These options must be specified after the subcommand.
         Likewise, roles or groups may also be added to or removed from the
         session template itself, and these changes would not be reflected in
         any BOS running or completed session either.
+
+**--bos-version BOS_VERSION**
+        The version of the BOS API to use when looking up BOS template boot
+        sets or querying BOS boot status.
 
 .. include:: _sat-format-opts.rst
 .. include:: _sat-filter-opts.rst


### PR DESCRIPTION
## Summary and Scope

Documented `--bos-version` in relevant subcommand man pages.

## Issues and Related PRs

* Additional change for work related to epic CRAYSAT-1376

## Testing

### Tested on:

* Local development machine

### Test description:

Build man pages, inspect output manually to ensure proper text and
formatting

## Risks and Mitigations

None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

