### PR TITLE
CRAYSAT-1410: Allow session templates to refer to images by ref_name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   schema version specified by `sat bootprep` input files.
 - Added functionality to `sat bootprep` to look up images and recipes provided
   by products.
+- Added functionality to `sat bootprep` to allow session templates to refer to
+  images by their `ref_name` under the new `image.image_ref` property.
 
 ### Changed
 - Changed the `sat bootprep` input file schema by adding a new `base` property
@@ -53,6 +55,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 - Specifying the `ims` property at the top level of an image in the `sat
   bootprep` input file is deprecated.
+- Specifying a string value for the `image` property of session templates in the
+  `sat bootprep` input file is deprecated.
 
 ### Fixed
 - Deprecated version comparison utilites from `distutils` have been replaced

--- a/sat/cli/bootprep/input/base.py
+++ b/sat/cli/bootprep/input/base.py
@@ -314,7 +314,10 @@ class BaseInputItemCollection(ABC, Validatable):
                 the constructor of the class defined in the class attribute
                 `item_class`
         """
-        self.items = [self.item_class(item_data, instance, index, jinja_env, **kwargs)
+        constructor = self.item_class
+        if hasattr(self.item_class, 'get_item'):
+            constructor = self.item_class.get_item
+        self.items = [constructor(item_data, instance, index, jinja_env, **kwargs)
                       for index, item_data in enumerate(items_data)]
         self.instance = instance
         self.items_to_create = []

--- a/sat/cli/bootprep/input/session_template.py
+++ b/sat/cli/bootprep/input/session_template.py
@@ -24,6 +24,7 @@
 """
 Defines class for session templates defined in the input file.
 """
+from abc import abstractmethod
 import re
 
 from sat.apiclient import APIError
@@ -81,6 +82,14 @@ class InputSessionTemplate(BaseInputItem):
         # Additional context to be used when rendering Jinja2 templated properties
         self.jinja_context = {}
 
+    @staticmethod
+    def get_item(data, *args, **kwargs):
+        """Get an instance of the appropriate subclass based on the data."""
+        if isinstance(data['image'], str):
+            return InputSessionTemplateV1(data, *args, **kwargs)
+        else:
+            return InputSessionTemplateV2(data, *args, **kwargs)
+
     @property
     @jinja_rendered
     def configuration(self):
@@ -95,11 +104,103 @@ class InputSessionTemplate(BaseInputItem):
         return self.data['bos_parameters']['boot_sets']
 
     @property
+    @abstractmethod
+    def image_record(self):
+        """dict: the image record from IMS for this session template"""
+
+    @Validatable.validation_method()
+    def validate_configuration_exists(self, **_):
+        """Validate that the configuration specified for this session template exists.
+
+        Raises:
+            InputItemValidateError: if the configuration does not exist
+        """
+        # First check if the configuration is being created anew by the same input file
+        input_config_names = [config.name for config in self.instance.input_configurations]
+        if self.configuration in input_config_names:
+            return
+
+        try:
+            self.cfs_client.get_configuration(self.configuration)
+        except APIError as err:
+            # TODO: should probably differentiate between 404 Not Found and other errors
+            raise InputItemValidateError(f'Configuration {self.configuration} specified for '
+                                         f'{self} does not exist: {err}')
+
+    @abstractmethod
+    def validate_image_exists(self, **_):
+        """Validate that the image specified for this session template exists.
+
+        Returns:
+            dict: information about the image to make available in an `image`
+                variable in Jinja2 context when rendering the name of the
+                session template.
+
+        Raises:
+            InputItemValidateError: if the image cannot be verified to exist
+        """
+
+    def get_bos_api_data(self):
+        """Get the data to pass to the BOS API to create this session template.
+
+        Returns:
+            dict: the data to pass to the BOS API to create the session template
+        """
+        api_data = {
+            'cfs': {'configuration': self.configuration},
+            'enable_cfs': True,
+            'name': self.name,
+            'boot_sets': {}
+        }
+        for boot_set_name, boot_set_data in self.boot_sets.items():
+            boot_set_api_data = self.bos_client.get_base_boot_set_data()
+            image_record = self.image_record
+            boot_set_api_data.update({
+                'etag': get_val_by_path(image_record, 'link.etag'),
+                'path': get_val_by_path(image_record, 'link.path'),
+                'type': get_val_by_path(image_record, 'link.type')
+            })
+            boot_set_api_data.update(boot_set_data)
+            api_data['boot_sets'][boot_set_name] = boot_set_api_data
+
+        return api_data
+
+    def create(self, dumper=None):
+        """Create the session template with a request to the BOS API."""
+        request_body = self.get_bos_api_data()
+        if dumper is not None:
+            dumper.write_request_body(self.name, request_body)
+
+        try:
+            self.bos_client.create_session_template(request_body)
+        except APIError as err:
+            raise SessionTemplateCreateError(f'Failed to create session template: {err}')
+
+
+class InputSessionTemplateV1(InputSessionTemplate):
+    """A BOS session template that specifies its IMS image as a simple string."""
+
+    @provides_context('image')
+    @Validatable.validation_method()
+    def validate_image_exists(self, **_):
+        """Validate that the image specified for this session template exists.
+
+        See docstring of InputSessionTemplate.validate_image_exists.
+        """
+        # First check if the image is being created anew by the same input file
+        input_image_names = [image.name for image in self.instance.input_images]
+        if self.image in input_image_names:
+            image_name = self.image
+        else:
+            # Accessing the image_record queries IMS to find the image
+            image_name = self.image_record['name']
+
+        return {'name': image_name}
+
+    @property
     @jinja_rendered
     def image(self):
         """str: the image specified for the session template
-
-        Per the bootprep schema, this may be an image name or id.
         """
         # the 'image' property is required by the schema
         return self.data['image']
@@ -139,78 +240,93 @@ class InputSessionTemplate(BaseInputItem):
         else:
             return name_matches[0]
 
-    @Validatable.validation_method()
-    def validate_configuration_exists(self, **_):
-        """Validate that the configuration specified for this session template exists.
 
-        Raises:
-            InputItemValidateError: if the configuration does not exist
-        """
-        # First check if the configuration is being created anew by the same input file
-        input_config_names = [config.name for config in self.instance.input_configurations]
-        if self.configuration in input_config_names:
-            return
-
-        try:
-            self.cfs_client.get_configuration(self.configuration)
-        except APIError as err:
-            # TODO: should probably differentiate between 404 Not Found and other errors
-            raise InputItemValidateError(f'Configuration {self.configuration} specified for '
-                                         f'{self} does not exist: {err}')
+class InputSessionTemplateV2(InputSessionTemplate):
+    """A BOS session template that specifies its IMS image as a dict."""
 
     @provides_context('image')
     @Validatable.validation_method()
     def validate_image_exists(self, **_):
         """Validate that the image specified for this session template exists.
 
-        Raises:
-            InputItemValidateError: if the image cannot be verified to exist
+        See docstring of InputSessionTemplate.validate_image_exists.
         """
         # First check if the image is being created anew by the same input file
         input_image_names = [image.name for image in self.instance.input_images]
-        if self.image in input_image_names:
-            image_name = self.image
+        if self.ims_image_name and self.ims_image_name in input_image_names:
+            image_name = self.ims_image_name
+        elif self.image_ref:
+            if self.image_ref_input_image:
+                # Found the image from the input instance by its ref
+                image_name = self.image_ref_input_image.name
+            else:
+                # If the image_ref does not exist in the input instance, this is an error
+                raise InputItemValidateError(f'No image exists with ref_name={self.image_ref} '
+                                             f'for use by {self}.')
         else:
-            # Accessing the image_record queries IMS to find the image
+            # Image is not from input instance. Access image_record to look up in IMS
             image_name = self.image_record['name']
 
         return {'name': image_name}
 
-    def get_bos_api_data(self):
-        """Get the data to pass to the BOS API to create this session template.
+    @cached_property
+    @jinja_rendered
+    def ims_image_name(self):
+        """str or None: the name specified for the ims image, or None if not specified"""
+        return get_val_by_path(self.data, 'image.ims.name')
 
