### PR TITLE
Revert "CRAYSAT-1463: Switch default BOS version to v2"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Reverted the default value of the config file option `bos.api_version` to "v1".
+
 ### Fixed
 - The ordering of the bootup sequence of management NCNs in the
   `sat-bootsys(8)` man page was fixed to reflect their correct ordering in the

--- a/sat/config.py
+++ b/sat/config.py
@@ -103,7 +103,7 @@ SAT_CONFIG_SPEC = {
         'api_timeout': OptionSpec(int, 60, None, 'api_timeout'),
     },
     'bos': {
-        'api_version': OptionSpec(str, 'v2', validate_bos_api_version, 'bos_version')
+        'api_version': OptionSpec(str, 'v1', validate_bos_api_version, 'bos_version')
     },
     'bootsys': {
         'max_hsn_states': OptionSpec(int, 10, None, None),

--- a/tests/cli/bootsys/test_bos.py
+++ b/tests/cli/bootsys/test_bos.py
@@ -325,7 +325,6 @@ class TestBOSSessionThread(unittest.TestCase):
         self.mock_bos_client = Mock()
         patch('sat.cli.bootsys.bos.BOSClientCommon.get_bos_client', return_value=self.mock_bos_client).start()
         patch('sat.cli.bootsys.bos.SATSession').start()
-        self.mock_get_config_value = patch('sat.cli.bootsys.bos.get_config_value').start()
 
         self.mock_session_id = '0123456789abcdef'
         self.mock_create_response = {
@@ -399,9 +398,8 @@ class TestBOSSessionThread(unittest.TestCase):
                 'row.'.format(bos_thread.max_consec_fails + 1)
             )
 
-    def test_create_session_bos_v1(self):
+    def test_create_session(self):
         """Test create_session method of BOSSessionThread."""
-        self.mock_get_config_value.return_value = 'v1'
         bos_thread = BOSSessionThread('cle-1.3.0', 'boot')
         bos_thread.create_session()
         self.assertEqual(self.mock_session_id, bos_thread.session_id)


### PR DESCRIPTION
This reverts commit e7dc853bdff03876722bd1c783b2cf4a39467f88.

## Summary and Scope

Revert the default BOS API version to "v1".

## Issues and Related PRs

* Resolves [CRAYSAT-1547](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1547)

## Testing

### Tested on:

  * `groot`

### Test description:

Run unit tests. Simply run `sat status --bos-fields` and check that an error is shown saying it only supports BOS v2. Try with `--bos-version=v2` to check that toggling works as expected.

## Risks and Mitigations

We would like to stay in line with the behavior of the `cray` CLI.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

