### PR TITLE
CRAYSAT-1593: Update csm-api-client version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed a bug which prevented `sat init` from creating a configuration file in
   the current directory when not prefixed with `./`.
+- Updated `csm-api-client` dependency to version 1.1.0 to fix minor type
+  checking bug with `APIGatewayClient.set_timeout()`.
 
 ## [3.19.3] - 2022-09-29
 

--- a/requirements-dev.lock.txt
+++ b/requirements-dev.lock.txt
@@ -14,7 +14,7 @@ coverage==6.3.2
 cray-product-catalog==1.6.0
 croniter==0.3.37
 cryptography==36.0.1
-csm-api-client==1.0.0
+csm-api-client==1.1.0
 dataclasses-json==0.5.6
 docutils==0.17.1
 google-auth==2.6.0

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -11,7 +11,7 @@ click==8.0.4
 cray-product-catalog==1.6.0
 croniter==0.3.37
 cryptography==36.0.1
-csm-api-client==1.0.0
+csm-api-client==1.1.0
 dataclasses-json==0.5.6
 google-auth==2.6.0
 htmlmin==0.1.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ argcomplete
 boto3
 botocore
 cray-product-catalog >= 1.6.0
-csm-api-client >= 1.0, <2.0
+csm-api-client >= 1.1.0, <2.0
 croniter >= 0.3, < 1.0
 inflect >= 0.2.5, < 3.0
 Jinja2 >= 3.0, < 4.0


### PR DESCRIPTION
## Summary and Scope

This change updates the csm-api-client dependency version to fix a minor type-checking issue where the `APIGatewayClient.set_timeout()` parameter was `int` instead of `Optional[int]`.

## Issues and Related PRs

* Resolves [CRAYSAT-1593](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1593)

## Testing

### Tested on:

  * Local development environment

### Test description:
Run unit tests, check type checker output.

## Risks and Mitigations
None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

