### PR TITLE
CRAYSAT-1620: Use authentication when accessing csm-python-modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,8 @@ RUN apk update && \
 
 COPY requirements.lock.txt requirements.txt
 ARG PIP_EXTRA_INDEX_URL="https://artifactory.algol60.net/artifactory/csm-python-modules/simple"
-RUN pip3 install --no-cache-dir -U pip && \
+RUN --mount=type=secret,id=netrc,target=/root/.netrc \
+    pip3 install --no-cache-dir -U pip && \
     pip3 install -r requirements.txt
 
 COPY CHANGELOG.md README.md setup.cfg setup.py ./
@@ -74,7 +75,8 @@ RUN pip3 install --no-cache-dir pip && \
 FROM base as ci_base
 COPY --from=build $VIRTUAL_ENV $VIRTUAL_ENV
 COPY requirements-dev.lock.txt requirements-dev.lock.txt
-RUN pip3 install -r requirements-dev.lock.txt
+RUN --mount=type=secret,id=netrc,target=/root/.netrc \
+    pip3 install -r requirements-dev.lock.txt
 
 # The testing stage runs tests in the container in the CI pipeline. This allows
 # us to use the same Python version in CI as we use in our production Docker

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -41,6 +41,7 @@ pipeline {
         IS_STABLE = getBuildIsStable(releaseBranchIsStable: true)
         VERSION = getDockerBuildVersion(versionScript: 'build_scripts/version.sh', isStable: env.IS_STABLE)
         DOCKER_ARGS = getDockerBuildArgs(name: 'sat', description: env.DESCRIPTION, version: env.VERSION)
+        DOCKER_BUILDKIT = '1'
     }
 
     stages {

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,9 @@ DOCKER_BUILD = docker build . --pull $(DOCKER_ARGS)
 DEFAULT_TAG = '$(NAME):$(VERSION)'
 TEST_TAG = '$(NAME)-testing:$(VERSION)'
 CODESTYLE_TAG = '$(NAME)-codestyle:$(VERSION)'
+ifneq ($(wildcard ${HOME}/.netrc),)
+	DOCKER_ARGS ?= --secret id=netrc,src=${HOME}/.netrc
+endif
 
 all : unittest codestyle image
 


### PR DESCRIPTION
This commit adds authenticated access when accessing the csm-python-modules repository on artifactory.algol60.net. To do this, a `.netrc` file containing read-only credentials is mounted into the container at build time. This follows an example given by the CASM devops team (See: CASMINST-5443).

Test Description: Built image locally and in Jenkins