### PR TITLE
CRAYSAT-1411: Refactor image dependencies and add name templating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 	- `name` of elements of the `configurations` array
 	- `name`, `branch`, and `version` of elements under `layers` in
 	  elements of the `configurations` array
+	- `name`, `base.product.version`, and `configuration` properties of
+	  elements in the `images` array.
+	- `name`, `configuration`, and `image` properties of elements in the
+	  `session_templates` array.
 - Defined a `sat bootprep` input file schema version and began validating the
   schema version specified by `sat bootprep` input files.
 - Added functionality to `sat bootprep` to look up images and recipes provided
@@ -43,6 +47,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Changed the `sat bootprep` input file schema by adding a new `base` property
   for an image and moved the existing `ims` property beneath that new property.
+- Changed how `sat bootprep` determines dependencies between images in the input
+  file using new `ref_name` and `base.image_ref` properties.
 
 ### Deprecated
 - Specifying the `ims` property at the top level of an image in the `sat

--- a/docs/man/sat-bootprep.8.rst
+++ b/docs/man/sat-bootprep.8.rst
@@ -120,9 +120,8 @@ These options only apply to the ``run`` action.
 **--recipe-version RECIPE_VERSION**
         The HPC software recipe version, e.g. 22.03. This is used to obtain the
         product versions which can be substituted for variables specified in
-        fields in the input file. If not specified, variables are not loaded
-        from the HPC software recipe. If "latest" is specified, use the latest
-        available HPC software recipe.
+        fields in the input file. If not specified or if "latest" is specified,
+        use the latest available HPC software recipe.
 
 **--vars-file VARS_FILE**
         A file containing variables that can be used in fields in the input

--- a/sat/cli/bootprep/input/base.py
+++ b/sat/cli/bootprep/input/base.py
@@ -38,23 +38,109 @@ from sat.cli.bootprep.errors import InputItemCreateError, InputItemValidateError
 from sat.util import pester_choices
 
 LOGGER = logging.getLogger(__name__)
+inflector = engine()
+
+
+def provides_context(context_var=None):
+    """Get decorator for instance methods which provide Jinja2 context.
+
+    This should be used to decorate instance methods which provide additional
+    context which should be used when rendering Jinja2 templates with the
+    jinja_rendered decorator defined below.
+
+    Note that the context provided by the instance method decorated with this
+    decorator will not be available until that method is called.
+
+    This decorator requires that the instance has the following attribute:
+
+        jinja_context (dict): additional context to use when rendering the
+            result of the method as a Jinja2 template. Defaults to the empty
+            dict if not set.
+    """
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(self, *args, **kwargs):
+            result = func(self, *args, **kwargs)
+            self.jinja_context[context_var or func.__name__] = result
+            return result
+
+        return wrapper
+
+    return decorator
+
+
+def jinja_rendered(func):
+    """Decorator for instance methods which return Jinja2 templates.
+
+    This should be used to decorate instance methods which return content from
+    the InputInstance that supports rendering as a Jinja2 template. If the
+    `func` returns `None`, this wrapper will as well.
+
+    This decorator requires the instance has the following attribute:
+
+        jinja_env (jinja2.Environment): the Jinja2 environment to use to get
+            Template objects to be rendered. Variables to use as context are
+            expected to already be set in the `globals` attribute.
+
+    This decorator uses the following additional optional attributes of the instance:
+
+        create_error_cls: the exception class that should be raised if there is
+            an issue rendering the template. Defaults to InputItemValidateError
+            if not set.
+
+        jinja_context (dict): additional context to use when rendering the
+            result of the method as a Jinja2 template. Defaults to the empty
+            dict if not set.
+    """
+    @functools.wraps(func)
+    def wrapper(self, *args, **kwargs):
+        # First call the wrapped method and get its result
+        unrendered_result = func(self, *args, **kwargs)
+
+        # If value not specified in input file, the `func` may return `None`
+        if unrendered_result is None:
+            return unrendered_result
+
+        # Default to InputItemCreateError if no error class is specified
+        error_cls = getattr(self, 'create_error_cls', InputItemValidateError)
+
+        # Default to no additional context if not set
+        context = getattr(self, 'jinja_context', {})
+
+        try:
+            return self.jinja_env.from_string(unrendered_result).render(context)
+        except SecurityError as err:
+            raise error_cls(f'Jinja2 template {unrendered_result} for value '
+                            f'{func.__name__} tried to access unsafe attributes.') from err
+        except TemplateError as err:
+            raise error_cls(f'Failed to render Jinja2 template {unrendered_result} '
+                            f'for value {func.__name__}: {err}') from err
+
+    return wrapper
 
 
 class Validatable:
     """A base class for something that can be validated"""
 
     VAL_METHOD_ATTR = 'is_validation_method'
+    VAL_METHOD_ORDINAL_ATTR = 'validation_method_ordinal'
+    # The default value for a validation method's ordinal value
+    DEFAULT_ORDINAL = 1
 
     @staticmethod
-    def validation_method(method):
-        """Mark a method as a validation method.
+    def validation_method(ordinal=DEFAULT_ORDINAL):
+        """Return a decorator to mark a method as a validation method.
 
         Args:
-            method: the method on which to set the attribute
-                Validatable.VAL_METHOD_ATTR to True
+            ordinal (int): the priority of the validation method. Validation
+                methods will be called in priority order
         """
-        setattr(method, Validatable.VAL_METHOD_ATTR, True)
-        return method
+        def decorator(method):
+            setattr(method, Validatable.VAL_METHOD_ATTR, True)
+            setattr(method, Validatable.VAL_METHOD_ORDINAL_ATTR, ordinal)
+            return method
+
+        return decorator
 
     def attr_is_validation_method(self, attr_name):
         """Returns whether the method is a validation method of this class
@@ -80,9 +166,12 @@ class Validatable:
 
     @property
     def validation_methods(self):
-        """list of callable: all the methods tagged as validation methods"""
-        return [getattr(self, attr_name) for attr_name in dir(self)
-                if self.attr_is_validation_method(attr_name)]
+        """list of callable: all the methods tagged as validation methods in ordinal order"""
+        return sorted(
+            [getattr(self, attr_name) for attr_name in dir(self)
+             if self.attr_is_validation_method(attr_name)],
+            key=lambda m: getattr(m, self.VAL_METHOD_ORDINAL_ATTR, self.DEFAULT_ORDINAL)
+        )
 
     def validate(self, **kwargs):
         """Validate this object by calling all of its validation methods.
@@ -120,28 +209,38 @@ class BaseInputItem(Validatable, ABC):
     # The description for the input item, to be overridden by each subclass
     description = 'base input item'
 
-    def __init__(self, data, instance, **_):
+    create_error_cls = InputItemValidateError
+
+    def __init__(self, data, instance, index, jinja_env, **_):
         """Create a new BaseInputItem.
 
         Args:
             data (dict): the data defining the item from the input file, already
                 validated by the bootprep schema
-            instance (sat.cli.bootprep.input.InputInstance): a reference to the
-                full instance loaded from the config file
+            instance (sat.cli.bootprep.input.instance.InputInstance): a reference
+                to the full instance loaded from the input file
+            index (int): the index of the item in the collection in the instance
+            jinja_env (jinja2.Environment): the Jinja2 environment in which
+                fields supporting Jinja2 templating should be rendered.
         """
         self.data = data
         self.instance = instance
+        self.index = index
+        self.jinja_env = jinja_env
         self.items_to_delete = []
 
     @property
+    @jinja_rendered
     def name(self):
-        """str: the name of this input item that is to be created"""
+        """str: the rendered name of this input item that is to be created"""
         # The 'name' property is required by the schema for all types of input
         # items that inherit from BaseInputItem.
         return self.data['name']
 
     def __str__(self):
-        return f'{self.description} named {self.name}'
+        # Since the name can be rendered, and when unrendered, it does not need
+        # to be unique, just refer to this item by its index in the instance.
+        return f'{self.description} at index {self.index}'
 
     def add_items_to_delete(self, delete_list):
         """Add a list of items that should be deleted after this item is created.
@@ -199,10 +298,9 @@ class BaseInputItemCollection(ABC, Validatable):
         skipped_items (list of BaseInputItem): the input items that
             should be skipped
     """
-    inflector = engine()
     item_class = BaseInputItem
 
-    def __init__(self, items_data, instance, **kwargs):
+    def __init__(self, items_data, instance, jinja_env, **kwargs):
         """Create a new BaseInputItemCollection.
 
         Args:
@@ -210,17 +308,20 @@ class BaseInputItemCollection(ABC, Validatable):
                 input file, already validated by the schema
             instance (sat.bootprep.input.InputInstance): a reference to the
                 full instance loaded from the config file
+            jinja_env (jinja2.Environment): the Jinja2 environment in which
+                fields supporting Jinja2 templating should be rendered.
             **kwargs: additional keyword arguments which are passed through to
                 the constructor of the class defined in the class attribute
                 `item_class`
         """
-        self.items = [self.item_class(item_data, instance, **kwargs) for item_data in items_data]
+        self.items = [self.item_class(item_data, instance, index, jinja_env, **kwargs)
+                      for index, item_data in enumerate(items_data)]
         self.instance = instance
         self.items_to_create = []
         self.skipped_items = []
 
     def __str__(self):
-        return f'collection of {self.inflector.plural(self.item_class.description)}'
+        return f'collection of {inflector.plural(self.item_class.description)}'
 
     def item_count_string(self, count):
         """Get a string describing the given `count` of items.
@@ -228,9 +329,11 @@ class BaseInputItemCollection(ABC, Validatable):
         Args:
             count (int): the number of items to get a descriptor for
         """
-        return f'{count} {self.inflector.plural(self.item_class.description, count)}'
+        return f'{count} {inflector.plural(self.item_class.description, count)}'
 
-    @Validatable.validation_method
+    # Item validation should occur before name validation because validating an
+    # item ensures its name can be rendered.
+    @Validatable.validation_method(ordinal=0)
     def validate_items(self, **kwargs):
         """Validate all items within this collection.
 
@@ -242,7 +345,7 @@ class BaseInputItemCollection(ABC, Validatable):
             InputItemValidateError: if any item is invalid
         """
         valid = True
-        for item in self.items_to_create:
+        for item in self.items:
             try:
                 item.validate(**kwargs)
             except InputItemValidateError as err:
@@ -252,19 +355,36 @@ class BaseInputItemCollection(ABC, Validatable):
         if not valid:
             raise InputItemValidateError(f'One or more items is not valid in {self}')
 
-    @Validatable.validation_method
+    # Validation of unique names must occur after item validation because item
+    # validation will render names using Jinja2 templates.
+    @Validatable.validation_method(ordinal=1)
     def validate_unique_names(self, **_):
         """Validate that all items in collection have unique names.
 
         Raises:
             InputItemValidateError: if there are any items with the same name
         """
-        counts_by_name = Counter(item.name for item in self.items)
+        counts_by_name = Counter()
+
+        failed_name_renders = 0
+        for item in self.items:
+            try:
+                counts_by_name[item.name] += 1
+            except self.item_class.create_error_cls as err:
+                failed_name_renders += 1
+                LOGGER.error(f'Failed to render name of {item}: {err}')
+
+        if failed_name_renders:
+            raise InputItemValidateError(
+                f'Failed to render name of {failed_name_renders} '
+                f'{inflector.plural(self.item_class.description, failed_name_renders)}'
+            )
+
         non_unique_names = [name for name, count in counts_by_name.items() if count > 1]
         if non_unique_names:
             raise InputItemValidateError(
-                f'Names of {self.inflector.plural(self.item_class.description)} '
-                f'must be unique. Non-unique {self.inflector.plural("name", len(non_unique_names))}: '
+                f'Names of {inflector.plural(self.item_class.description)} '
+                f'must be unique. Non-unique {inflector.plural("name", len(non_unique_names))}: '
                 f'{", ".join(non_unique_names)}'
             )
 
@@ -307,8 +427,8 @@ class BaseInputItemCollection(ABC, Validatable):
         for item in existing_input_items:
             conflicting_items = existing_items_by_name.get(item.name, [])
             count = len(conflicting_items)
-            conflict_msg = (f'{count} {self.inflector.plural(self.item_class.description, count)} '
-                            f'already {self.inflector.plural_verb("exists", count)} with the name {item.name}')
+            conflict_msg = (f'{count} {inflector.plural(self.item_class.description, count)} '
+                            f'already {inflector.plural_verb("exists", count)} with the name {item.name}')
 
             overwrite = overwrite_all
             skip = skip_all
@@ -316,7 +436,7 @@ class BaseInputItemCollection(ABC, Validatable):
             if not overwrite and not skip:
                 choices = ('skip', 'overwrite', 'abort')
                 answer = pester_choices(f'{conflict_msg}. Would you like to '
-                                        f'{self.inflector.join(choices, conj="or")}?', choices)
+                                        f'{inflector.join(choices, conj="or")}?', choices)
                 if answer == 'abort':
                     raise UserAbortException()
 
@@ -374,43 +494,3 @@ class BaseInputItemCollection(ABC, Validatable):
             raise InputItemCreateError(
                 f'Failed to create {self.item_count_string(len(failed_items))}'
             )
-
-
-def jinja_rendered(func):
-    """Decorator for instance methods which return Jinja2 templates.
-
-    This should be used to decorate instance methods which return content from
-    the InputInstance that supports rendering as a Jinja2 template. If the
-    `func` returns `None`, this wrapper will as well.
-
-    This wrapper assumes the instance has the following attributes:
-
-        jinja_env (jinja2.Environment): the Jinja2 environment to use to get
-            Template objects to be rendered. Variables to use as context are
-            expected to already be set in the `globals` attribute.
-        create_error_cls: the specific subclass of InputItemCreateError that
-            should be raised if there is an issue rendering the template.
-            Defaults to InputItemCreateError if not set.
-    """
-    @functools.wraps(func)
-    def wrapper(self, *args, **kwargs):
-        # First call the wrapped method and get its result
-        unrendered_result = func(self, *args, **kwargs)
-
-        # If value not specified in input file, the `func` may return `None`
-        if unrendered_result is None:
-            return unrendered_result
-
-        # Default to InputItemCreateError if no error class is specified
-        error_cls = getattr(self, 'create_error_cls', InputItemCreateError)
-
-        try:
-            return self.jinja_env.from_string(unrendered_result).render()
-        except SecurityError as err:
-            raise error_cls(f'Jinja2 template {unrendered_result} for value '
-                            f'{func.__name__} tried to access unsafe attributes.') from err
-        except TemplateError as err:
-            raise error_cls(f'Failed to render Jinja2 template {unrendered_result} '
-                            f'for value {func.__name__}: {err}') from err
-
-    return wrapper

--- a/sat/cli/bootprep/input/instance.py
+++ b/sat/cli/bootprep/input/instance.py
@@ -67,9 +67,9 @@ class InputInstance:
     @cached_property
     def input_images(self):
         """list of InputImages: the images in the input instance"""
-        return [BaseInputImage.get_image(image, self.jinja_env, self.product_catalog,
+        return [BaseInputImage.get_image(image, index, self, self.jinja_env, self.product_catalog,
                                          self.ims_client, self.cfs_client)
-                for image in self.instance_dict.get('images', [])]
+                for index, image in enumerate(self.instance_dict.get('images', []))]
 
     @cached_property
     def input_session_templates(self):
@@ -77,6 +77,7 @@ class InputInstance:
         return InputSessionTemplateCollection(
             self.instance_dict.get('session_templates', []),
             self,
+            jinja_env=self.jinja_env,
             bos_client=self.bos_client,
             cfs_client=self.cfs_client,
             ims_client=self.ims_client

--- a/sat/cli/bootprep/main.py
+++ b/sat/cli/bootprep/main.py
@@ -216,6 +216,14 @@ def do_bootprep_run(schema_validator, args):
     # newly created images when constructing session templates.
     ims_client.clear_resource_cache(resource_type='image')
 
+    # Must validate first because `handle_existing_items` must know the name of each
+    # item to be created, and validation will render names.
+    try:
+        instance.input_session_templates.validate(dry_run=args.dry_run)
+    except InputItemValidateError as err:
+        LOGGER.error(str(err))
+        raise SystemExit(1)
+
     try:
         instance.input_session_templates.handle_existing_items(args.overwrite_templates,
                                                                args.skip_existing_templates,
@@ -224,12 +232,6 @@ def do_bootprep_run(schema_validator, args):
         LOGGER.error('Aborted')
         raise SystemExit(1)
     except InputItemCreateError as err:
-        LOGGER.error(str(err))
-        raise SystemExit(1)
-
-    try:
-        instance.input_session_templates.validate(dry_run=args.dry_run)
-    except InputItemValidateError as err:
         LOGGER.error(str(err))
         raise SystemExit(1)
 

--- a/sat/cli/bootprep/parser.py
+++ b/sat/cli/bootprep/parser.py
@@ -220,14 +220,13 @@ def _add_bootprep_run_subparser(subparsers):
         choices=['v1', 'v2'],
         help='The version of the BOS API to use for BOS operations',
     )
-    # TODO (CASM-2920): With official recipe manifest, default to LATEST_VERSION_VALUE
     run_subparser.add_argument(
-        '--recipe-version',
-        help='The HPC software recipe version, e.g. 22.03. This is used to '
-             'obtain the product versions which can be substituted for variables '
-             'specified in fields in the input file. If not specified, variables '
-             f'are not loaded from the HPC software recipe. If "{LATEST_VERSION_VALUE}" '
-             f'is specified, use the latest available HPC software recipe.'
+        '--recipe-version', default=LATEST_VERSION_VALUE,
+        help=f'The HPC software recipe version, e.g. 22.03. This is used to '
+             f'obtain the product versions which can be substituted for variables '
+             f'specified in fields in the input file. If not specified or if '
+             f'"{LATEST_VERSION_VALUE}" is specified, use the latest available HPC '
+             f'software recipe version.'
     )
     run_subparser.add_argument(
         '--vars-file',

--- a/sat/cli/bootprep/vars.py
+++ b/sat/cli/bootprep/vars.py
@@ -74,7 +74,7 @@ class VariableContext:
         """Load variables from the HPC software recipe, vars file, and command-line.
 
         Raises:
-            VariableContextError: if there is a failure to load variables.
+            VariableContextError: if there is a failure to load variables from a file.
         """
         deep_update_dict(self.vars, self.get_hpc_software_recipe_vars())
         deep_update_dict(self.vars, self.get_file_vars())
@@ -117,14 +117,7 @@ class VariableContext:
 
         Returns:
             dict: the variables loaded from the HPC software recipe.
-
-        Raises:
-            VariableContextError: if there is a problem loading variables from
-                HPC software recipe
         """
-        if self.recipe_version is None:
-            return {}
-
         try:
             recipe_catalog = HPCSoftwareRecipeCatalog()
             if self.recipe_version == LATEST_VERSION_VALUE:
@@ -134,10 +127,10 @@ class VariableContext:
 
             return recipe.all_vars
         except HPCSoftwareRecipeError as err:
-            # Once we start defaulting to the latest version of the recipe, this
-            # should become a warning since the user may be overriding vars with
-            # --vars-file or --vars.
-            raise VariableContextError(
+            # Only issue a warning because the input file may not use the variables provided
+            # by the recipe, or the variables may be provided by --vars-file or --vars.
+            LOGGER.warning(
                 f'Failed to load variables defined by HPC software recipe version '
                 f'{self.recipe_version}: {err}'
-            ) from err
+            )
+            return {}

--- a/sat/data/schema/bootprep_schema.yaml
+++ b/sat/data/schema/bootprep_schema.yaml
@@ -80,7 +80,7 @@ properties:
         current version.
 
       - If the input version matches the current version, it is compatible.
-    default: '1.0.0'
+    default: '1.0.3'
     type: string
 
   configurations:
@@ -207,6 +207,13 @@ properties:
         properties:
           name:
             $ref: '#/$defs/ImageName'
+          ref_name:
+            type: string
+            description: >
+              A name for this image that can be used to refer to this image from other images
+              and session templates defined in this file. This name must be unique amongst all
+              other images in the input file.
+            examples: ['compute-image', 'uan-image']
           description:
             $ref: '#/$defs/ImageDescription'
           base:
@@ -262,6 +269,16 @@ properties:
                         Supports rendering as a Jinja template.
                     type:
                       $ref: '#/$defs/ImageBaseType'
+            - type: object
+              required: ['image_ref']
+              additionalProperties: false
+              properties:
+                image_ref:
+                  type: string
+                  description: >
+                    A reference to another image from this file to use as a base when creating this
+                    image. The value specified here should match the value of the "ref_name" property
+                    of another image.
           configuration:
             $ref: '#/$defs/ImageConfiguration'
           configuration_group_names:
@@ -336,6 +353,8 @@ properties:
           description: >
             The name of the session template to create. This is the name
             the session template will have in BOS.
+
+            Supports rendering as a Jinja template.
           type: string
         image:
           description: >
@@ -350,11 +369,15 @@ properties:
             The s3 path to the manifest.json file will be determined from the
             IMS image, and it will be populated in the "path" key in the boot
             set(s) within the session template.
+
+            Supports rendering as a Jinja template.
           type: string
         configuration:
           description: >
             The name of the CFS configuration that will be applied to the
             nodes in this session template after they have been booted.
+
+            Supports rendering as a Jinja template.
           type: string
         bos_parameters:
           description: >
@@ -476,6 +499,8 @@ $defs:
 
       If the image name is not unique in IMS, this command will fail and
       will not create another IMS image with this name.
+
+      Supports rendering as a Jinja template.
     type: string
   ImageDescription:
     description: >
@@ -493,6 +518,8 @@ $defs:
       prior to boot. This is optional. If omitted, the image will
       not be customized. If present, a value must be provided for
       configuration_group_names.
+
+      Supports rendering as a Jinja template.
     type: string
   ImageConfigurationGroupNames:
     description: >

--- a/tests/cli/bootprep/test_validate.py
+++ b/tests/cli/bootprep/test_validate.py
@@ -122,13 +122,24 @@ VALID_IMAGE_IMS_ID_WITH_CONFIG_V2 = {
 }
 
 VALID_IMAGE_PRODUCT_WITH_CONFIG = {
-    'name': '{{ base.name }}',
+    'name': 'compute-{{ base.name }}',
+    'ref_name': 'cos-compute-image',
     'base': {
         'product': {
             'type': 'recipe',
             'name': 'cos',
             'version': '2.2.101'
         }
+    },
+    'configuration': COMPUTE_CONFIG_IMAGE_NAME,
+    'configuration_group_names': ['Compute', 'Compute_GPU']
+}
+
+VALID_IMAGE_REF_WITH_CONFIG = {
+    'name': 'compute-{{ base.name }}',
+    'ref_name': 'compute-cos-image',
+    'base': {
+        'image_ref': 'cos-image'
     },
     'configuration': COMPUTE_CONFIG_IMAGE_NAME,
     'configuration_group_names': ['Compute', 'Compute_GPU']
@@ -464,6 +475,13 @@ class TestValidateInstance(ExtendedTestCase):
         """Valid image from a version of a product with config specified"""
         instance = {
             'images': [VALID_IMAGE_PRODUCT_WITH_CONFIG]
+        }
+        self.assert_valid_instance(instance)
+
+    def test_valid_image_ref_with_config(self):
+        """Valid image using another image from bootprep input file as a base"""
+        instance = {
+            'images': [VALID_IMAGE_REF_WITH_CONFIG]
         }
         self.assert_valid_instance(instance)
 


### PR DESCRIPTION
## Summary and Scope
Add the ability to use the name of the base image or recipe that was
used to construct an image as a variable when templating the `name`
property of an image.

Add the ability to use the name of the image as a variable when
templating the `name` property of a session template.

Since names of session templates and images are now templated and not
required to be unique and cannot be rendered until the base is
validated, change the `__str__` methods of both `InputSessionTemplate`
and `BaseInputImage` to simply state the index of the item in the input
instance.

Also add general variable substitution (e.g. product versions) to the
`conifguration` property for images and to the `name`, `image`, and
`configuration` properties of session templates.

Since image names are now templated using variables from the base of the
image, it is necessary to change how images in a `sat bootprep` input
file refer to other images as a base. Add a `ref_name` property on the
images which gives them a unique static name that can be referenced by
another image's `base.image_ref` property. It is no longer supported to
specify a dependency between images using the IMS image name.

Now that we are no longer checking for dependencies between images based
on the images' IMS names, add a check to ensure there is no overlap
between the IMS names of images created by the input file and the IMS
names of images used as bases. This would result in possible race
conditions and non-deterministic behavior if the base of on image is
created by another image in the input file.

## Issues and Related PRs

* Resolves [CRAYSAT-1411](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1411)

## Testing

### Tested on:

  * vale
  * virtual env on local macbook (for generating and viewing schema docs)

### Test description:

Tested on vale with a bootprep input file that builds an image from the
recipe provided by the CSM product, and then customizes it with a second
image specification that refers to the first by its `ref_name`.

Also tested using the `image.name` variable substitution in BOS session
template names.

## Risks and Mitigations

This does change the schema, but it does so in a backwards-compatible way.

It does also change the behavior of determining dependencies between images. This was not clearly documented before this change anyway, and I don't think users necessarily understood how that would work.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable