### PR TITLE
CRAYSAT-1502: Update the name of the VCS repo

### DIFF
--- a/sat/recipe.py
+++ b/sat/recipe.py
@@ -43,7 +43,7 @@ from sat.cached_property import cached_property
 from sat.config import get_config_value
 
 HPC_SOFTWARE_RECIPE_REPO_ORG = 'cray'
-HPC_SOFTWARE_RECIPE_REPO_NAME = 'hpc-software-recipe'
+HPC_SOFTWARE_RECIPE_REPO_NAME = 'hpc-shasta-software-recipe'
 HPC_SOFTWARE_RECIPE_REPO_PATH = f'/vcs/{HPC_SOFTWARE_RECIPE_REPO_ORG}/{HPC_SOFTWARE_RECIPE_REPO_NAME}.git'
 # Be generous with what is allowed after cray/hpc-software-recipe/
 HPC_SOFTWARE_RECIPE_RELEASE_REGEX = rf'refs/heads/(cray/{HPC_SOFTWARE_RECIPE_REPO_NAME}/(.+))'

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -93,7 +93,7 @@ class TestHPCSoftwareRecipeCatalog(unittest.TestCase):
             self.assertIn(recipe_version, recipe_catalog.recipes)
             recipe = recipe_catalog.recipes[recipe_version]
             self.assertEqual(version.parse(recipe_version), recipe.version)
-            self.assertEqual(f'cray/hpc-software-recipe/{recipe_version}',
+            self.assertEqual(f'cray/hpc-shasta-software-recipe/{recipe_version}',
                              recipe.vcs_branch)
             self.assertEqual(self.mock_vcs_repo, recipe.vcs_repo)
 


### PR DESCRIPTION
## Summary and Scope

The name of the repository created to contain recipe information was
changed to hpc-shasta-software-recipe, so change the name used by the
`sat bootprep` code to match.

## Issues and Related PRs

* Part of [CRAYSAT-1502]()

## Testing

### Tested on:

  * N/A

### Test description:

Minor change. Will be tested with integration of SAT with new
hpc-shasta-software-recipe release distribution prior to merge of
feature branch to integration.

## Risks and Mitigations

Low risk, fixing a mismatch between sat and hpc-shasta-software-recipe.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable