### PR TITLE
CRAYSAT-1539: Use raise_not_ok API in subcommand implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactored to use common `APIGatewayClient`, `CFSClient`, `HSMClient`, and
   `VCSRepo` classes and associated exception classes and utility functions from
   the new `csm-api-client` Python library.
+- New common functionality in `csm-api-client` is now used to differentiate 404
+  errors to provided better error messages and clearer semantics in `sat swap
+  blade` and `sat bootprep`.
 
 ## [3.19.3] - 2022-09-29
 

--- a/sat/cli/bootprep/input/session_template.py
+++ b/sat/cli/bootprep/input/session_template.py
@@ -121,11 +121,16 @@ class InputSessionTemplate(BaseInputItem):
             return
 
         try:
-            self.cfs_client.get_configuration(self.configuration)
-        except APIError as err:
-            # TODO: should probably differentiate between 404 Not Found and other errors
-            raise InputItemValidateError(f'Configuration {self.configuration} specified for '
-                                         f'{self} does not exist: {err}')
+            resp = self.cfs_client.get('configurations', self.configuration, raise_not_ok=False)
+            if not resp.ok:
+                if resp.status_code == 404:
+                    raise InputItemValidateError(f'Configuration {self.configuration} specified for '
+                                                 f'{self} does not exist.')
+                else:
+                    self.cfs_client.raise_from_response(resp)
+        except (APIError, ValueError) as err:
+            raise InputItemValidateError(f'An error occurred while querying configuration '
+                                         f'{self.configuration}: {err}')
 
     @abstractmethod
     def validate_image_exists(self, **_):
@@ -164,6 +169,33 @@ class InputSessionTemplate(BaseInputItem):
             api_data['boot_sets'][boot_set_name] = boot_set_api_data
 
         return api_data
+
+    def get_image_record_by_id(self, ims_image_id):
+        """Look up an IMS image record by its ID.
+
+        Args:
+            ims_image_id (str): the UUID of the image
+
+        Returns:
+            dict: the IMS image ID corresponding to the given UUID
+
+        Raises:
+            InputItemValidateError: if there is an issue looking up the image
+                or if the image does not exist.
+        """
+        try:
+            resp = self.ims_client.get('images', ims_image_id, raise_not_ok=False)
+            if not resp.ok:
+                if resp.status_code == 404:
+                    raise InputItemValidateError(f'No image with name or ID {ims_image_id} exists '
+                                                 f'for use by {self}')
+                else:
+                    self.ims_client.raise_from_response(resp)
+            else:
+                return resp.json()
+        except (APIError, ValueError) as err:
+            raise InputItemValidateError(f'An error occurred while querying the image record '
+                                         f'with ID {ims_image_id}: {err}') from err
 
     def create(self, dumper=None):
         """Create the session template with a request to the BOS API."""
@@ -222,12 +254,7 @@ class InputSessionTemplateV1(InputSessionTemplate):
 
         if len(name_matches) == 0:
             if self.image_is_uuid:
-                try:
-                    return self.ims_client.get_image(self.image)
-                except APIError as err:
-                    # TODO: should probably differentiate between 404 Not Found and other errors
-                    raise InputItemValidateError(f'No image with name or ID {self.image} exists '
-                                                 f'for use by {self}: {err}')
+                return self.get_image_record_by_id(self.image)
             else:
                 raise InputItemValidateError(f'No image with name {self.image} exists for '
                                              f'use by session template {self}.')
@@ -297,12 +324,7 @@ class InputSessionTemplateV2(InputSessionTemplate):
     def image_record(self):
         """dict: the image record from IMS if one can be found"""
         if self.ims_image_id:
-            try:
-                return self.ims_client.get_image(self.ims_image_id)
-            except APIError as err:
-                # TODO: should probably differentiate between 404 Not Found and other errors
-                raise InputItemValidateError(f'No image with ID {self.ims_image_id} exists '
-                                             f'for use by {self}: {err}')
+            return self.get_image_record_by_id(self.ims_image_id)
         else:
             # First, get the name of the image
             image_name = self.ims_image_name


### PR DESCRIPTION

## Summary and Scope

This change uses the `raise_not_ok` option in implementations of `sat swap blade` and the validators for `sat bootprep`. This allows easier changes to behavior based on HTTP status codes.

## Issues and Related PRs

* Resolves [CRAYSAT-1539](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1539)

## Testing

### Tested on:

  * `mug`
  * Local development environment

### Test description:

Run unit tests. Manually perform regression test for `sat bootprep`.

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

