### PR TITLE
CRAYSAT-1606: Implement `--limit` option to `sat bootprep run`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   bootprep run.
 - The value of the `playbook` property of CFS configuration layers in `sat
   bootprep` input files can now be rendered with Jinja2 templates.
+- Added a new `--limit` option to `sat bootprep run` that allows limiting which
+  types of items from the input file are created.
 
 ### Changed
 - Refactored to use common `APIGatewayClient`, `CFSClient`, `HSMClient`, and

--- a/docs/man/sat-bootprep.8.rst
+++ b/docs/man/sat-bootprep.8.rst
@@ -97,6 +97,15 @@ RUN OPTIONS
 
 These options only apply to the ``run`` action.
 
+**--limit {configurations,images,session_templates}**
+        Create only the given types of items from the input file. Specify this
+        option multiple times to specify multiple types of items to create. By
+        default, all items from the input file are created.
+
+        Validation of the other types of items in the input file is still
+        performed in order to ensure references from one type of item in the
+        input file to another type of item in the input file can be resolved.
+
 **-d, --dry-run**
         Do a dry-run. Do not actually create CFS configurations, build
         images, customize images, or create BOS session templates. This still

--- a/sat/cli/bootprep/constants.py
+++ b/sat/cli/bootprep/constants.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -44,3 +44,9 @@ LATEST_VERSION_VALUE = 'latest'
 # This is the version that would have been used in the initial version of the
 # input file schema if one had been specified.
 DEFAULT_INPUT_SCHEMA_VERSION = '1.0.0'
+
+# Top-level keys in the bootprep input file
+CONFIGURATIONS_KEY = 'configurations'
+IMAGES_KEY = 'images'
+SESSION_TEMPLATES_KEY = 'session_templates'
+ALL_KEYS = [CONFIGURATIONS_KEY, IMAGES_KEY, SESSION_TEMPLATES_KEY]

--- a/sat/cli/bootprep/image.py
+++ b/sat/cli/bootprep/image.py
@@ -28,11 +28,11 @@ from collections import defaultdict, Counter
 import logging
 import math
 
-from sat.apiclient import APIError, CFSClient, IMSClient
+from sat.apiclient import APIError
+from sat.cli.bootprep.constants import CONFIGURATIONS_KEY, IMAGES_KEY
 from sat.cli.bootprep.errors import ImageCreateError
 from sat.cli.bootprep.input.image import DependentInputImage, IMSInputImage
 from sat.cli.bootprep.public_key import get_ims_public_key_id
-from sat.session import SATSession
 from sat.util import pester_choices
 from sat.waiting import (
     DependencyCycleError,
@@ -324,7 +324,7 @@ def validate_image_ims_bases(input_images):
                                f'input images')
 
 
-def validate_image_configurations(input_images, cfs_client, input_config_names, dry_run):
+def validate_image_configurations(input_images, cfs_client, input_config_names, input_configs_exist):
     """Validate that the images refer to valid existing configurations.
 
     Args:
@@ -334,18 +334,22 @@ def validate_image_configurations(input_images, cfs_client, input_config_names, 
             determine whether the configuration for the image exists.
         input_config_names (list of str): the list of configuration names that
             are defined in the input file
-        dry_run (bool): True if this is a dry run, False otherwise.
+        input_configs_exist (bool): True if we should assume configs from input file
+            exist. False if we must check for their existence in CFS regardless.
+
+    Raises:
+        ImageCreateError: if there is a failure to validate image configurations
     """
     failed_images = []
     for image in input_images:
         if not image.configuration:
             continue
 
-        # In the dry-run case, configurations will not actually be created, so
-        # we have to check against what would have been created.
-        if dry_run and image.configuration in input_config_names:
+        if input_configs_exist and image.configuration in input_config_names:
+            # It's okay for configs to only exist in input_config_names
             continue
 
+        # Otherwise, all configurations must exist in CFS.
         resp = cfs_client.get('configurations', image.configuration, raise_not_ok=False)
         if not resp.ok:
             if resp.status_code == 404:
@@ -410,7 +414,52 @@ class ImageCreationGroupWaiter(DependencyGroupWaiter):
             raise WaitingFailure(f'status check failed: {err}')
 
 
-def create_images(instance, args):
+def validate_images(instance, args, cfs_client):
+    """Validate the IMS images defined in the given instance.
+
+    Args:
+        instance (sat.cli.bootprep.input.instance.InputInstance): the full bootprep
+            input instance loaded from the input file and already validated
+            against the schema.
+        args: The argparse.Namespace object containing the parsed arguments
+            passed to the bootprep subcommand.
+        cfs_client (csm_api_client.service.cfs.CFSClient): the CFS API client to make
+            requests to the CFS API
+
+    Returns: None
+
+    Raises:
+        ImageCreateError: if there is a failure to validate images
+    """
+    input_images = instance.input_images
+    if not input_images:
+        LOGGER.debug('Given input file did not define any images, so skipping validation.')
+        return
+
+    validate_unique_image_ref_names(input_images)
+    # Validate dependencies on the full set of input images
+    find_image_dependencies(input_images)
+
+    # Raises ImageCreateError if validation of IMS bases fails
+    # Do this early to provide information required to render names.
+    validate_image_ims_bases(input_images)
+
+    # This validation is not necessary when images are skipped
+    if IMAGES_KEY in args.limit:
+        # When the configurations are not excluded via --limit, and it's a dry run,
+        # assume the configurations from the input file do exist.
+        input_configs_exist = CONFIGURATIONS_KEY in args.limit and args.dry_run
+        # Raises ImageCreateError if validation of CFS configurations fails
+        validate_image_configurations(input_images, cfs_client,
+                                      instance.input_configuration_names, input_configs_exist)
+
+    # This is where name properties are first accessed and thus rendered
+    validate_unique_image_names(input_images)
+    # Images must use image_ref to reference other images from input file
+    validate_no_overwritten_ims_bases(input_images)
+
+
+def create_images(instance, args, ims_client):
     """Create and customize IMS images defined in the given instance
 
     Args:
@@ -419,6 +468,8 @@ def create_images(instance, args):
             against the schema.
         args: The argparse.Namespace object containing the parsed arguments
             passed to the bootprep subcommand.
+        ims_client (sat.apiclient.IMSClient): the IMS API client to make
+            requests to the IMS API
 
     Returns:
         Iterable[IMSInputImage]: images which were created or overwritten
@@ -431,39 +482,10 @@ def create_images(instance, args):
         LOGGER.info('Given input did not define any IMS images')
         return []
 
-    sat_session = SATSession()
-    ims_client = IMSClient(sat_session)
-    cfs_client = CFSClient(sat_session)
-
-    ims_public_key_id = get_ims_public_key_id(ims_client, public_key_id=args.public_key_id,
-                                              public_key_file_path=args.public_key_file_path,
-                                              dry_run=args.dry_run)
-    LOGGER.info(f'Using IMS public key with id {ims_public_key_id}')
-
-    # TODO (CRAYSAT-1275): Fix up this error-prone way of requiring that we set public_key_id later
-    for image in input_images:
-        image.public_key_id = ims_public_key_id
-
-    validate_unique_image_ref_names(input_images)
-    # Validate dependencies on the full set of input images
-    find_image_dependencies(input_images)
-
-    # Raises ImageCreateError if validation of IMS bases fails
-    # Do this early to provide information required to render names.
-    validate_image_ims_bases(input_images)
-
-    # Raises ImageCreateError if validation of CFS configurations fails
-    validate_image_configurations(input_images, cfs_client,
-                                  instance.input_configuration_names, args.dry_run)
-
-    # This is where name properties are first accessed and thus rendered
-    validate_unique_image_names(input_images)
-
     images_to_create = handle_existing_images(ims_client, input_images, args.overwrite_images,
                                               args.skip_existing_images, args.dry_run)
 
-    validate_no_overwritten_ims_bases(images_to_create)
-
+    # TODO (CRAYSAT-1277): This part appears redundant with logic in DependencyGroupWaiter.__init__
     images_without_dependencies = [image for image in images_to_create
                                    if not image.has_dependencies()]
 
@@ -479,6 +501,19 @@ def create_images(instance, args):
         LOGGER.info("Dry run, not creating images.")
         return []
 
+    ims_public_key_id = get_ims_public_key_id(ims_client, public_key_id=args.public_key_id,
+                                              public_key_file_path=args.public_key_file_path,
+                                              dry_run=args.dry_run)
+    LOGGER.info(f'Using IMS public key with id {ims_public_key_id}')
+
+    # TODO (CRAYSAT-1275): Fix up this error-prone way of requiring that we set public_key_id later
+    for image in input_images:
+        image.public_key_id = ims_public_key_id
+
+    # TODO (CRAYSAT-1277): Create subclass of BaseInputItemCollection
+    # I think we could take this part that creates the ImageCreationGroupWaiter and waits on
+    # it and generalize it into a BaseInputItemCollection subclass that creates its items in
+    # parallel using a subclass of the GroupWaiter class.
     # Default to no timeout since it's unknown how long image creation could take
     waiter = ImageCreationGroupWaiter(images_to_create, math.inf)
     LOGGER.info('Creating images')

--- a/sat/cli/bootprep/input/instance.py
+++ b/sat/cli/bootprep/input/instance.py
@@ -25,6 +25,7 @@
 Defines a class for the input instance loaded from the input file.
 """
 from sat.cached_property import cached_property
+from sat.cli.bootprep.constants import CONFIGURATIONS_KEY, IMAGES_KEY, SESSION_TEMPLATES_KEY
 from sat.cli.bootprep.input.configuration import InputConfigurationCollection
 from sat.cli.bootprep.input.image import BaseInputImage
 from sat.cli.bootprep.input.session_template import InputSessionTemplateCollection
@@ -36,7 +37,7 @@ class InputInstance:
 
     def __init__(self, instance_dict, request_dumper,
                  cfs_client, ims_client, bos_client,
-                 jinja_env, product_catalog, dry_run):
+                 jinja_env, product_catalog, dry_run, limit):
         """Create a new InputInstance from the validated contents of an input file.
 
         Args:
@@ -55,6 +56,8 @@ class InputInstance:
             product_catalog (cray_product_catalog.query.ProductCatalog):
                 the product catalog object
             dry_run (bool): True if this is a dry run, False otherwise.
+            limit (list of str): the list of types of items from the input file
+                to be created.
         """
         self.instance_dict = instance_dict
         self.request_dumper = request_dumper
@@ -64,12 +67,13 @@ class InputInstance:
         self.jinja_env = jinja_env
         self.product_catalog = product_catalog
         self.dry_run = dry_run
+        self.limit = limit
 
     @cached_property
     def input_configurations(self):
         """InputConfigurationCollection: the configurations in the input instance"""
         return InputConfigurationCollection(
-            self.instance_dict.get('configurations', []),
+            self.instance_dict.get(CONFIGURATIONS_KEY, []),
             self,
             jinja_env=self.jinja_env,
             request_dumper=self.request_dumper,
@@ -82,13 +86,13 @@ class InputInstance:
         """list of InputImages: the images in the input instance"""
         return [BaseInputImage.get_image(image, index, self, self.jinja_env, self.product_catalog,
                                          self.ims_client, self.cfs_client)
-                for index, image in enumerate(self.instance_dict.get('images', []))]
+                for index, image in enumerate(self.instance_dict.get(IMAGES_KEY, []))]
 
     @cached_property
     def input_session_templates(self):
         """InputSessionTemplateCollection: the session templates in the input instance"""
         return InputSessionTemplateCollection(
-            self.instance_dict.get('session_templates', []),
+            self.instance_dict.get(SESSION_TEMPLATES_KEY, []),
             self,
             jinja_env=self.jinja_env,
             request_dumper=self.request_dumper,

--- a/sat/cli/bootprep/main.py
+++ b/sat/cli/bootprep/main.py
@@ -339,19 +339,18 @@ def print_report(args, instance, created_images):
         return
 
     created_types_items = [
-        ('configurations', instance.input_configurations),
-        ('images', created_images),
-        ('session_templates', instance.input_session_templates),
+        (CONFIGURATIONS_KEY, instance.input_configurations),
+        (IMAGES_KEY, created_images),
+        (SESSION_TEMPLATES_KEY, instance.input_session_templates),
     ]
     bootprep_report = MultiReport(print_format=args.format)
     for item_type_name, items in created_types_items:
-        if item_type_name == 'images':
+        if item_type_name == IMAGES_KEY:
             # Special case for images since they are not BaseInputItems
             created = items
             item_class = IMSInputImage
         else:
             created = items.created
-            skipped = items.skipped_items
             item_class = items.item_class
 
         if not created:

--- a/sat/cli/bootprep/parser.py
+++ b/sat/cli/bootprep/parser.py
@@ -27,10 +27,11 @@ The parser for the bootprep subcommand.
 from inflect import engine
 
 from sat.cli.bootprep.constants import (
+    ALL_KEYS,
     DEFAULT_PUBLIC_KEY_FILE,
     DOCS_ARCHIVE_FILE_NAME,
     EXAMPLE_FILE_NAME,
-    LATEST_VERSION_VALUE
+    LATEST_VERSION_VALUE,
 )
 from sat.parsergroups import (
     StoreNestedVariable,
@@ -223,6 +224,15 @@ def _add_bootprep_run_subparser(subparsers):
         'input_file',
         help='Path to the input YAML file that defines the configurations, '
              'images, and session templates to create.')
+    run_subparser.add_argument(
+        '--limit',
+        help='Create only the given types of items from the input file. Specify '
+             'this option multiple times to specify multiple types of items to '
+             'create. By default, all items from the input file are created.',
+        action='append',
+        choices=ALL_KEYS,
+        # Do not use default=ALL_KEYS here or it is impossible to omit keys.
+    )
     run_subparser.add_argument(
         '--dry-run', '-d', action='store_true',
         help='Do a dry-run. Do not actually create CFS configurations, '

--- a/tests/cli/bootprep/test_main.py
+++ b/tests/cli/bootprep/test_main.py
@@ -29,6 +29,7 @@ import logging
 import unittest
 from unittest.mock import MagicMock, patch
 
+from sat.cli.bootprep.constants import ALL_KEYS
 from sat.cli.bootprep.errors import (
     BootPrepInternalError,
     BootPrepDocsError,
@@ -121,7 +122,7 @@ class TestDoBootprepRun(unittest.TestCase):
                               dry_run=self.dry_run, view_input_schema=False, generate_schema_docs=False,
                               bos_version='v1', recipe_version=None, vars_file=None, vars=None,
                               output_dir='.', save_files=True, resolve_branches=True,
-                              format='json')
+                              format='json', limit=None)
         self.schema_file = 'schema.yaml'
         self.mock_multireport_cls = patch('sat.cli.bootprep.main.MultiReport').start()
         self.mock_validator_cls = MagicMock()
@@ -135,6 +136,7 @@ class TestDoBootprepRun(unittest.TestCase):
         self.mock_bos_client = patch('sat.cli.bootprep.main.BOSClientCommon.get_bos_client').start().return_value
         self.mock_configurations = self.mock_input_instance.input_configurations
         self.mock_create_images = patch('sat.cli.bootprep.main.create_images').start()
+        self.mock_validate_images = patch('sat.cli.bootprep.main.validate_images').start()
         self.mock_session_templates = self.mock_input_instance.input_session_templates
         self.mock_product_catalog_cls = patch('sat.cli.bootprep.main.ProductCatalog').start()
         self.mock_product_catalog = self.mock_product_catalog_cls.return_value
@@ -159,14 +161,15 @@ class TestDoBootprepRun(unittest.TestCase):
         self.mock_input_instance_cls.assert_called_once_with(
             self.validated_data, self.mock_request_dumper, self.mock_cfs_client, self.mock_ims_client,
             self.mock_bos_client, self.mock_sandboxed_environment, self.mock_product_catalog,
-            self.dry_run
+            self.dry_run, ALL_KEYS
         )
         self.mock_configurations.handle_existing_items.assert_called_once_with(
             self.overwrite_configs, self.skip_existing_configs
         )
         self.mock_configurations.validate.assert_called_once_with()
         self.mock_configurations.create_items.assert_called_once_with()
-        self.mock_create_images.assert_called_once_with(self.mock_input_instance, self.args)
+        self.mock_validate_images.assert_called_once_with(self.mock_input_instance, self.args, self.mock_cfs_client)
+        self.mock_create_images.assert_called_once_with(self.mock_input_instance, self.args, self.mock_ims_client)
         self.mock_session_templates.handle_existing_items.assert_called_once_with(
             self.overwrite_templates, self.skip_existing_templates
         )
@@ -226,13 +229,14 @@ class TestDoBootprepRun(unittest.TestCase):
         self.mock_input_instance_cls.assert_called_once_with(
             self.validated_data, self.mock_request_dumper, self.mock_cfs_client, self.mock_ims_client,
             self.mock_bos_client, self.mock_sandboxed_environment, self.mock_product_catalog,
-            self.dry_run
+            self.dry_run, ALL_KEYS
         )
         self.mock_configurations.handle_existing_items.assert_called_once_with(
             self.overwrite_configs, self.skip_existing_configs
         )
         self.mock_configurations.validate.assert_called_once_with()
         self.mock_configurations.create_items.assert_called_once_with()
+        self.mock_validate_images.assert_not_called()
         self.mock_create_images.assert_not_called()
         self.mock_session_templates.handle_existing_items.assert_not_called()
         self.mock_session_templates.validate.assert_not_called()
@@ -255,14 +259,15 @@ class TestDoBootprepRun(unittest.TestCase):
         self.mock_input_instance_cls.assert_called_once_with(
             self.validated_data, self.mock_request_dumper, self.mock_cfs_client, self.mock_ims_client,
             self.mock_bos_client, self.mock_sandboxed_environment, self.mock_product_catalog,
-            self.dry_run
+            self.dry_run, ALL_KEYS
         )
         self.mock_configurations.handle_existing_items.assert_called_once_with(
             self.overwrite_configs, self.skip_existing_configs
         )
         self.mock_configurations.validate.assert_called_once_with()
         self.mock_configurations.create_items.assert_called_once_with()
-        self.mock_create_images.assert_called_once_with(self.mock_input_instance, self.args)
+        self.mock_validate_images.assert_called_once_with(self.mock_input_instance, self.args, self.mock_cfs_client)
+        self.mock_create_images.assert_called_once_with(self.mock_input_instance, self.args, self.mock_ims_client)
         self.mock_session_templates.handle_existing_items.assert_not_called()
         self.mock_session_templates.validate.assert_not_called()
         self.mock_session_templates.create_items.assert_not_called()


### PR DESCRIPTION
## Summary and Scope

Implement a `--limit` option that allows the user to limit which types
of items from the input file are created. For example, the admin can
choose to create only the CFS configurations or only the IMS images and
BOS session templates.

This functionality is needed by the IUF because the stages are split
into `update_cfs_config` which will create the CFS configurations and
`prepare_images` which will create and configure IMS images and create
BOS session templates.

Also created constants for the keys in the input file and used it when
reading those properties from the input file and as the possible values
for the `--limit` option.

## Issues and Related PRs

* Resolves [CRAYSAT-1606](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1606)

## Testing

Not tested yet.

### Tested on:

  * frigg

### Test description:

## Risks and Mitigations

New feature being added to some complicated code. Risks will be mitigated by manual testing of various edge cases on frigg.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

