### PR TITLE
CRAYSAT-1546: Fix traceback on invalid subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The ordering of the bootup sequence of management NCNs in the
   `sat-bootsys(8)` man page was fixed to reflect their correct ordering in the
   `ncn-power` stage of `sat bootsys boot`.
+- Fixed a bug in which giving an invalid subcommand resulted in a traceback
+  on Python 3.9.
 
 ### Security
 - Update the version of paramiko from 2.9.2 to 2.10.1 to mitigate

--- a/sat/parser.py
+++ b/sat/parser.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -79,10 +79,6 @@ class SATArgParser(ArgumentParser):
 
         else:
             return parsed
-
-    def parse_known_args(self, args=None, namespace=None):
-        self.exit_on_error = False
-        return super().parse_known_args(args=args, namespace=namespace)
 
     def error(self, message):
         """Prints errors based on invalid arguments.


### PR DESCRIPTION
This commit removes setting `exit_on_error` to `False` in the
`parse_known_args` method of `sat.parser.SATArgParser`. Add
a change log entry.

Test Description:
* I installed SAT into a virtualenv with Python 3.9
* I ran SAT with an invalid subcommand and verified that a succinct
  error message was printed.
* I ran SAT with a valid subcommand but an invalid option and verified
  that the help text for the subcommand was printed.
* I ran SAT with both an invalid subcommand and invalid option and
  verified it behaved the same as just giving the invalid subcommand.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CRAYSAT-1546](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1546)

## Testing

### Tested on:

  * Local development environment

### Test description:

See commit message.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

