### PR TITLE
CRAYSAT-1657: Add staged boot to bootsys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a bug in which `sat firmware` would fail with 400 Bad Request errors.
 - Fixed a bug in which API requests were not being logged.
 
+### Added
+- Added the `--staged-session` option to `sat bootsys` which can be used to
+  create staged BOS sessions.
+- Added descriptions for `--bos-limit` and `--recursive` to the `sat bootsys`
+  man page.
+
 ## [3.20.0] - 2022-01-13
 
 ### Added

--- a/docs/man/sat-bootsys.8.rst
+++ b/docs/man/sat-bootsys.8.rst
@@ -7,7 +7,7 @@ Perform boot, shutdown, or reboot actions on the system
 -------------------------------------------------------
 
 :Author: Hewlett Packard Enterprise Development LP.
-:Copyright: Copyright 2020-2022 Hewlett Packard Enterprise Development LP.
+:Copyright: Copyright 2020-2023 Hewlett Packard Enterprise Development LP.
 :Manual section: 8
 
 SYNOPSIS
@@ -173,6 +173,29 @@ These options apply to both the ``shutdown`` and ``boot`` actions.
         config file. This option is deprecated in favor of ``--bos-templates``
         (above). If ``--bos-templates`` or its configuration-file equivalent is
         specified, then this option will be ignored.
+
+**--bos-limit** *XNAMES*
+        A comma-separated list of xnames, node groups, and roles which should be
+        included in the shutdown or boot action. If not specified, all
+        components in the specified BOS session template's boot sets will be
+        used.
+
+**--recursive**
+        If specified, then the xnames listed in the limit string for
+        ``--bos-limit`` will be expanded recursively into their constituent node
+        xnames. For instance, if a slot xname is given as part of
+        ``--bos-limit``, then that xname will be expanded into the node xnames
+        for all nodes in that slot.
+
+**--staged-session**
+        If specified, then create a "staged" BOS session. A staged session
+        differs from a normal BOS session in that a staged session does not
+        automatically change the state of any components targeted by the session
+        templates. Instead, a staged session will update components'
+        "staged_state", which can later be applied through the command
+        'cray bos v2 applystaged create', or through an API call to BOS. When
+        using this option, the command will not wait for completion of BOS
+        sessions. This option cannot be used with BOS v1.
 
 **--excluded-ncns** *EXCLUDED_NCNS*
         A comma-separated list of NCN hostnames that should be excluded from the

--- a/sat/apiclient/bos.py
+++ b/sat/apiclient/bos.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -247,7 +247,7 @@ class BOSV2Client(BOSClientCommon):
     session_template_path = 'sessiontemplates'
     session_path = 'sessions'
 
-    def create_session(self, session_template, operation, limit=None):
+    def create_session(self, session_template, operation, limit=None, stage=False):
         """Create a BOS session from a session template with an operation.
 
         Args:
@@ -257,6 +257,8 @@ class BOSV2Client(BOSClientCommon):
                 one of boot, configure, reboot, shutdown.
             limit (str): a limit string to pass through to BOS as the `limit`
                 parameter in the POST payload when creating the BOS session
+            stage (bool): if True, create a 'staged' BOS session, which updates
+                components' staged state rather than their desired state.
 
         Returns:
             The response from the POST to 'sessions'.
@@ -266,7 +268,8 @@ class BOSV2Client(BOSClientCommon):
         """
         request_body = {
             'template_name': session_template,
-            'operation': operation
+            'operation': operation,
+            'stage': stage
         }
 
         if limit:

--- a/sat/cli/bootsys/parser.py
+++ b/sat/cli/bootsys/parser.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -137,6 +137,18 @@ def _add_bos_template_options(subparser, action):
              'will be expanded recursively into their constituent node xnames. For '
              'instance, if a slot xname is given as part of --bos-limit, then that '
              'xname will be expanded into the node xnames for all nodes in that slot.'
+    )
+
+    subparser.add_argument(
+        '--staged-session', action='store_true',
+        help=f'If specified, then create a "staged" BOS session. A staged session differs '
+             f'from a normal BOS session in that a staged session does not automatically '
+             f'change the state of any components targeted by the session templates. '
+             f'Instead, a staged session will update components\' "staged_state", which '
+             f'can later be applied through the command \'cray bos v2 applystaged create\', '
+             f'or through an API call to BOS. When using this option, the command will '
+             f'not wait for completion of BOS sessions. This option cannot be used with '
+             f'BOS v1.'
     )
 
 

--- a/tests/cli/bootsys/test_bos.py
+++ b/tests/cli/bootsys/test_bos.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -259,7 +259,7 @@ class TestBOSV2SessionWaiter(unittest.TestCase):
         self.mock_session_thread = MagicMock(session_id=self.session_id)
         self.mock_session_thread.stopped.return_value = False
 
-        self.waiter = BOSV2SessionWaiter(self.mock_session_thread, math.inf)
+        self.waiter = BOSV2SessionWaiter(self.mock_session_thread, timeout=math.inf)
 
     def tearDown(self):
         patch.stopall()
@@ -552,7 +552,7 @@ class TestDoBosShutdowns(ExtendedTestCase):
         self.mock_get_config = patch('sat.cli.bootsys.bos.get_config_value', return_value=60).start()
 
         self.limit = None
-        self.args = Namespace(bos_limit=self.limit, recursive=False)
+        self.args = Namespace(bos_limit=self.limit, recursive=False, staged_session=False)
         self.args.disruptive = False
 
     def tearDown(self):
@@ -562,7 +562,8 @@ class TestDoBosShutdowns(ExtendedTestCase):
         """Test running BOS shutdown with prompting to continue."""
         do_bos_shutdowns(self.args)
         self.mock_prompt.assert_called_once()
-        self.mock_do_bos_ops.assert_called_once_with('shutdown', 60, limit=self.limit, recursive=False)
+        self.mock_do_bos_ops.assert_called_once_with(
+            'shutdown', 60, limit=self.limit, recursive=False, stage=False)
 
     def test_do_bos_shutdowns_without_prompt(self):
         """Test running BOS shutdown without prompting."""
@@ -570,7 +571,8 @@ class TestDoBosShutdowns(ExtendedTestCase):
         do_bos_shutdowns(self.args)
 
         self.mock_prompt.assert_not_called()
-        self.mock_do_bos_ops.assert_called_once_with('shutdown', 60, limit=self.limit, recursive=False)
+        self.mock_do_bos_ops.assert_called_once_with(
+            'shutdown', 60, limit=self.limit, recursive=False, stage=False)
 
 
 class TestDoBosReboots(ExtendedTestCase):
@@ -584,7 +586,7 @@ class TestDoBosReboots(ExtendedTestCase):
             'sat.cli.bootsys.bos.get_config_value', side_effect=[60, 90]).start()
 
         self.limit = None
-        self.args = Namespace(bos_limit=self.limit, recursive=False)
+        self.args = Namespace(bos_limit=self.limit, recursive=False, staged_session=False)
         self.args.disruptive = False
 
     def tearDown(self):
@@ -595,7 +597,7 @@ class TestDoBosReboots(ExtendedTestCase):
         do_bos_reboots(self.args)
         self.mock_prompt.assert_called_once()
         self.mock_do_bos_ops.assert_called_once_with(
-            'reboot', 150, limit=self.limit, recursive=False)
+            'reboot', 150, limit=self.limit, recursive=False, stage=False)
 
     def test_do_bos_reboots_without_prompt(self):
         """Test running BOS shutdown without prompting."""
@@ -604,7 +606,7 @@ class TestDoBosReboots(ExtendedTestCase):
 
         self.mock_prompt.assert_not_called()
         self.mock_do_bos_ops.assert_called_once_with(
-            'reboot', 150, limit=self.limit, recursive=False)
+            'reboot', 150, limit=self.limit, recursive=False, stage=False)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary and Scope

* This PR introduces an option called `--staged-session` which makes use of the `stage` parameter to BOS V2 session creation, in order to stage sessions. Staged sessions update a component's "staged_state" rather than their "desired_state", and as a result staged sessions do not reach "complete" state until after a separate API endpoint is used.

## Issues and Related PRs

* Resolves CRAYSAT-1657

## Testing

Tested on frigg. See test description in commit message.

## Risks and Mitigations

This change should be a relatively low-risk change as I was able to test the `bos-operations` stage thoroughly.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

