### PR TITLE
CRAYSAT-1463: Switch default BOS version to v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+- Changed the default value of the config file option `bos.api_version` to "v2".
+
 ## [3.18.0] - 2022-08-10
 
 ### Added

--- a/sat/config.py
+++ b/sat/config.py
@@ -103,7 +103,7 @@ SAT_CONFIG_SPEC = {
         'api_timeout': OptionSpec(int, 60, None, 'api_timeout'),
     },
     'bos': {
-        'api_version': OptionSpec(str, 'v1', validate_bos_api_version, 'bos_version')
+        'api_version': OptionSpec(str, 'v2', validate_bos_api_version, 'bos_version')
     },
     'bootsys': {
         'max_hsn_states': OptionSpec(int, 10, None, None),

--- a/tests/cli/bootsys/test_bos.py
+++ b/tests/cli/bootsys/test_bos.py
@@ -325,6 +325,7 @@ class TestBOSSessionThread(unittest.TestCase):
         self.mock_bos_client = Mock()
         patch('sat.cli.bootsys.bos.BOSClientCommon.get_bos_client', return_value=self.mock_bos_client).start()
         patch('sat.cli.bootsys.bos.SATSession').start()
+        self.mock_get_config_value = patch('sat.cli.bootsys.bos.get_config_value').start()
 
         self.mock_session_id = '0123456789abcdef'
         self.mock_create_response = {
@@ -398,8 +399,9 @@ class TestBOSSessionThread(unittest.TestCase):
                 'row.'.format(bos_thread.max_consec_fails + 1)
             )
 
-    def test_create_session(self):
+    def test_create_session_bos_v1(self):
         """Test create_session method of BOSSessionThread."""
+        self.mock_get_config_value.return_value = 'v1'
         bos_thread = BOSSessionThread('cle-1.3.0', 'boot')
         bos_thread.create_session()
         self.assertEqual(self.mock_session_id, bos_thread.session_id)


### PR DESCRIPTION


Test Description:


## Summary and Scope

This change updates the default version of BOS to "v2" in the config
file.

## Issues and Related PRs

* Resolves [CRAYSAT-1463](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1463)

## Testing

### Tested on:

  * Local development environment

### Test description:

Run unit tests.

(Functionality relating to BOS v2 has already been tested.)

## Risks and Mitigations

N/A.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

