### PR TITLE
CASMTRIAGE-4288: Fix bootprep error in copying image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Updated the README file to remove outdated information.
+- Removed the HTTP timeout from the IMSClient instance used in
+  `sat bootprep` to address slow IMS delete requests.
 
 ### Removed
 - Removed the `cray-sat` spec file from the repository.
+
+### Fixed
+- Fixed an issue where `sat bootprep` would sometimes fail to rename
+  large images.
 
 ### Security
 - Update the version of oauthlib from 3.2.0 to 3.2.1 to address

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.19.3] - 2022-09-29
 
 ### Changed
 - Updated the README file to remove outdated information.

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 argcomplete
 boto3
+botocore
 cray-product-catalog >= 1.6.0
 croniter >= 0.3, < 1.0
 inflect >= 0.2.5, < 3.0

--- a/sat/cli/bootprep/main.py
+++ b/sat/cli/bootprep/main.py
@@ -169,6 +169,9 @@ def do_bootprep_run(schema_validator, args):
     session = SATSession()
     cfs_client = CFSClient(session)
     ims_client = IMSClient(session)
+    # CASMTRIAGE-4288: IMS can be extremely slow to return DELETE requests for
+    # large images, so this IMSClient will not use a timeout on HTTP requests
+    ims_client.set_timeout(None)
     bos_client = BOSClientCommon.get_bos_client(session)
 
     try:


### PR DESCRIPTION
This commit changes the method of copying from using boto3 S3.Object.copy_from to using boto3 s3.Object.copy, which handles large files better.

Additionally, this change imports botocore.exceptions.ClientError and catches it in the same places that Boto3Error is caught, so that future failures will be logged appropriately rather than failing with a traceback. As a result of importing this exception, botocore is added to the list of top-level dependencies in requirements.txt

Finally, this commit adds a change log entry.

Test Description: After building this image in Jenkins, asked an admin to re-run `sat bootprep` with the value of SAT_IMAGE set to the resulting build.

## Summary and Scope

See commit message

## Issues and Related PRs

[CASMTRIAGE-4288](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-4288)

## Testing

See commit message

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable