### PR TITLE
CRAYSAT-1647: Pass FAS snapshot payload with json parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Removed the "active" field from the output of `sat showrev`.
 
+### Fixed
+- Fixed a bug in which `sat firmware` would fail with 400 Bad Request errors.
+
 ## [3.20.0] - 2022-01-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed a bug in which `sat firmware` would fail with 400 Bad Request errors.
+- Fixed a bug in which API requests were not being logged.
 
 ## [3.20.0] - 2022-01-13
 

--- a/sat/apiclient/fas.py
+++ b/sat/apiclient/fas.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -332,7 +332,7 @@ class FASClient(APIGatewayClient):
             payload['stateComponentFilter'] = {'xnames': xnames}
 
         try:
-            self.post('snapshots', payload=payload)
+            self.post('snapshots', json=payload)
         except APIError as err:
             raise APIError('Error when posting new snapshot: {}'.format(err))
 

--- a/sat/logging.py
+++ b/sat/logging.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2020,2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -29,6 +29,7 @@ import os
 
 from sat.config import get_config_value
 
+CSM_CLIENT_MODULE_NAME = 'csm_api_client'
 CONSOLE_LOG_FORMAT = '%(levelname)s: %(message)s'
 FILE_LOG_FORMAT = '%(asctime)s - %(levelname)s - %(name)s - %(message)s'
 LOGGER = logging.getLogger(__name__)
@@ -87,6 +88,10 @@ def configure_logging():
     """
     sat_logger_name = __name__.split('.', 1)[0]
     sat_logger = logging.getLogger(sat_logger_name)
+    # Handle log messages from the CSM API client with the same
+    # handlers and log levels as log messages from SAT.
+    csm_client_logger = logging.getLogger(CSM_CLIENT_MODULE_NAME)
+    csm_client_logger.setLevel(logging.DEBUG)
 
     log_file_name = get_config_value('logging.file_name')
     log_file_level = get_config_value('logging.file_level')
@@ -100,6 +105,7 @@ def configure_logging():
     sat_logger.handlers = []
 
     _add_console_handler(sat_logger, log_stderr_level)
+    _add_console_handler(csm_client_logger, log_stderr_level)
 
     # Create log directories if needed
     log_dir = os.path.dirname(log_file_name)
@@ -118,3 +124,4 @@ def configure_logging():
         file_formatter = logging.Formatter(FILE_LOG_FORMAT)
         file_handler.setFormatter(file_formatter)
         sat_logger.addHandler(file_handler)
+        csm_client_logger.addHandler(file_handler)

--- a/tests/apiclient/test_fas.py
+++ b/tests/apiclient/test_fas.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -444,7 +444,7 @@ class TestFASClient(ExtendedTestCase):
         exp_payload = {'name': exp_name, 'expirationTime': later.isoformat() + 'Z'}
 
         self.assertEqual(expected, actual)
-        self.mock_post.assert_called_once_with('snapshots', payload=exp_payload)
+        self.mock_post.assert_called_once_with('snapshots', json=exp_payload)
         self.mock_get.assert_has_calls([call('snapshots', exp_name)] * 2)
 
     def test_get_device_firmwares_with_xname(self):
@@ -490,7 +490,7 @@ class TestFASClient(ExtendedTestCase):
         }
 
         self.assertEqual(expected, actual)
-        self.mock_post.assert_called_once_with('snapshots', payload=exp_payload)
+        self.mock_post.assert_called_once_with('snapshots', json=exp_payload)
         self.mock_get.assert_has_calls([call('snapshots', exp_name)] * 2)
 
     def test_get_device_firmwares_post_api_error(self):


### PR DESCRIPTION
As a result of refactoring SAT to use the common CSM python client, `sat firmware` changed the data it was passing to the FASClient post() method, from passing a serialized JSON object to passing a Python dictionary of the data.

To account for this change, the post() method should take the payload data with the json parameter rather than the payload parameter.

This commit also updates the relevant unit tests, and adds a change log entry.

Test Description: I ran `sat firmware -x <xname>` locally with my development machine targeting shandy. After reproducing the error, I verified that the commit fixes the issue.

## Summary and Scope

See commit message

## Issues and Related PRs

* Resolves CRAYSAT-1647

## Testing

See commit message

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

