### PR TITLE
CRAYSAT-1488: Replace `distutils` version handling with `packaging`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Specifying the `ims` property at the top level of an image in the `sat
   bootprep` input file is deprecated.
 
+### Fixed
+- Deprecated version comparison utilites from `distutils` have been replaced
+  equivalent functionality from the `packaging` library.
+
 ## [Unreleased]
 
 ### Added

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -28,6 +28,7 @@ marshmallow-enum==1.5.1
 mypy-extensions==0.4.3
 natsort==8.1.0
 oauthlib==3.2.0
+packaging==21.3
 paramiko==2.9.2
 parsec==3.5
 prettytable==0.7.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,16 +1,16 @@
 # Top-level requirements for sat package to function.
 # (C) Copyright 2019-2022 Hewlett Packard Enterprise Development LP.
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
 # to deal in the Software without restriction, including without limitation
 # the rights to use, copy, modify, merge, publish, distribute, sublicense,
 # and/or sell copies of the Software, and to permit persons to whom the
 # Software is furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included
 # in all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
@@ -27,6 +27,7 @@ Jinja2 >= 3.0, < 4.0
 json-schema-for-humans
 jsonschema >= 4.0, < 5.0
 kubernetes
+packaging
 paramiko >= 2.4.2
 parsec == 3.5.0
 prettytable >= 0.7.2, < 1.0

--- a/sat/recipe.py
+++ b/sat/recipe.py
@@ -28,7 +28,6 @@ The manifest defines the versions of the products that are included in a given
 version of the HPC software recipe.
 """
 from contextlib import contextmanager
-from distutils.version import LooseVersion
 from functools import total_ordering
 import logging
 import os
@@ -36,6 +35,7 @@ import re
 from tempfile import TemporaryDirectory
 from urllib.parse import ParseResult, urlunparse
 
+from packaging.version import parse as parse_version
 import yaml
 
 from sat.apiclient.vcs import VCSError, VCSRepo
@@ -69,7 +69,7 @@ class HPCSoftwareRecipe:
         """
         # Allows for comparison of two software recipes. Original string can be
         # retrieved by calling `str` on it.
-        self.version = LooseVersion(version)
+        self.version = parse_version(version)
         self.vcs_repo = vcs_repo
         self.vcs_branch = vcs_branch
 


### PR DESCRIPTION
## Summary and Scope

This change removes the deprecated `distutils` version handling features
and replaces them with the `packaging` library. HPC Software Version
handling and schema version validation were affected.

## Issues and Related PRs

* Resolves [CRAYSAT-1488](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1488)

## Testing

### Tested on:

  * `vale`
  * Local development environment

### Test description:

Run unit tests. Test on vale with `sat bootprep run --recipe-version
latest` and ensure that the 22.07 recipe is treated as "latest" over an
example 22.07rc1 recipe.

## Risks and Mitigations

N/A


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

