### PR TITLE
CRAYSAT-1532: Respect formatting options in `sat bootprep list-vars`

### DIFF
--- a/sat/cli/bootprep/main.py
+++ b/sat/cli/bootprep/main.py
@@ -60,6 +60,7 @@ from sat.cli.bootprep.validate import (
     SCHEMA_FILE_RELATIVE_PATH,
 )
 from sat.cli.bootprep.vars import VariableContext, VariableContextError
+from sat.config import get_config_value
 from sat.report import Report
 from sat.session import SATSession
 
@@ -283,7 +284,15 @@ def do_bootprep_list_available_vars(args):
         args.vars_file,
         args.vars
     )
-    report = Report(['Variable name', 'Value', 'Source'])
+    report = Report(
+        ['Variable name', 'Value', 'Source'], 'Bootprep Variables',
+        args.sort_by, args.reverse,
+        get_config_value('format.no_headings'),
+        get_config_value('format.no_borders'),
+        filter_strs=args.filter_strs,
+        display_headings=args.fields,
+        print_format=args.format
+    )
     report.add_rows(var_context.enumerate_vars_and_sources())
     print(report)
 


### PR DESCRIPTION
## Summary and Scope

Fix a small issue in https://github.com/Cray-HPE/sat/pull/67 which caused formatting options to not be respected.

## Issues and Related PRs

* Resolves [CRAYSAT-1532](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1532)

## Testing

### Tested on:

  * `mug`

### Test description:

Run on mug with `--filter`, `--format`, `--fields`, `--no-headings`, `--no-borders`, etc.

## Risks and Mitigations
None


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

