### PR TITLE
CRAYSAT-1653: Replace hyphens with underscores in top-level keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   man page.
 - Added ability to filter the images provided by a product using a prefix when
   specifying the base of an image in a `sat bootprep` input file.
+- Added support for hyphenated product names in `sat bootprep` variables.
 
 ## [3.20.0] - 2022-01-13
 

--- a/sat/cli/bootprep/vars.py
+++ b/sat/cli/bootprep/vars.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -83,6 +83,13 @@ class VariableContext:
         deep_update_dict(self.vars, self.software_recipe_vars)
         deep_update_dict(self.vars, self.file_vars)
         deep_update_dict(self.vars, self.cli_vars)
+        # CRAYSAT-1653: Replace hyphens in top-level keys with underscores.
+        # This allows us to support hyphens in IUF product names, but note that
+        # this substitution is only done for top-level keys.
+        self.vars = {
+            key.replace('-', '_'): value
+            for key, value in self.vars.items()
+        }
 
     @cached_property
     def file_vars(self):
@@ -161,6 +168,13 @@ class VariableContext:
         for source, attr in var_attr_by_source.items():
             vars_from_source = getattr(self, attr)
             if vars_from_source:
+                # CRAYSAT-1653: Replace hyphens in top-level keys with underscores.
+                # This allows us to support hyphens in IUF product names, but note that
+                # this substitution is only done for top-level keys.
+                vars_from_source = {
+                    key.replace('-', '_'): value
+                    for key, value in vars_from_source.items()
+                }
                 variables = collapse_keys(vars_from_source)
                 for fq_var_name, var_value in variables.items():
                     if fq_var_name not in yielded_keys:


### PR DESCRIPTION
This commit changes how bootprep variables are processed. This applies to variables defined in the software recipe, variables provided on the command line, and variables in local files (i.e. passed in with --vars-file).

This changes top-level keys of dictionaries to replace hyphens with underscores. This gives us the ability to support product names that contain hyphens. To refer to a product name that contains hyphens, the bootprep input file will need to refer to that product with its hyphens replaced with underscores.

Test Description: I ran sat bootprep using an input file that creates a CFS configuration. Then, using `--save-files` I inspected the resulting configuration that was created locally.

With a vars file containing a product with a hyphenated name:

    sat bootprep run --dry-run --vars-file vars.yaml \
        configs-hyphen-vars.yaml --save-files

With equivalent variables specified on the command line:

    sat bootprep run --dry-run \
        --vars "slingshot-host-software.version=2.0.0-75" \
        configs-hyphen-vars.yaml --save-files

## Summary and Scope

See commit message 

## Issues and Related PRs

Resolves CRAYSAT-1653

## Testing

See commit message

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable