### PR TITLE
CRAYSAT-1650: Use fixed version of csm-api-client package

### DIFF
--- a/requirements-dev.lock.txt
+++ b/requirements-dev.lock.txt
@@ -14,7 +14,7 @@ coverage==6.3.2
 cray-product-catalog==1.6.0
 croniter==0.3.37
 cryptography==36.0.1
-csm-api-client==1.1.0
+csm-api-client==1.1.1
 dataclasses-json==0.5.6
 docutils==0.17.1
 google-auth==2.6.0

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -11,7 +11,7 @@ click==8.0.4
 cray-product-catalog==1.6.0
 croniter==0.3.37
 cryptography==36.0.1
-csm-api-client==1.1.0
+csm-api-client==1.1.1
 dataclasses-json==0.5.6
 google-auth==2.6.0
 htmlmin==0.1.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ argcomplete
 boto3
 botocore
 cray-product-catalog >= 1.6.0
-csm-api-client >= 1.1.0, <2.0
+csm-api-client >= 1.1.1, <2.0
 croniter >= 0.3, < 1.0
 inflect >= 0.2.5, < 3.0
 Jinja2 >= 3.0, < 4.0


### PR DESCRIPTION
## Summary and Scope

Use a newer version of csm-api-client which fixes an issue with the `json` kwarg being dropped from calls to `APIGatewayClient.patch`.

This fixes an issue seen when `sat bootprep` renames images after customizing them.

## Issues and Related PRs

* Resolves [CRAYSAT-1650](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1650)

## Testing

### Tested on:

  * frigg

### Test description:

Will test an image customization on frigg with the cray-sat container image built from this branch.

## Risks and Mitigations

Low risk.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x]  Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable