### PR TITLE
CRAYSAT-1664: Enable bos timeouts on reboot action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.21.1] - 2023-01-30
+
+### Fixed
+- Fixed missing `--bos-boot-timeout` and `--bos-shutdown-timeout` options
+  for `sat bootsys reboot`. 
+
 ## [3.21.0] - 2023-01-27
 
 ### Changed

--- a/docs/man/sat-bootsys.8.rst
+++ b/docs/man/sat-bootsys.8.rst
@@ -298,6 +298,29 @@ These options set the timeouts of various parts of the stages of the
         Defaults to 900. Overrides the option
         bootsys.bos_boot_timeout in the config file.
 
+REBOOT TIMEOUT OPTIONS
+----------------------
+
+These options set the timeouts of various parts of the stages of the
+``reboot`` action.
+
+**--bos-shutdown-timeout** *BOS_SHUTDOWN_TIMEOUT*
+        Timeout, in seconds, to wait until compute and
+        application nodes have completed their BOS shutdown.
+        Defaults to 600. Overrides the option
+        bootsys.bos_shutdown_timeout in the config file.
+
+        For a reboot, the --bos-shutdown-timeout and
+        --bos-boot-timeout options are added.
+
+**--bos-boot-timeout** *BOS_BOOT_TIMEOUT*
+        Timeout, in seconds, to wait until compute and
+        application nodes have completed their BOS boot.
+        Defaults to 900. Overrides the option
+        bootsys.bos_boot_timeout in the config file.
+
+        For a reboot, the --bos-shutdown-timeout and
+        --bos-boot-timeout options are added.
 
 EXAMPLES
 ========

--- a/sat/cli/bootsys/parser.py
+++ b/sat/cli/bootsys/parser.py
@@ -51,9 +51,9 @@ TIMEOUT_SPECS = [
                 'BGP routes report that they are established on management switches.'),
     TimeoutSpec('hsn', ['boot'], 300,
                 'the high-speed network (HSN) has returned to its pre-shutdown state.'),
-    TimeoutSpec('bos-shutdown', ['shutdown'], 600,
+    TimeoutSpec('bos-shutdown', ['shutdown', 'reboot'], 600,
                 'compute and application nodes have completed their BOS shutdown.'),
-    TimeoutSpec('bos-boot', ['boot'], 900,
+    TimeoutSpec('bos-boot', ['boot', 'reboot'], 900,
                 'compute and application nodes have completed their BOS boot.'),
     TimeoutSpec('ncn-shutdown', ['shutdown'], 300,
                 'management NCNs have completed a graceful shutdown and have reached '


### PR DESCRIPTION
Fix the missing `--bos-shutdown-timeout` and `--bos-boot-timeout` options on the `sat bootsys reboot` action.

Test Description:
Built and examined man page. Examined output of `sat bootsys reboot --help`.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

