### PR TITLE
CRAYSAT-1591: Add `sat bootprep list-vars` info to bootprep man page

### DIFF
--- a/docs/man/sat-bootprep.8.rst
+++ b/docs/man/sat-bootprep.8.rst
@@ -27,7 +27,7 @@ ARGUMENTS
 
 **ACTION**
         Specify the action for sat bootprep to execute. This should be ``run``,
-        ``generate-docs``, ``generate-example``, or ``view-schema``.
+        ``generate-docs``, ``generate-example``, ``view-schema``, or ``list-vars``.
 
         **run**
                 Process an input file, creating CFS configurations, building and
@@ -56,7 +56,12 @@ ARGUMENTS
         **view-schema**
                 Print the raw JSON Schema definition which is used to validate
                 the schema of input files given to the ``run`` action.
-    
+
+        **list-vars**
+                Print the variables that ``sat bootprep`` will resolve when
+                processing an input file. Variables are sourced from the command
+                line, any vars files, and the HPC CSM Software Recipe in use, in
+                that order.
 
 RUN ARGUMENTS
 -------------
@@ -118,20 +123,20 @@ These options only apply to the ``run`` action.
         The version of the BOS API to use when creating BOS session templates.
 
 **--recipe-version RECIPE_VERSION**
-        The HPC software recipe version, e.g. 22.03. This is used to obtain the
+        The HPC CSM Software Recipe version, e.g. 22.03. This is used to obtain the
         product versions which can be substituted for variables specified in
         fields in the input file. If not specified or if "latest" is specified,
-        use the latest available HPC software recipe.
+        use the latest available HPC CSM Software Recipe.
 
 **--vars-file VARS_FILE**
         A file containing variables that can be used in fields in the input
         file. Values from this file take precedence over values in the HPC
-        software recipe defaults.
+        CSM Software Recipe defaults.
 
 **--vars VARS**
         Variables that can be used in fields in the input file. Values specified
         here take precedence over values specified in any --vars-file or in the
-        HPC software recipe defaults.
+        HPC CSM Software Recipe defaults.
 
         Specify this option multiple times to specify values for multiple
         variables. Use dots to refer to keys in dictionaries. For example, to
@@ -173,6 +178,33 @@ These options only apply to the ``run`` action.
         specified, the default is to use the public key located at
         ~/.ssh/id_rsa.pub.
 
+LIST-VARS OPTIONS
+-----------------
+
+**--recipe-version RECIPE_VERSION**
+        The HPC CSM Software Recipe version, e.g. 22.03. This is used to obtain the
+        product versions which can be substituted for variables specified in
+        fields in the input file. If not specified or if "latest" is specified,
+        use the latest available HPC CSM Software Recipe.
+
+**--vars-file VARS_FILE**
+        A file containing variables that can be used in fields in the input
+        file. Values from this file take precedence over values in the HPC CSM
+        Software Recipe defaults.
+
+**--vars VARS**
+        Variables that can be used in fields in the input file. Values specified
+        here take precedence over values specified in any --vars-file or in the
+        HPC CSM Software Recipe defaults.
+
+        Specify this option multiple times to specify values for multiple
+        variables. Use dots to refer to keys in dictionaries. For example, to
+        override the value of the "version" key within the value of the "cos"
+        key, specify ``--vars cos.version=VALUE``.
+
+.. include:: _sat-format-opts.rst
+.. include:: _sat-filter-opts.rst
+
 EXAMPLES
 ========
 
@@ -184,7 +216,7 @@ session templates as described in the input file, ``bootprep_input.yaml``:
         # sat bootprep run bootprep_input.yaml
 
 Create CFS configurations, IMS images, and BOS session templates as described in
-the input file, using variables from HPC software recipe version 22.06 and
+the input file, using variables from HPC CSM Software Recipe version 22.06 and
 overrides from a file:
 
 ::
@@ -192,7 +224,7 @@ overrides from a file:
         # sat bootprep run --recipe-version 22.06 --vars-file overrides.yaml bootprep_input.yaml
 
 Create CFS configurations, IMS images, and BOS session templates as described in
-the input file, using variables from a HPC software recipe version 22.06 and
+the input file, using variables from a HPC CSM Software Recipe version 22.06 and
 overriding the variables ``cos.version`` and ``cpe.version``:
 
 ::
@@ -216,6 +248,30 @@ Generate an example bootprep input file:
 ::
 
         # sat bootprep generate-example
+
+View available variables and their values from the latest HPC CSM Software
+Recipe version:
+
+::
+
+        # sat bootprep list-vars --recipe-version latest
+
+View variables and their values as they will be resolved in an input file during
+processing when HPC CSM Software Recipe version 22.06 and the vars file
+``overrides.yaml`` are in use:
+
+::
+
+        # sat bootprep list-vars --recipe-version 22.06 --vars-file overrides.yaml
+
+View variables and their values as they will be resolved in an input file during
+processing when HPC CSM Software Recipe version 22.06 is in use and the variable
+``cos.version`` is overridden on the command line:
+
+::
+
+        # sat bootprep list-vars --recipe-version 22.06 --vars cos.version=2.1.65
+
 
 SEE ALSO
 ========


### PR DESCRIPTION
## Summary and Scope
This change adds information about the `sat bootprep list-vars` subcommand to the `sat-bootprep(8)` man page.

## Issues and Related PRs

* Resolves [CRAYSAT-1591](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1591)
* Change will also be needed in `docs-csm` and `docs-sat`.

## Testing

### Tested on:

  * Local development environment

### Test description:

Build man pages. Inspect manually with `man ./sat-bootprep.8`.

## Risks and Mitigations

None


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

