### PR TITLE
CRAYSAT-1414: Fix `sat init` bug preventing config creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   errors to provided better error messages and clearer semantics in `sat swap
   blade` and `sat bootprep`.
 
+### Fixed
+- Fixed a bug which prevented `sat init` from creating a configuration file in
+  the current directory when not prefixed with `./`.
+
 ## [3.19.3] - 2022-09-29
 
 ### Changed

--- a/sat/config.py
+++ b/sat/config.py
@@ -433,7 +433,7 @@ def generate_default_config(path, username=None, force=False):
             f'Configuration file "{path}" already exists. Not generating configuration file.'
         )
     config_file_dir = os.path.dirname(path)
-    if not os.path.isdir(config_file_dir):
+    if config_file_dir and not os.path.isdir(config_file_dir):
         try:
             os.makedirs(config_file_dir, mode=0o700, exist_ok=True)
         except OSError as e:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -220,6 +220,15 @@ class TestGenerateDefaultConfig(unittest.TestCase):
         self.mock_fchmod.assert_called_once_with(self.mock_output_stream.fileno.return_value, 0o600)
         self.mock_makedirs.assert_called_once_with('/etc/opt/cray', mode=0o700, exist_ok=True)
 
+    def test_generate_in_current_directory(self):
+        """Test generate_default_config() will not create a directory when not needed"""
+        self.mock_isdir.return_value = False
+        generate_default_config('local.toml')
+        self.mock_open.assert_called_once_with('local.toml', 'w')
+        self.mock_output_stream.write.assert_called_once_with(self.expected_config)
+        self.mock_makedirs.assert_not_called()
+        self.mock_fchmod.assert_called_once_with(self.mock_output_stream.fileno.return_value, 0o600)
+
     def test_generate_with_username(self):
         """Test generating config with a username will write a config file with a username"""
         self.expected_config = self.expected_config.replace('# username = ""', 'username = "sat_user"')


### PR DESCRIPTION
## Summary and Scope

This change fixes a bug which caused an error when the config file path was not prefixed with the current directory '.' as the dirname component of the path.

## Issues and Related PRs

* Resolves [CRAYSAT-1414](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1414)

## Testing

### Tested on:

  * Local development environment

### Test description:

`sat init -o foo.toml`

## Risks and Mitigations

None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

