### PR TITLE
PE-42104 - Adding Jobstat to SAT CLI (continuation of PR-38)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added new command `jobstat`, which provides system-wide view of application
+  status data.
 ### Changed
 - Updated the README file to remove outdated information.
 

--- a/docs/man/sat-jobstat.8.rst
+++ b/docs/man/sat-jobstat.8.rst
@@ -1,0 +1,60 @@
+=============
+ SAT-JOBSTAT
+=============
+
+---------------------------------------------------
+Jobstat - Check status of jobs and its applications
+---------------------------------------------------
+
+:Author: Hewlett Packard Enterprise Development LP.
+:Copyright: Copyright 2022 Hewlett Packard Enterprise Development LP.
+:Manual section: 8
+
+SYNOPSIS
+========
+
+**sat** [global-opts] **jobstat** [options]
+
+DESCRIPTION
+===========
+
+Jobstat is a command that allows a user or admin to access application and job
+data via the command line. The command provides a table showing the user the
+apid, jobid, user, state, and time-reported of all jobs on the system.
+
+OPTIONS
+=======
+
+These options must be specified after the subcommand.
+
+**-h, --help**
+        Print the help message for 'sat jobstat'.
+
+.. include:: _sat-format-opts.rst
+
+EXAMPLES
+========
+
+The command displays a summary report for all jobs on the system e.g.
+
+::
+
+    # sat jobstat --filter state=completed
+    +---------------------------------------+--------------+-------+-------------------------------------+-----------+-----------+---------------------+
+    | apid                                  | jobid        | user  | command                             | state     | num_nodes | node_list           |
+    +---------------------------------------+--------------+-------+-------------------------------------+-----------+-----------+---------------------+
+    | 7677b7d3-ec35-4e23-8678-92b823347939  | 49.pbs-host  | 5827  | mpiexec --ppn=1 -n2 ./signals       | completed | 2         | nid000001,nid000002 |
+    | 76b783af-5c7e-4462-97c0-3dfd0f04b9b3  | 51.pbs-host  | 5827  | mpiexec --ppn=1 -n2 ./signals       | completed | 2         | nid000001,nid000002 |
+    | 7a85c000-05a9-40cd-8551-00092cead801  | 48.pbs-host  | 5827  | mpiexec -n2 ./signals               | completed | 1         | nid000001           |
+    | 8b5b14b3-8215-4cbe-bba4-7d7c82d48fef  | 50.pbs-host  | 5827  | mpiexec --ppn=1 -n2 ./signals       | completed | 2         | nid000001,nid000002 |
+    | 957bbd4c-de3c-424d-99d6-fd2b728b2941  | 54.pbs-host  | 5827  | mpiexec --ppn=1 -n2 ./signals       | completed | 2         | nid000001,nid000002 |
+    | ba977b71-40b6-40db-aa20-a583edc18be3  | 59.pbs-host  | 5827  | mpiexec --ppn=1 -n2 ./signals-sleep | completed | 2         | nid000001,nid000002 |
+    | fea2726a-c531-4acd-b158-3fae197999dd  | 57.pbs-host  | 5827  | mpiexec --ppn=1 -n2 ./signals       | completed | 2         | nid000001,nid000002 |
+    +---------------------------------------+--------------+-------+-------------------------------------+-----------+-----------+---------------------+
+
+SEE ALSO
+========
+
+sat(8)
+
+.. include:: _notice.rst

--- a/sat/apiclient/jobstat.py
+++ b/sat/apiclient/jobstat.py
@@ -1,0 +1,60 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""
+Client for querying the Job State Checker service
+"""
+
+import logging
+
+from sat.apiclient.gateway import APIError, APIGatewayClient
+
+LOGGER = logging.getLogger(__name__)
+
+
+class JobstatClient(APIGatewayClient):
+    base_resource_path = 'statechecker/jobstat/'
+
+    def get_all(self):
+        """Get all results from Job State Checker.
+
+        Returns:
+            A list of dictionaries where each dictionary pertains to a
+            single job.
+
+        Raises:
+            APIError: if there is a failure querying the Job State Checker API
+                or getting the required information from the response.
+        """
+        err_prefix = 'Failed to get State Checker data'
+        try:
+            response = self.get('all').json()
+            if 'errorcode' in response and response['errorcode'] != 0:
+                raise APIError(response.get('errormessage', 'unknown error'))
+            return response['jobstat']
+        except APIError as err:
+            raise APIError(f'{err_prefix}: {err}')
+        except ValueError as err:
+            raise APIError(f'{err_prefix} due to bad JSON in response: {err}')
+        except KeyError as err:
+            raise APIError(f'{err_prefix} due to missing {err} key in response.')

--- a/sat/cli/jobstat/main.py
+++ b/sat/cli/jobstat/main.py
@@ -1,0 +1,62 @@
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""
+The main entry point for the jobstat subcommand.
+"""
+import logging
+from sat.report import Report
+from sat.config import get_config_value
+from sat.apiclient import APIError
+from sat.apiclient.jobstat import JobstatClient
+from sat.session import SATSession
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+def do_jobstat(args):
+    """Run the jobstat command with the given arguments.
+    Args:
+        args: The argparse.Namespace object containing the parsed arguments
+            passed to this subcommand.
+    """
+    state_checker_client = JobstatClient(SATSession())
+    try:
+        application_data = state_checker_client.get_all()
+        if not application_data:
+            return
+        report = Report(
+            tuple(application_data[0].keys()),
+            None,
+            args.sort_by,
+            args.reverse,
+            filter_strs=args.filter_strs,
+            display_headings=args.fields,
+            print_format=args.format,
+        )
+        for row in application_data:
+            report.add_row(row)
+        print(report)
+    except APIError as err:
+        LOGGER.error(err)
+        raise SystemExit(1)

--- a/sat/cli/jobstat/parser.py
+++ b/sat/cli/jobstat/parser.py
@@ -1,0 +1,46 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""
+The parser for the jobstat subcommand.
+"""
+import sat.parsergroups
+
+
+def add_jobstat_subparser(subparsers):
+    """Add the jobstat parser to the parent parser.
+    Args:
+        subparsers: The argparse.ArgumentParser object returned by the
+            add_subparsers method.
+    Returns:
+        None
+    """
+    format_options = sat.parsergroups.create_format_options()
+    filter_options = sat.parsergroups.create_filter_options()
+
+    jobstat_parser = subparsers.add_parser(
+        'jobstat',
+        help='Application information',
+        description='This command shows all jobs and relevant information pertaining to those applications.',
+        parents=[format_options, filter_options],
+    )


### PR DESCRIPTION
This commit implements `sat jobstat`. This command gets a system-wide view of
  applications and displays it in a pretty table format. This commit also adds
  a change log entry and man page for the command.