### PR TITLE
CRAYSAT-1532: Add `sat bootprep list-vars` subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added a `sat bootprep list-vars` subcommand which lists the variables
+  available in bootprep input files at runtime.
+
 ### Changed
 - Refactored to use common `APIGatewayClient`, `CFSClient`, `HSMClient`, and
   `VCSRepo` classes and associated exception classes and utility functions from

--- a/sat/cli/bootprep/main.py
+++ b/sat/cli/bootprep/main.py
@@ -60,10 +60,39 @@ from sat.cli.bootprep.validate import (
     SCHEMA_FILE_RELATIVE_PATH,
 )
 from sat.cli.bootprep.vars import VariableContext, VariableContextError
+from sat.report import Report
 from sat.session import SATSession
 
 
 LOGGER = logging.getLogger(__name__)
+
+
+def load_vars_or_exit(recipe_version, vars_file, additional_vars):
+    """Load variables and construct the variable context.
+
+    This is a simple wrapper around VariableContext.load_vars()
+    which handles constructing the context and loading variables.
+    If there is a problem loading the variables, exit the program.
+
+    Args:
+        recipe_version (str): the version of the software recipe to
+            load from VCS
+        vars_file (str): the path to the vars file to load
+        additional_vars (str):
+
+    Returns:
+        VariableContext: the context containing the loaded variables
+
+    Raises:
+        SystemExit: if the variables cannot be loaded.
+    """
+    try:
+        var_context = VariableContext(recipe_version, vars_file, additional_vars)
+        var_context.load_vars()
+        return var_context
+    except VariableContextError as err:
+        LOGGER.error(str(err))
+        raise SystemExit(1)
 
 
 def do_bootprep_docs(args):
@@ -183,12 +212,12 @@ def do_bootprep_run(schema_validator, args):
         # data will fail. Otherwise, this is not a problem.
         product_catalog = None
 
-    var_context = VariableContext(args.recipe_version, args.vars_file, args.vars)
-    try:
-        var_context.load_vars()
-    except VariableContextError as err:
-        LOGGER.error(str(err))
-        raise SystemExit(1)
+    var_context = load_vars_or_exit(
+        args.recipe_version,
+        args.vars_file,
+        args.vars
+    )
+
     jinja_env = SandboxedEnvironment()
     jinja_env.globals = var_context.vars
 
@@ -247,6 +276,17 @@ def do_bootprep_run(schema_validator, args):
             raise SystemExit(1)
 
 
+def do_bootprep_list_available_vars(args):
+    var_context = load_vars_or_exit(
+        args.recipe_version,
+        args.vars_file,
+        args.vars
+    )
+    report = Report(['Variable name', 'Value', 'Source'])
+    report.add_rows(var_context.enumerate_vars_and_sources())
+    print(report)
+
+
 def do_bootprep(args):
     """Main entry point for bootprep command.
 
@@ -273,3 +313,5 @@ def do_bootprep(args):
         do_bootprep_schema(schema_file_contents)
     elif args.action == 'generate-example':
         do_bootprep_example(schema_validator, args)
+    elif args.action == 'list-vars':
+        do_bootprep_list_available_vars(args)

--- a/sat/cli/bootprep/main.py
+++ b/sat/cli/bootprep/main.py
@@ -67,7 +67,7 @@ from sat.session import SATSession
 LOGGER = logging.getLogger(__name__)
 
 
-def load_vars_or_exit(recipe_version, vars_file, additional_vars):
+def load_vars_or_exit(recipe_version, vars_file_path, additional_vars):
     """Load variables and construct the variable context.
 
     This is a simple wrapper around VariableContext.load_vars()
@@ -77,8 +77,9 @@ def load_vars_or_exit(recipe_version, vars_file, additional_vars):
     Args:
         recipe_version (str): the version of the software recipe to
             load from VCS
-        vars_file (str): the path to the vars file to load
-        additional_vars (str):
+        vars_file_path (str): the path to the vars file to load
+        additional_vars (dict): additional variables, e.g. from
+            the command line
 
     Returns:
         VariableContext: the context containing the loaded variables
@@ -87,7 +88,7 @@ def load_vars_or_exit(recipe_version, vars_file, additional_vars):
         SystemExit: if the variables cannot be loaded.
     """
     try:
-        var_context = VariableContext(recipe_version, vars_file, additional_vars)
+        var_context = VariableContext(recipe_version, vars_file_path, additional_vars)
         var_context.load_vars()
         return var_context
     except VariableContextError as err:

--- a/sat/cli/bootprep/parser.py
+++ b/sat/cli/bootprep/parser.py
@@ -103,19 +103,19 @@ def add_vars_options(parser):
              f'obtain the product versions which can be substituted for variables '
              f'specified in fields in the input file. If not specified or if '
              f'"{LATEST_VERSION_VALUE}" is specified, use the latest available HPC '
-             f'software recipe version.'
+             f'CSM Software Recipe version.'
     )
     parser.add_argument(
         '--vars-file',
         help='A file containing variables that can be used in fields in the '
              'input file. Values from this file take precedence over values '
-             'in the HPC Software Recipe defaults.'
+             'in the HPC CSM Software Recipe defaults.'
     )
     parser.add_argument(
         '--vars', action=StoreNestedVariable,
         help='Variables that can be used in fields in the input file. Values '
              'specified here take precedence over values specified in any '
-             '--vars-file or in the HPC software recipe defaults.'
+             '--vars-file or in the HPC CSM Software Recipe defaults.'
     )
 
 
@@ -279,10 +279,10 @@ def _add_bootprep_list_vars_subparser(subparsers):
     vars_subparser = subparsers.add_parser(
         'list-vars',
         parents=[format_options, filter_options],
-        help='List the variables that may be used in bootprep input file',
+        help='List the variables that may be used in bootprep input files.',
         description='List the variables that are available during variable substitution '
                     'when processing a bootprep input file. Variables are sourced from '
-                    'vars files and the software recipe.',
+                    'the command line, vars files, and the HPC CSM Software Recipe.',
     )
 
     add_vars_options(vars_subparser)

--- a/sat/cli/bootprep/vars.py
+++ b/sat/cli/bootprep/vars.py
@@ -150,6 +150,8 @@ class VariableContext:
                 value: value of variable
                 source: "--vars", vars file path, or "recipe ..."
         """
+        # Order of dict keys is important here: it determines the
+        # precedence of where the variables are sourced from.
         var_attr_by_source = {
             f'--vars': 'cli_vars',
             self.vars_file_path: 'file_vars',

--- a/sat/util.py
+++ b/sat/util.py
@@ -548,7 +548,7 @@ def deep_update_dict(original_dict, new_dict):
             original_dict[key] = value
 
 
-def collapse_keys(vars, separator="."):
+def collapse_keys(nested_dict, separator="."):
     """Convert a nested dict to a flat dict with dot-separated keys.
 
     For example, given the following input dictionary:
@@ -570,15 +570,15 @@ def collapse_keys(vars, separator="."):
     }
 
     Args:
-        vars (dict): A (nested) dictionary of strings mapping to strings
-        separator (str): the separator to use to concated nested keys
+        nested_dict (dict): A (nested) dictionary of strings mapping to strings
+        separator (str): the separator to use to concatenated nested keys
 
     Returns:
         dict: a "flattened" dictionary in which nested dictionaries' keys are
             concatenated using the given separator, and the values are the
             corresponding leaves in the nested dictionary tree
     """
-    vars_stack = dict(vars)
+    vars_stack = dict(nested_dict)
     collapsed = {}
 
     while vars_stack:

--- a/sat/util.py
+++ b/sat/util.py
@@ -548,6 +548,57 @@ def deep_update_dict(original_dict, new_dict):
             original_dict[key] = value
 
 
+def collapse_keys(vars, separator="."):
+    """Convert a nested dict to a flat dict with dot-separated keys.
+
+    For example, given the following input dictionary:
+
+    {
+        "foo": {"bar": "baz"},
+        "quux": {
+            "giblet": {"znurt": "fizzle"},
+            "xyzzy": "fnord"
+        }
+    }
+
+    The following "collapsed" dictionary will be returned:
+
+    {
+        "foo.bar": "baz",
+        "quux.giblet.znurt": "fizzle",
+        "quux.xyzzy": "fnord"
+    }
+
+    Args:
+        vars (dict): A (nested) dictionary of strings mapping to strings
+        separator (str): the separator to use to concated nested keys
+
+    Returns:
+        dict: a "flattened" dictionary in which nested dictionaries' keys are
+            concatenated using the given separator, and the values are the
+            corresponding leaves in the nested dictionary tree
+    """
+    vars_stack = dict(vars)
+    collapsed = {}
+
+    while vars_stack:
+        key, val = vars_stack.popitem()
+        if isinstance(val, dict):
+            for subkey, subval in val.items():
+                push_key = f'{key}{separator}{subkey}'
+                if push_key in vars_stack:
+                    raise ValueError(f'Collapsed dict key conflicts with '
+                                     f'existing input key {push_key}')
+                vars_stack[push_key] = subval
+        else:
+            if key in collapsed:
+                raise ValueError(f'Existing input key {key} conflicts '
+                                 f'with collapsed dict key')
+            collapsed[key] = val
+
+    return collapsed
+
+
 def get_new_ordered_dict(orig_dict, dotted_paths, default_value=None, strip_path=True):
     """Get a new ordered dict from a dict using the given dotted_paths.
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -54,7 +54,7 @@ setup(
     author='Hewlett Packard Enterprise Development LP',
     license='MIT',
     packages=find_packages(exclude=['tests', 'tests.*', 'tools', 'tools.*']),
-    python_requires='>=3, <4',
+    python_requires='>=3.8, <4',
     # Top-level dependencies are parsed from requirements.txt
     install_requires=install_requires,
 

--- a/tests/cli/bootprep/test_vars.py
+++ b/tests/cli/bootprep/test_vars.py
@@ -51,6 +51,7 @@ class TestEnumeratingVars(unittest.TestCase):
             'bar': {'version': '2.3.4'}
         }
         self.mock_catalog.return_value.get_latest_version.return_value.all_vars = self.software_recipe_vars
+        self.mock_catalog.return_value.get_recipe_version.return_value.all_vars = self.software_recipe_vars
 
     def tearDown(self):
         patch.stopall()
@@ -60,16 +61,15 @@ class TestEnumeratingVars(unittest.TestCase):
         self.context.recipe_version = LATEST_VERSION_VALUE
         expected_elements = {('foo.version', '1.2.3', 'latest recipe'),
                              ('bar.version', '2.3.4', 'latest recipe')}
-        for element in list(self.context.enumerate_vars_and_sources()):
-            self.assertIn(element, expected_elements)
+        self.assertEqual(set(self.context.enumerate_vars_and_sources()), expected_elements)
 
     def test_getting_arbitrary_recipe_vars(self):
         """Test enumerating variables from a given recipe version"""
         self.context.recipe_version = '22.07'
+
         expected_elements = {('foo.version', '1.2.3', '22.07 recipe'),
                              ('bar.version', '2.3.4', '22.07 recipe')}
-        for element in list(self.context.enumerate_vars_and_sources()):
-            self.assertIn(element, expected_elements)
+        self.assertEqual(set(self.context.enumerate_vars_and_sources()), expected_elements)
 
     def test_getting_file_vars(self):
         """Test retrieving variables from a vars file"""
@@ -79,8 +79,7 @@ class TestEnumeratingVars(unittest.TestCase):
         with patch('sat.cli.bootprep.vars.open', mock_open(read_data=self.vars_file_contents)):
             expected_elements = {('foo.version', '2.3.4', vars_file_path),
                                  ('bar.version', '4.5.6', vars_file_path)}
-            for element in list(self.context.enumerate_vars_and_sources()):
-                self.assertIn(element, expected_elements)
+            self.assertEqual(set(self.context.enumerate_vars_and_sources()), expected_elements)
 
     def test_getting_cli_vars(self):
         """Test retrieving variables from the command line"""
@@ -89,25 +88,24 @@ class TestEnumeratingVars(unittest.TestCase):
             'foo': {'version': '1.2.3'},
             'bar': {'version': '2.3.4'}
         }
+        self.context.recipe_version = LATEST_VERSION_VALUE
         expected_elements = {('foo.version', '1.2.3', '--vars'),
                              ('bar.version', '2.3.4', '--vars')}
-
-        for element in list(self.context.enumerate_vars_and_sources()):
-            self.assertIn(element, expected_elements)
+        self.assertEqual(set(self.context.enumerate_vars_and_sources()), expected_elements)
 
     def test_file_vars_override_catalog(self):
-        """Test that file vars override the product catalog"""
+        """Test that file vars override the HPC CSM Software Recipe"""
         vars_file_path = 'some_path.yaml'
         self.context.vars_file_path = vars_file_path
         vars_file_content = dedent("""
         foo:
             version: 1.2.4
         """)
+        self.context.recipe_version = LATEST_VERSION_VALUE
         with patch('sat.cli.bootprep.vars.open', mock_open(read_data=vars_file_content)):
             expected_elements = {('foo.version', '1.2.4', vars_file_path),
                                  ('bar.version', '2.3.4', 'latest recipe')}
-            for element in expected_elements:
-                self.assertIn(element, expected_elements)
+            self.assertEqual(set(self.context.enumerate_vars_and_sources()), expected_elements)
 
     def test_cli_vars_override_file_and_catalog(self):
         """Test that CLI vars override the vars file and catalog"""
@@ -120,8 +118,8 @@ class TestEnumeratingVars(unittest.TestCase):
         self.context.cli_vars = {
             'foo': {'version': '1.2.5'}
         }
+        self.context.recipe_version = LATEST_VERSION_VALUE
         with patch('sat.cli.bootprep.vars.open', mock_open(read_data=vars_file_content)):
             expected_elements = {('foo.version', '1.2.5', '--vars'),
                                  ('bar.version', '2.3.4', 'latest recipe')}
-            for element in expected_elements:
-                self.assertIn(element, expected_elements)
+            self.assertEqual(set(self.context.enumerate_vars_and_sources()), expected_elements)

--- a/tests/cli/bootprep/test_vars.py
+++ b/tests/cli/bootprep/test_vars.py
@@ -1,0 +1,127 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""
+Unit tests for variable loading
+"""
+
+from textwrap import dedent
+import unittest
+from unittest.mock import mock_open, patch
+
+from sat.cli.bootprep.constants import LATEST_VERSION_VALUE
+from sat.cli.bootprep.vars import VariableContext
+
+
+class TestEnumeratingVars(unittest.TestCase):
+    """Test enumerating variables and sources"""
+
+    def setUp(self):
+        self.context = VariableContext()
+        self.vars_file_contents = dedent("""
+        foo:
+            version: 2.3.4
+        bar:
+            version: 4.5.6
+        """)
+
+        self.mock_catalog = patch('sat.cli.bootprep.vars.HPCSoftwareRecipeCatalog').start()
+        self.software_recipe_vars = {
+            'foo': {'version': '1.2.3'},
+            'bar': {'version': '2.3.4'}
+        }
+        self.mock_catalog.return_value.get_latest_version.return_value.all_vars = self.software_recipe_vars
+
+    def tearDown(self):
+        patch.stopall()
+
+    def test_getting_latest_recipe_vars(self):
+        """Test enumerating variables from the latest recipe"""
+        self.context.recipe_version = LATEST_VERSION_VALUE
+        expected_elements = {('foo.version', '1.2.3', 'latest recipe'),
+                             ('bar.version', '2.3.4', 'latest recipe')}
+        for element in list(self.context.enumerate_vars_and_sources()):
+            self.assertIn(element, expected_elements)
+
+    def test_getting_arbitrary_recipe_vars(self):
+        """Test enumerating variables from a given recipe version"""
+        self.context.recipe_version = '22.07'
+        expected_elements = {('foo.version', '1.2.3', '22.07 recipe'),
+                             ('bar.version', '2.3.4', '22.07 recipe')}
+        for element in list(self.context.enumerate_vars_and_sources()):
+            self.assertIn(element, expected_elements)
+
+    def test_getting_file_vars(self):
+        """Test retrieving variables from a vars file"""
+        self.software_recipe_vars = {}
+        vars_file_path = 'some_path.yaml'
+        self.context.vars_file_path = vars_file_path
+        with patch('sat.cli.bootprep.vars.open', mock_open(read_data=self.vars_file_contents)):
+            expected_elements = {('foo.version', '2.3.4', vars_file_path),
+                                 ('bar.version', '4.5.6', vars_file_path)}
+            for element in list(self.context.enumerate_vars_and_sources()):
+                self.assertIn(element, expected_elements)
+
+    def test_getting_cli_vars(self):
+        """Test retrieving variables from the command line"""
+        self.software_recipe_vars = {}
+        self.context.cli_vars = {
+            'foo': {'version': '1.2.3'},
+            'bar': {'version': '2.3.4'}
+        }
+        expected_elements = {('foo.version', '1.2.3', '--vars'),
+                             ('bar.version', '2.3.4', '--vars')}
+
+        for element in list(self.context.enumerate_vars_and_sources()):
+            self.assertIn(element, expected_elements)
+
+    def test_file_vars_override_catalog(self):
+        """Test that file vars override the product catalog"""
+        vars_file_path = 'some_path.yaml'
+        self.context.vars_file_path = vars_file_path
+        vars_file_content = dedent("""
+        foo:
+            version: 1.2.4
+        """)
+        with patch('sat.cli.bootprep.vars.open', mock_open(read_data=vars_file_content)):
+            expected_elements = {('foo.version', '1.2.4', vars_file_path),
+                                 ('bar.version', '2.3.4', 'latest recipe')}
+            for element in expected_elements:
+                self.assertIn(element, expected_elements)
+
+    def test_cli_vars_override_file_and_catalog(self):
+        """Test that CLI vars override the vars file and catalog"""
+        vars_file_path = 'some_path.yaml'
+        self.context.vars_file_path = vars_file_path
+        vars_file_content = dedent("""
+        foo:
+            version: 1.2.4
+        """)
+        self.context.cli_vars = {
+            'foo': {'version': '1.2.5'}
+        }
+        with patch('sat.cli.bootprep.vars.open', mock_open(read_data=vars_file_content)):
+            expected_elements = {('foo.version', '1.2.5', '--vars'),
+                                 ('bar.version', '2.3.4', 'latest recipe')}
+            for element in expected_elements:
+                self.assertIn(element, expected_elements)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -418,6 +418,57 @@ class TestDeepUpdateDict(unittest.TestCase):
             util.deep_update_dict('mrducks', {'response': 'mrnotducks'})
 
 
+class TestCollapseVariables(unittest.TestCase):
+    """Tests for collapsing variable names"""
+
+    def test_non_nested_variable(self):
+        """Test that flat dicts are unaffected"""
+        flat_dict = {'foo': 'bar'}
+        self.assertEqual(util.collapse_keys(flat_dict), flat_dict)
+
+    def test_single_nested(self):
+        """Test collapsing a single level of nesting"""
+        self.assertEqual(util.collapse_keys({'foo': {'bar': 'baz'}}),
+                         {'foo.bar': 'baz'})
+
+    def test_multiple_nested(self):
+        """Test collapsing multiple levels of nesting"""
+        self.assertEqual(util.collapse_keys({'foo': {'bar': {'baz': {'quux': 'znurt'}}}}),
+                         {'foo.bar.baz.quux': 'znurt'})
+
+    def test_nested_with_multiple_keys(self):
+        """Test collapsing multiple levels of nesting with multiple keys at each level"""
+        input_dict = {
+            'foo': {
+                'bar': {
+                    'baz': 'quux',
+                    'giblet': 'znurt'
+                }
+            },
+            'spam': {
+                'eggs': 'france'
+            }
+        }
+
+        collapsed = {
+            'foo.bar.baz': 'quux',
+            'foo.bar.giblet': 'znurt',
+            'spam.eggs': 'france'
+        }
+
+        self.assertEqual(util.collapse_keys(input_dict), collapsed)
+
+    def test_conflicting_existing_key(self):
+        """Test that conflicts with an existing key with a collapsed name are detected"""
+        with self.assertRaises(ValueError):
+            _ = util.collapse_keys({'foo': {'bar': 'baz'}, 'foo.bar': 'baz'})
+
+    def test_conflicting_collapsed_key(self):
+        """Test that conflicts with a collapsed name with an existing key are detected"""
+        with self.assertRaises(ValueError):
+            _ = util.collapse_keys({'foo.bar': 'baz', 'foo': {'bar': 'baz'}})
+
+
 class TestGetNewOrderedDict(unittest.TestCase):
     """Test the get_new_ordered_dict function."""
 


### PR DESCRIPTION


Test Description:


## Summary and Scope

This change adds a new `list-vars` subcommand to `sat bootprep`. This new subcommand dynamically lists the variables available for use in a bootprep input file given the software recipe, vars file, and command line arguments in use at runtime. Variables are listed by what set them and by their fully-qualified dot-separated name, as they would appear in a bootprep input file, along with their literal values.

## Issues and Related PRs

* Resolves [CRAYSAT-1532](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1532)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `mug`
  * Local development environment

### Test description:

Run unit tests, run various `list-vars` invocations on internal system to test behavior with vars files and command line variables.

## Risks and Mitigations

Low risk, no changes to core bootprep functionality. If issues exist with `list-vars`, it can be rolled back.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