-        Returns:
-            dict: the data to pass to the BOS API to create the session template
-        """
-        api_data = {
-            'cfs': {'configuration': self.configuration},
-            'enable_cfs': True,
-            'name': self.name,
-            'boot_sets': {}
-        }
-        for boot_set_name, boot_set_data in self.boot_sets.items():
-            boot_set_api_data = self.bos_client.get_base_boot_set_data()
-            image_record = self.image_record
-            boot_set_api_data.update({
-                'etag': get_val_by_path(image_record, 'link.etag'),
-                'path': get_val_by_path(image_record, 'link.path'),
-                'type': get_val_by_path(image_record, 'link.type')
-            })
-            boot_set_api_data.update(boot_set_data)
-            api_data['boot_sets'][boot_set_name] = boot_set_api_data
+    @property
+    def ims_image_id(self):
+        """str or None: the id specified for the IMS image, or None if not specified"""
+        return get_val_by_path(self.data, 'image.ims.id')
 
-        return api_data
+    @cached_property
+    @jinja_rendered
+    def image_ref(self):
+        """str or None: the name specified for the image ref, or None if not specified"""
+        return get_val_by_path(self.data, 'image.image_ref')
 
-    def create(self, dumper=None):
-        """Create the session template with a request to the BOS API."""
-        request_body = self.get_bos_api_data()
-        if dumper is not None:
-            dumper.write_request_body(self.name, request_body)
+    @cached_property
+    def image_ref_input_image(self):
+        """BaseInputImage or None: the image referenced by image.image_ref, if it exists"""
+        for input_image in self.instance.input_images:
+            if self.image_ref == input_image.ref_name:
+                return input_image
 
-        try:
-            self.bos_client.create_session_template(request_body)
-        except APIError as err:
-            raise SessionTemplateCreateError(f'Failed to create session template: {err}')
+    @cached_property
+    def image_record(self):
+        """dict: the image record from IMS if one can be found"""
+        if self.ims_image_id:
+            try:
+                return self.ims_client.get_image(self.ims_image_id)
+            except APIError as err:
+                # TODO: should probably differentiate between 404 Not Found and other errors
+                raise InputItemValidateError(f'No image with ID {self.ims_image_id} exists '
+                                             f'for use by {self}: {err}')
+        else:
+            # First, get the name of the image
+            image_name = self.ims_image_name
+            if not image_name:
+                # Image must have been specified by image_ref. `validate_image_exists` already
+                # checked that the ref_name exists, but be defensive anyway.
+                if self.image_ref_input_image:
+                    image_name = self.image_ref_input_image.name
+                else:
+                    raise InputItemValidateError(f'No image exists with ref_name={self.image_ref} '
+                                                 f'for use by {self}.')
+
+            try:
+                name_matches = self.ims_client.get_matching_resources('image', name=image_name)
+            except APIError as err:
+                raise InputItemValidateError(f'Unable to find image with name {image_name} '
+                                             f'for use by {self}: {err}')
+
+            if not name_matches:
+                raise InputItemValidateError(f'No image with name {image_name} exists for use by {self}.')
+            elif len(name_matches) > 1:
+                raise InputItemValidateError(f'Found multiple images named {image_name} for use '
+                                             f'by {self}. This image must be specified by ID.')
+            return name_matches[0]
 
 
 class InputSessionTemplateCollection(BaseInputItemCollection):

--- a/sat/data/schema/bootprep_schema.yaml
+++ b/sat/data/schema/bootprep_schema.yaml
@@ -357,21 +357,68 @@ properties:
             Supports rendering as a Jinja template.
           type: string
         image:
-          description: >
-            The image to use from IMS. This will first be treated as the name
-            of an IMS image. If multiple images with this name exist, then an
-            error will be reported. If it is not the name of an IMS image, and
-            it takes the form of a UUID, then it will be treated as an IMS
-            image ID. If it is neither a valid IMS image name nor a valid IMS
-            image ID, then an error will be reported.
+          oneOf:
+          - description: The IMS image to use in the BOS session template.
+            type: object
+            additionalProperties: false
+            required: ['ims']
+            properties:
+              ims:
+                oneOf:
+                - type: object
+                  required: ['name']
+                  additionalProperties: false
+                  properties:
+                    name:
+                      description: >
+                        The name of an image in IMS. Note that names are not
+                        required to be unique in IMS. If more than one image
+                        exists with this name, the image must be specified by
+                        ID.
+                      type: string
+                - type: object
+                  required: ['id']
+                  additionalProperties: false
+                  properties:
+                    id:
+                      description: >
+                        The id of an image in IMS.
+                      type: string
+          - description: The IMS image from this file to use in the BOS session template.
+            type: object
+            additionalProperties: false
+            required: ['image_ref']
+            properties:
+              image_ref:
+                type: string
+                description: >
+                  A reference to an image from this file to use in the BOS session
+                  template. The value specified here should match the value of the
+                  "ref_name" property of an image in this file.
 
-            This image will be used to boot the nodes in this session template.
-            The s3 path to the manifest.json file will be determined from the
-            IMS image, and it will be populated in the "path" key in the boot
-            set(s) within the session template.
+          - description: >
+              <h3>Deprecation Notice</h3>
+              Specifying a simple string here is deprecated. Instead, specify
+              an object with one of the supported properties, "ims" or "image_ref".
 
-            Supports rendering as a Jinja template.
-          type: string
+              <h3>Description</h3>
+              The image to use from IMS. This will first be treated as the name
+              of an IMS image. If multiple images with this name exist, then an
+              error will be reported. If it is not the name of an IMS image, and
+              it takes the form of a UUID, then it will be treated as an IMS
+              image ID. If it is neither a valid IMS image name nor a valid IMS
+              image ID, then an error will be reported.
+
+              This image will be used to boot the nodes in this session template.
+              The s3 path to the manifest.json file will be determined from the
+              IMS image, and it will be populated in the "path" key in the boot
+              set(s) within the session template.
+
+              Supports rendering as a Jinja template.
+            type: string
+            # Mark this entire alternative as deprecated, but note that this `deprecated`
+            # property is not supported by json-schema-for-humans yet.
+            deprecated: true
         configuration:
           description: >
             The name of the CFS configuration that will be applied to the


### PR DESCRIPTION
## Summary and Scope

Add functionality to `sat bootprep` to allow session templates in the
input file to refer to images by their `ref_name` value. This is a
usability improvement to make it easier to refer to an image which has a
name that uses its base image or recipe name in its name.

Deprecate the old way of specifying the IMS image name or ID as a string
in the session template. Add the ability to specify an object under the
`image` property that has either an `ims` property or an `image_ref`
property. The value of the `ims` property is a dict with either a `name`
or an `id` property. The value of the `image_ref` property is a string
that refers to an image in the input file by the value of its `ref_name`
property.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CRAYSAT-1410](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1410)

## Testing

### Tested on:

  * vale
  * python virtual env on macbook (generate-docs)

### Test description:
Tested on vale with a bootprep input file that creates session templates
which specify their images using `image.ims.id`, `image.ims.name`, or
`image.image_ref`.

Also tested creating a session template with `image` set to a string
containing either the `id` or the `name` of an image.

## Risks and Mitigations

None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable