### PR TITLE
CRAYSAT-1480: Fix ordering of NCN power operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+- The ordering of the bootup sequence of management NCNs in the
+  `sat-bootsys(8)` man page was fixed to reflect their correct ordering in the
+  `ncn-power` stage of `sat bootsys boot`.
+
 ## [3.19.0] - 2022-08-16
 
 ### Added

--- a/docs/man/sat-bootsys.8.rst
+++ b/docs/man/sat-bootsys.8.rst
@@ -73,7 +73,7 @@ action, each stage automates a specific portion of the system boot procedure.
 
 In the ``ncn-power`` stage, ``sat bootsys`` powers on all mangagement NCNs in
 stages. It first boots the master nodes and waits for them to become accessible
-over the network, and then repeats for the worker nodes, then the storage
+over the network, and then repeats for the storage nodes, then the worker
 nodes.
 
 In the ``platform-services`` stage, it ensures that containerd and etcd are are


### PR DESCRIPTION
## Summary and Scope

The ordering of NCN power operations in the boot phase of `sat bootsys` was fixed. See Ryan's comment [here](https://github.com/Cray-HPE/sat/pull/36#discussion_r949647100).

## Issues and Related PRs

* Resolves [CRAYSAT-1480](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1480)

## Testing

### Tested on:

  * Local development environment

### Test description:

Build man pages and inspect.

## Risks and Mitigations

N/A.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

