### PR TITLE
CRAYSAT-1537: Handle version comparisons using semver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,10 +25,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.19.1] - 2022-08-26
 
 ### Changed
 - Reverted the default value of the config file option `bos.api_version` to "v1".
+- Shasta Software Recipe version numbers now conform to Semantic Versioning
+  syntax, and version comparisons to determine the latest version are now
+  handled according to Semantic Versioning precedence rules.
 
 ### Fixed
 - The ordering of the bootup sequence of management NCNs in the

--- a/requirements-dev.lock.txt
+++ b/requirements-dev.lock.txt
@@ -44,7 +44,7 @@ pycodestyle==2.8.0
 pycparser==2.21
 Pygments==2.11.2
 PyNaCl==1.5.0
-pyparsing==3.0.7
+pyparsing==3.0.9
 pyrsistent==0.18.1
 python-dateutil==2.8.2
 pytz==2021.3
@@ -53,6 +53,7 @@ requests==2.27.1
 requests-oauthlib==1.3.1
 rsa==4.8
 s3transfer==0.5.2
+semver==2.13.0
 six==1.16.0
 snowballstemmer==2.2.0
 Sphinx==2.4.5

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -28,7 +28,6 @@ marshmallow-enum==1.5.1
 mypy-extensions==0.4.3
 natsort==8.1.0
 oauthlib==3.2.0
-packaging==21.3
 paramiko==2.10.1
 parsec==3.5
 prettytable==0.7.2
@@ -45,6 +44,7 @@ requests==2.27.1
 requests-oauthlib==1.3.1
 rsa==4.8
 s3transfer==0.5.2
+semver==2.13.0
 six==1.16.0
 sseclient-py==1.7.2
 toml==0.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,6 @@ Jinja2 >= 3.0, < 4.0
 json-schema-for-humans
 jsonschema >= 4.0, < 5.0
 kubernetes
-packaging
 paramiko >= 2.4.2
 parsec == 3.5.0
 prettytable >= 0.7.2, < 1.0
@@ -35,6 +34,7 @@ python-dateutil >= 2.7.3, < 3.0
 pyyaml >= 5.4.1, < 6.0
 requests < 3.0
 requests-oauthlib
+semver >= 2.13.0, < 3.0
 sseclient-py >= 1.7
 toml == 0.10.0
 urllib3 >= 1.26.5, < 2.0

--- a/sat/cli/bootprep/validate.py
+++ b/sat/cli/bootprep/validate.py
@@ -29,7 +29,7 @@ import pkgutil
 
 from jsonschema import SchemaError
 from jsonschema.validators import validator_for
-from packaging import version
+from semver import VersionInfo
 from yaml import safe_load, YAMLError
 
 from sat.cli.bootprep.constants import DEFAULT_INPUT_SCHEMA_VERSION
@@ -116,17 +116,12 @@ def validate_instance_schema_version(instance, schema_validator):
 
     # No default is needed here because the version property was added to the
     # bootprep_schema.yaml schema file simultaneously with this code.
-    current_version = version.parse(schema_validator.schema['version'])
+    current_version = VersionInfo.parse(schema_validator.schema['version'])
 
     try:
-        instance_version = version.parse(instance_version_str)
+        instance_version = VersionInfo.parse(instance_version_str)
 
-        # LegacyVersion is deprecated (see https://github.com/pypa/packaging/issues/321),
-        # and sometimes invalid versions can parse as "Legacy". To avoid this,
-        # treat LegacyVersions as invalid.
-        if isinstance(instance_version, version.LegacyVersion):
-            raise version.InvalidVersion()
-    except version.InvalidVersion as err:
+    except ValueError as err:
         raise BootPrepValidationError(
             f'Invalid schema version {instance_version_str} specified '
             f'as value of {schema_version_property} property.'


### PR DESCRIPTION
## Summary and Scope

This change changes version comparison for Shasta Software Recipes and
bootprep schemas to use the `semver` library instead of the `packaging`
library, which uses the PEP 440 versioning scheme.

## Issues and Related PRs

* Resolves [CRAYSAT-1537](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1537)

## Testing

### Tested on:

  * `loki`
  * Local development environment

### Test description:

Run unit tests. Run on system with software recipe installed, and
push various "release" and "prerelease" branches to ensure their
ordering is handled properly.

## Risks and Mitigations

N/A

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

