### PR TITLE
PE-42104 - Adding Jobstat to SAT CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,11 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-
 - Added new command "Jobstat." Provides system-wide view of application status data.
-
-### Added
-
 - Added information regarding the `--bos-version` command line argument to man
   pages for relevant subcommands.
 - Added a ``sat swap blade`` subcommand which partially automates the procedure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added new command "Jobstat." Provides system-wide view of application status data.
+
+### Added
+
 - Added information regarding the `--bos-version` command line argument to man
   pages for relevant subcommands.
 - Added a ``sat swap blade`` subcommand which partially automates the procedure

--- a/docs/man/sat-jobstat.8.rst
+++ b/docs/man/sat-jobstat.8.rst
@@ -1,0 +1,51 @@
+=============
+ SAT-JOBSTAT
+=============
+
+-------------------------
+Jobstat Short Description
+-------------------------
+
+:Author: Hewlett Packard Enterprise Development LP.
+:Copyright: Copyright 2022 Hewlett Packard Enterprise Development LP.
+:Manual section: 8
+
+SYNOPSIS
+========
+
+**sat** [global-opts] **jobstat** [options]
+
+DESCRIPTION
+===========
+
+Jobstat is a command that allows a user or admin to access application and job data via the command line. The command provides a table showing the user the apid, jobid, user, state, and time-reported of all jobs on the system.
+
+OPTIONS
+=======
+
+These options must be specified after the subcommand.
+
+**-h, --help**
+        Print the help message for 'sat jobstat'.
+
+**-a, --all**
+        Show all application information that is currently documented on the system.
+
+Summarize Remaining Options
+
+EXAMPLES
+========
+
+An example usage of the command:
+
+::
+
+    # sat jobstat
+    TODO: Show example table here
+
+SEE ALSO
+========
+
+sat(8)
+
+.. include:: _notice.rst

--- a/docs/man/sat-jobstat.8.rst
+++ b/docs/man/sat-jobstat.8.rst
@@ -41,7 +41,17 @@ An example usage of the command:
 ::
 
     # sat jobstat
-    TODO: Show example table here
++---------------------------------------+--------------+-------+-------------------------------------+-----------+-----------+---------------------+
+| apid                                  | jobid        | user  | command                             | state     | num_nodes | node_list           |
++---------------------------------------+--------------+-------+-------------------------------------+-----------+-----------+---------------------+
+| 7677b7d3-ec35-4e23-8678-92b823347939  | 49.pbs-host  | 5827  | mpiexec --ppn=1 -n2 ./signals       | completed | 2         | nid000001,nid000002 |
+| 76b783af-5c7e-4462-97c0-3dfd0f04b9b3  | 51.pbs-host  | 5827  | mpiexec --ppn=1 -n2 ./signals       | completed | 2         | nid000001,nid000002 |
+| 7a85c000-05a9-40cd-8551-00092cead801  | 48.pbs-host  | 5827  | mpiexec -n2 ./signals               | completed | 1         | nid000001           |
+| 8b5b14b3-8215-4cbe-bba4-7d7c82d48fef  | 50.pbs-host  | 5827  | mpiexec --ppn=1 -n2 ./signals       | completed | 2         | nid000001,nid000002 |
+| 957bbd4c-de3c-424d-99d6-fd2b728b2941  | 54.pbs-host  | 5827  | mpiexec --ppn=1 -n2 ./signals       | completed | 2         | nid000001,nid000002 |
+| ba977b71-40b6-40db-aa20-a583edc18be3  | 59.pbs-host  | 5827  | mpiexec --ppn=1 -n2 ./signals-sleep | completed | 2         | nid000001,nid000002 |
+| fea2726a-c531-4acd-b158-3fae197999dd  | 57.pbs-host  | 5827  | mpiexec --ppn=1 -n2 ./signals       | completed | 2         | nid000001,nid000002 |
++---------------------------------------+--------------+-------+-------------------------------------+-----------+-----------+---------------------+
 
 SEE ALSO
 ========

--- a/sat/apiclient/elastic.py
+++ b/sat/apiclient/elastic.py
@@ -1,0 +1,37 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""
+API Client for Elasticsearch
+"""
+
+import logging
+
+from sat.apiclient.gateway import APIGatewayClient
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class ElasticClient(APIGatewayClient):
+    base_resource_path = 'elastic/v1/

--- a/sat/cli/jobstat/main.py
+++ b/sat/cli/jobstat/main.py
@@ -1,0 +1,79 @@
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""
+The main entry point for the jobstat subcommand.
+"""
+import logging
+import requests
+from sat.cli.jobstat import parser
+from sat.report import Report
+from sat.config import get_config_value
+
+
+URL = "http://localhost:1999/all"
+LOGGER = logging.getLogger(__name__)
+
+
+def unload_json(url):
+    """Unloads the JSON object from the server url and formats the data as a dictionary"""
+    data = {}
+    try:
+        response = requests.get(url)
+        data = response.json()
+    except Exception as err:
+        LOGGER.error(f"Failed to parse JSON from component state response: {err}")
+        raise SystemExit(1)
+    return data
+
+
+def do_jobstat(args):
+    """Run the jobstat command with the given arguments.
+    Args:
+        args: The argparse.Namespace object containing the parsed arguments
+            passed to this subcommand.
+    """
+    # print('Hello jobstat')
+    try:
+        if args.all is True:
+            server_data = unload_json(URL)
+            application_data = server_data.get("jobstat")
+            keys = []
+            for i in application_data[0]:
+                keys.append(i)
+            report = Report(
+                tuple(keys),
+                None,
+                args.sort_by,
+                args.reverse,
+                get_config_value("format.no_headings"),
+                get_config_value("format.no_borders"),
+                filter_strs=args.filter_strs,
+                display_headings=args.fields,
+                print_format=args.format,
+            )
+            for i in application_data:
+                report.add_row(i)
+            print(report)
+    except Exception as err:
+        LOGGER.error(f"Failed to execute jobstat command: {err}")
+        raise SystemExit(1)

--- a/sat/cli/jobstat/parser.py
+++ b/sat/cli/jobstat/parser.py
@@ -1,0 +1,54 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""
+The parser for the jobstat subcommand.
+"""
+import sat.parsergroups
+
+
+def add_jobstat_subparser(subparsers):
+    """Add the jobstat parser to the parent parser.
+    Args:
+        subparsers: The argparse.ArgumentParser object returned by the
+            add_subparsers method.
+    Returns:
+        None
+    """
+    format_options = sat.parsergroups.create_format_options()
+    filter_options = sat.parsergroups.create_filter_options()
+
+    jobstat_parser = subparsers.add_parser(
+        "jobstat",
+        help="Application information",
+        description="This command shows all applications and relevent information pertaining to those applications.",
+        parents=[format_options, filter_options],
+    )
+
+    jobstat_parser.add_argument(
+        "--all",
+        "-a",
+        action="store_true",
+        default=True,
+        help="Show all application information available on the system.",
+    )


### PR DESCRIPTION
## Summary and Scope

New feature named "Jobstat," which allows users and admins to get a system-wide view of application status data via the SAT toolkit.  The change is backwards compatible as long as it has access to the elasticsearch api. The feature is meant to be implemented on any system running PALS. Currently, it is being developed for Slice.

## Issues and Related PRs
PE-42104 - Adding Jobstat to SAT CLI


## Testing
Feature was tested in a pyenv environment. Output of the command gave desired table to the user. 

### Tested on:
  * Local development environment
  * Virtual Shasta

### Test description:

Test included running `sat jobstat` in a virtual environment. The script sent a HTTP GET request to a flask server (which will soon be held in Slice in a Kubernetes pod running on PBSPro). The flask server returns a JSON object from the elasticsearch api via a python script on the pod. `sat jobstat` returns proper table output. Exceptions were tested and handled properly by the script as well.



## Risks and Mitigations
A risk is the elasticsearch api not working with the command.


## Pull Request Checklist

- [x ] Version number(s) incremented, if applicable
- [ x] Copyrights updated
- [ x] License file intact
- [ x] Target branch correct
- [x ] CHANGELOG.md updated
- [x ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

