### PR TITLE
CRAYSAT-1648: Render playbook in CFS config layers in bootprep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a report to the output of `sat bootprep` which describes the
   configurations, images, and session templates which were created during the
   bootprep run.
+- The value of the `playbook` property of CFS configuration layers in `sat
+  bootprep` input files can now be rendered with Jinja2 templates.
 
 ### Changed
 - Refactored to use common `APIGatewayClient`, `CFSClient`, `HSMClient`, and

--- a/sat/cli/bootprep/input/configuration.py
+++ b/sat/cli/bootprep/input/configuration.py
@@ -81,6 +81,7 @@ class InputConfigurationLayer(ABC):
         self.jinja_env = jinja_env
 
     @property
+    @jinja_rendered
     def playbook(self):
         """str or None: the playbook specified in the layer"""
         return self.layer_data.get('playbook')


### PR DESCRIPTION
## Summary and Scope

Add the ability to render the playbook property of each CFS configuration layer in the bootprep input file using Jinja2. This will allow for variable substitution in playbooks, which is useful to support the two alternative playbooks for the SHS CFS configuration layer.

Add unit tests to check whether this renders correctly.

## Issues and Related PRs

* Resolves [CRAYSAT-1648](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1648)
* Merge before doc changes here: https://github.com/Cray-HPE/docs-sat/pull/64

## Testing

### Tested on:

  * Local development environment
  * frigg

### Test description:

Unit tests and pycodestyle pass. Will test on frigg.

## Risks and Mitigations

Low risk.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable