### PR TITLE
CRAYSAT-1552: Rename software recipe to hpc-csm-software-recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.19.2] - 2022-08-30
+
+### Changed
+- Changed the name of the VCS repository containing the `product_vars.yaml`
+  file from `hpc-shasta-software-recipe` to `hpc-csm-software-recipe`.
+
 ## [3.19.1] - 2022-08-26
 
 ### Changed

--- a/sat/recipe.py
+++ b/sat/recipe.py
@@ -43,7 +43,7 @@ from sat.cached_property import cached_property
 from sat.config import get_config_value
 
 HPC_SOFTWARE_RECIPE_REPO_ORG = 'cray'
-HPC_SOFTWARE_RECIPE_REPO_NAME = 'hpc-shasta-software-recipe'
+HPC_SOFTWARE_RECIPE_REPO_NAME = 'hpc-csm-software-recipe'
 HPC_SOFTWARE_RECIPE_REPO_PATH = f'/vcs/{HPC_SOFTWARE_RECIPE_REPO_ORG}/{HPC_SOFTWARE_RECIPE_REPO_NAME}.git'
 # Be generous with what is allowed after cray/hpc-software-recipe/
 HPC_SOFTWARE_RECIPE_RELEASE_REGEX = rf'refs/heads/(cray/{HPC_SOFTWARE_RECIPE_REPO_NAME}/(.+))'

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -95,7 +95,7 @@ class TestHPCSoftwareRecipeCatalog(unittest.TestCase):
             self.assertIn(recipe_version, recipe_catalog.recipes)
             recipe = recipe_catalog.recipes[recipe_version]
             self.assertEqual(VersionInfo.parse(recipe_version), recipe.version)
-            self.assertEqual(f'cray/hpc-shasta-software-recipe/{recipe_version}',
+            self.assertEqual(f'cray/hpc-csm-software-recipe/{recipe_version}',
                              recipe.vcs_branch)
             self.assertEqual(self.mock_vcs_repo, recipe.vcs_repo)
 


### PR DESCRIPTION
## Summary and Scope

Rename software recipe to hpc-csm-software-recipe subce it's been decided that "shasta" shouldn't be in the name of the repo.

This change is not backwards compatible with older versions of the software recipe, but that's okay because new versions of the software recipe will include this new version of `sat`, and older versions of the recipe will include old versions of `sat`.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CRAYSAT-1552](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1552)

## Testing

### Tested on:

  * surtur

### Test description:

Waited for Jenkins build. Exported SAT_IMAGE on surtur and ran `sat
bootprep` against an input file that used a version from the
`product_vars.yaml` file in the VCS repo for the recipe.

## Risks and Mitigations

No known issues.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

