### PR TITLE
CRAYSAT-1319: Add report output for `sat bootprep` results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a `sat bootprep list-vars` subcommand which lists the variables
   available in bootprep input files at runtime.
 - Added a `sat bootsys reboot` subcommand which uses BOS to reboot nodes.
+- Added a report to the output of `sat bootprep` which describes the
+  configurations, images, and session templates which were created during the
+  bootprep run.
 
 ### Changed
 - Refactored to use common `APIGatewayClient`, `CFSClient`, `HSMClient`, and

--- a/sat/cli/bootprep/input/configuration.py
+++ b/sat/cli/bootprep/input/configuration.py
@@ -313,6 +313,8 @@ class InputConfiguration(BaseInputItem):
     """A CFS Configuration from a bootprep input file."""
     description = 'CFS configuration'
 
+    report_attrs = ['name']
+
     def __init__(self, data, instance, index, jinja_env, cfs_client,
                  product_catalog, **kwargs):
         """Create a new InputConfiguration.

--- a/sat/cli/bootprep/input/image.py
+++ b/sat/cli/bootprep/input/image.py
@@ -37,6 +37,7 @@ from sat.apiclient import APIError
 from sat.cached_property import cached_property
 from sat.cli.bootprep.errors import ImageCreateError
 from sat.cli.bootprep.input.base import jinja_rendered, provides_context
+from sat.constants import MISSING_VALUE
 from sat.waiting import (
     DependencyGroupMember,
     WaitingFailure
@@ -72,7 +73,9 @@ class BaseInputImage(DependencyGroupMember, ABC):
             and renaming have been completed, as applicable
     """
 
+    description = 'IMS image'
     template_render_err = ImageCreateError
+    report_attrs = ['name', 'preconfigured_image_id', 'final_image_id', 'configuration', 'configuration_group_names']
 
     def __init__(self, image_data, index, instance, jinja_env, product_catalog, ims_client, cfs_client):
         """Create a new InputImage
@@ -321,6 +324,9 @@ class BaseInputImage(DependencyGroupMember, ABC):
             return None
         return self.finished_job_details.get('resultant_image_id')
 
+    # Alias for more descriptive reporting
+    preconfigured_image_id = ims_resultant_image_id
+
     @property
     def image_id_to_configure(self):
         """str: the IMS id of the image to be configured"""
@@ -528,6 +534,19 @@ class BaseInputImage(DependencyGroupMember, ABC):
         return self.image_create_success and self.image_configure_success
 
     begin = begin_image_create
+
+    def report_row(self):
+        """Create a report row about the image.
+
+        Each row contains the attributes listed in `report_attrs` in order.
+
+        Returns:
+            a list containing the attributes from report_attrs
+        """
+        # TODO: This implementation is here to be compatible with BaseInputItems
+        #  due to structural typing. Once BaseInputImage is a subtype of BaseInputItem,
+        #  this method will no longer be necessary.
+        return [getattr(self, attr, MISSING_VALUE) for attr in self.report_attrs]
 
 
 class IMSInputImage(BaseInputImage):

--- a/sat/cli/bootprep/input/session_template.py
+++ b/sat/cli/bootprep/input/session_template.py
@@ -54,6 +54,7 @@ class InputSessionTemplate(BaseInputItem):
             requests to the CFS API
     """
     description = 'BOS session template'
+    report_attrs = ['name', 'configuration']
 
     def __init__(self, data, instance, index, jinja_env, bos_client, cfs_client, ims_client, **kwargs):
         """Create a new InputSessionTemplate.

--- a/sat/cli/bootprep/parser.py
+++ b/sat/cli/bootprep/parser.py
@@ -216,7 +216,7 @@ def _add_bootprep_run_subparser(subparsers):
         None
     """
     run_subparser = subparsers.add_parser(
-        'run', help='Run sat bootprep.',
+        'run', help='Run sat bootprep.', parents=[create_format_options()],
         description='Create images, configurations and session templates.'
     )
     run_subparser.add_argument(

--- a/sat/report.py
+++ b/sat/report.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/tests/cli/bootprep/input/test_base.py
+++ b/tests/cli/bootprep/input/test_base.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/tests/cli/bootprep/input/test_base.py
+++ b/tests/cli/bootprep/input/test_base.py
@@ -1,0 +1,86 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""
+Tests for functionality in the BaseInputItem classes
+"""
+
+import unittest
+
+from sat.cli.bootprep.input.base import BaseInputItem
+from sat.constants import MISSING_VALUE
+
+
+def create_input_item_cls(cls_report_attrs):
+
+    class SomeTestItem(BaseInputItem):
+        """A mock concrete BaseInputItem class"""
+        description = 'some input item'
+        report_attrs = cls_report_attrs
+
+        def __init__(self, data):
+            # Since the test input item class doesn't need access
+            # to the input instance, we can just ignore it here.
+            # As a consequence, other methods on this class won't
+            # work as expected.
+            self.data = data
+
+        def __getattr__(self, item):
+            if item in cls_report_attrs:
+                try:
+                    return self.data[item]
+                except KeyError as err:
+                    raise AttributeError(str(err))
+
+        def get_create_item_data(self):
+            return
+
+        def create(self, payload):
+            return
+    return SomeTestItem
+
+
+class TestBaseInputItem(unittest.TestCase):
+    def test_report_rows_have_correct_attrs(self):
+        """Test that report rows are generated for input items"""
+        row_headings = ['name', 'type']
+        row_vals = ['foo', 'configuration']
+        item_cls = create_input_item_cls(row_headings)
+        self.assertEqual(item_cls(dict(zip(row_headings, row_vals))).report_row(),
+                         row_vals)
+
+    def test_report_rows_excluded(self):
+        """Test that report rows are not included if not present in report_attrs"""
+        item_cls = create_input_item_cls(['name'])
+        self.assertEqual(item_cls({'name': 'foo', 'something_else': 'another_thing'}).report_row(), ['foo'])
+
+    def test_missing_report_attrs_are_missing(self):
+        """Test that missing report attrs are reported as MISSING"""
+        row_headings = ['name', 'type', 'one_more_thing']
+        row_vals = ['foo', 'configuration', 'columbo']
+        item_cls = create_input_item_cls(row_headings)  # Cut off last report attr
+        data = dict(zip(row_headings[:-1], row_vals[:-1]))
+
+        report_row = item_cls(data).report_row()
+        self.assertEqual(len(report_row), len(row_headings))
+        self.assertEqual(report_row[-1], MISSING_VALUE)

--- a/tests/cli/bootprep/test_main.py
+++ b/tests/cli/bootprep/test_main.py
@@ -112,6 +112,7 @@ class TestDoBootprepRun(unittest.TestCase):
         self.overwrite_configs = False
         self.skip_existing_configs = False
         self.dry_run = False
+        self.mock_report = patch('sat.cli.bootprep.main.Report').start()
         self.args = Namespace(action='run', input_file=self.input_file,
                               overwrite_templates=self.overwrite_templates,
                               skip_existing_templates=self.skip_existing_templates,
@@ -119,7 +120,8 @@ class TestDoBootprepRun(unittest.TestCase):
                               skip_existing_configs=self.skip_existing_configs,
                               dry_run=self.dry_run, view_input_schema=False, generate_schema_docs=False,
                               bos_version='v1', recipe_version=None, vars_file=None, vars=None,
-                              output_dir='.', save_files=True, resolve_branches=True)
+                              output_dir='.', save_files=True, resolve_branches=True,
+                              format='pretty')
         self.schema_file = 'schema.yaml'
         self.mock_validator_cls = MagicMock()
         self.mock_load_and_validate_instance = patch('sat.cli.bootprep.main.load_and_validate_instance').start()

--- a/tests/cli/bootprep/test_main.py
+++ b/tests/cli/bootprep/test_main.py
@@ -121,8 +121,9 @@ class TestDoBootprepRun(unittest.TestCase):
                               dry_run=self.dry_run, view_input_schema=False, generate_schema_docs=False,
                               bos_version='v1', recipe_version=None, vars_file=None, vars=None,
                               output_dir='.', save_files=True, resolve_branches=True,
-                              format='pretty')
+                              format='json')
         self.schema_file = 'schema.yaml'
+        self.mock_multireport_cls = patch('sat.cli.bootprep.main.MultiReport').start()
         self.mock_validator_cls = MagicMock()
         self.mock_load_and_validate_instance = patch('sat.cli.bootprep.main.load_and_validate_instance').start()
         self.validated_data = self.mock_load_and_validate_instance.return_value
@@ -177,6 +178,7 @@ class TestDoBootprepRun(unittest.TestCase):
             'Input file successfully validated against schema'
         ]
         self.assertEqual(expected_msgs, info_msgs)
+        self.mock_multireport_cls.assert_called_once()
 
     def test_do_bootprep_run_validation_error(self):
         """Test do_bootprep_run when an error occurs loading the input file"""
@@ -191,6 +193,7 @@ class TestDoBootprepRun(unittest.TestCase):
         self.assertEqual(validation_err_msg, logs_cm.records[0].msg)
         self.mock_load_and_validate_instance.assert_called_once_with(
             self.input_file, self.mock_validator_cls)
+        self.mock_multireport_cls.assert_not_called()
 
     def test_do_bootprep_run_validation_error_collection(self):
         """Test do_bootprep_run when an error occurs validating the input against the schema"""
@@ -205,6 +208,7 @@ class TestDoBootprepRun(unittest.TestCase):
                          logs_cm.records[0].msg)
         self.mock_load_and_validate_instance.assert_called_once_with(
             self.input_file, self.mock_validator_cls)
+        self.mock_multireport_cls.assert_not_called()
 
     def test_do_bootprep_run_configuration_create_error(self):
         """Test do_bootprep_run when an error occurs creating a configuration"""
@@ -233,6 +237,7 @@ class TestDoBootprepRun(unittest.TestCase):
         self.mock_session_templates.handle_existing_items.assert_not_called()
         self.mock_session_templates.validate.assert_not_called()
         self.mock_session_templates.create_items.assert_not_called()
+        self.mock_multireport_cls.assert_not_called()
 
     def test_do_bootprep_run_image_create_error(self):
         """Test do_bootprep_run when an error occurs creating an image"""
@@ -261,6 +266,8 @@ class TestDoBootprepRun(unittest.TestCase):
         self.mock_session_templates.handle_existing_items.assert_not_called()
         self.mock_session_templates.validate.assert_not_called()
         self.mock_session_templates.create_items.assert_not_called()
+
+        self.mock_multireport_cls.assert_not_called()
 
 
 class TestDoBootprep(unittest.TestCase):

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),


### PR DESCRIPTION
## Summary and Scope

This change adds a reporting capability to `sat bootprep` which reports
which items (configs, images, and session templates) were created during
a sat bootprep run. This information is printed as a report and its
format can be set to 'pretty', 'yaml' or 'json' based on the context of
the run. (For instance, JSON output is useful for IUF runs, where a
pretty report is more useful for end-user runs.) Unit tests for the new 
functionality in the BaseInputItem class were also added.

This change also refactors the Report class to make it easier to dump JSON
and YAML reports. This change also adds a new MultiReport class which
acts as a container for multiple Reports such that they have consistent
formatting and display options. This can also be reused for other
applications where multiple reports are printed such as in `sat
showrev`.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CRAYSAT-1319](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1319)

## Testing

### Tested on:

  * `frigg`

### Test description:

Run unit tests. Manually test `sat bootprep` against a minimal input file. Test that ouptut is as expected.

## Risks and Mitigations


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

