### PR TITLE
CRAYSAT-1604: Add configurable retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.35.4] - 2025-04-17
+
+### Added
+- Added configurable `api_gateway.retries` and `api_gateway.backoff` config
+  file parameters, and added command-line equivalents `--api-retries` and
+  `--api-backoff`.
+
 ## [3.35.3] - 2025-04-11
 
 ### Added

--- a/docs/man/sat.8.rst
+++ b/docs/man/sat.8.rst
@@ -7,7 +7,7 @@ The System Admin Toolkit
 ------------------------
 
 :Author: Hewlett Packard Enterprise Development LP.
-:Copyright: Copyright 2019-2023 Hewlett Packard Enterprise Development LP.
+:Copyright: Copyright 2019-2023, 2025 Hewlett Packard Enterprise Development LP.
 :Manual section: 8
 
 SYNOPSIS
@@ -64,6 +64,17 @@ These global options must be specified before the subcommand.
         The amount of time, in seconds, allowed to wait for calls to any HTTP API
         to return before considering them failed. Overrides value set in config file.
 
+**--api-retries** *retries*
+        The number of times to retry calls to any HTTP API after encountering
+        network errors or internal server errors before considering them failed.
+        Overrides value set in config file.
+
+**--api-backoff** *backoff-factor*
+        The backoff factor controlling the time interval between retries. The time
+        between retries is calculated as BACKOFF_FACTOR * (2^(numRetries-1)),
+        per the documentation on urllib3.util.Retry. Overrides value set in config
+        file.
+
 **-h, --help**
         Print the help message for sat.
 
@@ -114,8 +125,18 @@ API_GATEWAY
 **api_timeout**
         This is the timeout for all calls to HTTP REST APIs, in seconds. This
         is the amount of time allowed to wait for calls to any HTTP API to
-        return before considering them failed. Overrides value set in config
-        file.
+        return before considering them failed. Defaults to 60 seconds.
+
+**retries**
+        The number of times to retry calls to any HTTP API after encountering
+        network errors or internal server errors before considering them failed.
+        Defaults to 5 retries.
+
+**backoff**
+        The backoff factor controlling the time interval between retries. The time
+        between retries is calculated as BACKOFF_FACTOR * (2^(numRetries-1)),
+        per the documentation on urllib3.util.Retry. Defaults to a backoff factor
+        of 0.2.
 
 
 BOOTSYS

--- a/sat/config.py
+++ b/sat/config.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -120,6 +120,8 @@ SAT_CONFIG_SPEC = {
         'token_file': OptionSpec(str, '', None, 'token_file'),
         'api_timeout': OptionSpec(int, 60, None, 'api_timeout'),
         'tenant_name': OptionSpec(str, '', None, 'tenant_name'),
+        'retries': OptionSpec(int, 5, None, 'api_retries'),
+        'backoff': OptionSpec(float, 0.2, None, 'api_backoff'),
     },
     'bos': {
         'api_version': OptionSpec(str, 'v2', validate_bos_api_version, 'bos_version')
@@ -406,7 +408,7 @@ def process_toml_output(toml_str):
     """
     copyright_stmt = """\
         Default configuration file for SAT.
-        (C) Copyright 2019-2022 Hewlett Packard Enterprise Development LP.
+        (C) Copyright 2019-2023 Hewlett Packard Enterprise Development LP.
 
         Permission is hereby granted, free of charge, to any person obtaining a
         copy of this software and associated documentation files (the "Software"),

--- a/sat/logging.py
+++ b/sat/logging.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2020, 2023-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2020, 2023-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -33,6 +33,7 @@ from sat.config import get_config_value
 
 CSM_CLIENT_MODULE_NAME = 'csm_api_client'
 WARNINGS_MODULE_NAME = 'py.warnings'
+URLLIB_MODULE_NAME = 'urllib3'
 CONSOLE_LOG_FORMAT = '%(levelname)s: %(message)s'
 FILE_LOG_FORMAT = '%(asctime)s - %(levelname)s - %(name)s - %(message)s'
 LOGGER = logging.getLogger(__name__)
@@ -111,6 +112,11 @@ def configure_logging():
     warnings_logger = logging.getLogger(WARNINGS_MODULE_NAME)
     warnings_logger.setLevel(logging.WARNING)
 
+    # Handle log messages from the urllib3 module, so that HTTP retries
+    # are logged.
+    urllib3_logger = logging.getLogger(URLLIB_MODULE_NAME)
+    urllib3_logger.setLevel(logging.DEBUG)
+
     log_file_name = get_config_value('logging.file_name')
     log_file_level = get_config_value('logging.file_level')
     log_stderr_level = get_config_value('logging.stderr_level')
@@ -125,6 +131,7 @@ def configure_logging():
     _add_console_handler(sat_logger, log_stderr_level)
     _add_console_handler(csm_client_logger, log_stderr_level)
     _add_console_handler(warnings_logger, log_stderr_level)
+    _add_console_handler(urllib3_logger, log_stderr_level)
 
     # Create log directories if needed
     log_dir = os.path.dirname(log_file_name)
@@ -145,3 +152,4 @@ def configure_logging():
         sat_logger.addHandler(file_handler)
         csm_client_logger.addHandler(file_handler)
         warnings_logger.addHandler(file_handler)
+        urllib3_logger.addHandler(file_handler)

--- a/sat/parser.py
+++ b/sat/parser.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2023, 2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -173,6 +173,21 @@ def create_parent_parser():
         help='The name of the tenant against which to run administrative commands.',
         metavar='NAME',
     )
+
+    parser.add_argument(
+        '--api-retries',
+        help='The number of times to retry calls to any HTTP API after encountering '
+             'network errors or internal server errors before considering them failed.',
+        metavar='RETRIES',
+        type=int)
+
+    parser.add_argument(
+        '--api-backoff',
+        help='The backoff factor controlling the time interval between retries. The time '
+             'between retries is calculated as BACKOFF_FACTOR * (2^(numRetries-1)), '
+             'per the documentation on urllib3.util.Retry.',
+        metavar='BACKOFF_FACTOR',
+        type=float)
 
     subparsers = parser.add_subparsers(metavar='command', dest='command')
     sat.cli.build_out_subparsers(subparsers)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2022, 2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2022, 2024-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -182,7 +182,7 @@ class TestGenerateDefaultConfig(unittest.TestCase):
 
         self.expected_config = dedent("""\
         # Default configuration file for SAT.
-        # (C) Copyright 2019-2022 Hewlett Packard Enterprise Development LP.
+        # (C) Copyright 2019-2023 Hewlett Packard Enterprise Development LP.
 
         # Permission is hereby granted, free of charge, to any person obtaining a
         # copy of this software and associated documentation files (the "Software"),

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2020, 2023-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2020, 2023-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -103,13 +103,31 @@ class TestLogging(unittest.TestCase):
         Sets up by patching getLogger to return a logger of our own and by
         patching get_config_value to return values from a dict.
         """
-        # In the logging module, getLogger is called twice, once to get the main
-        # logger for SAT and once to get the logger for the csm_api_client library.
+        # In the logging module, getLogger is called 3 times, once to get the main
+        # logger for SAT, once to get the logger for the csm_api_client library,
+        # and once to get the logger for urllib3.
         self.logger = logging.getLogger(__name__)
-        self.sub_logger = logging.getLogger('submodule')
+        self.csm_api_logger = logging.getLogger('csm_api_client')
+        self.urllib3_logger = logging.getLogger('urllib3')
+
+        # Save the original getLogger function
+        original_get_logger = logging.getLogger
+        # Mock getLogger to return the appropriate logger based on the name
+
+        def get_logger_side_effect(name):
+            if name == 'sat':
+                return self.logger
+            elif name == 'csm_api_client':
+                return self.csm_api_logger
+            elif name == 'urllib3':
+                return self.urllib3_logger
+            else:
+                # Call the original getLogger function to avoid recursion
+                return original_get_logger(name)
+
         self.mock_get_logger = mock.patch(
             'sat.logging.logging.getLogger',
-            side_effect=(self.logger, self.sub_logger, self.sub_logger)
+            side_effect=get_logger_side_effect
         ).start()
 
         config_values = self.config_values = {
@@ -194,6 +212,8 @@ class TestLogging(unittest.TestCase):
         self.mock_get_logger.assert_any_call('csm_api_client')
         # And finally, the 'py.warnings' module
         self.mock_get_logger.assert_any_call('py.warnings')
+        # And finally the logger named 'urllib3'
+        self.mock_get_logger.assert_any_call('urllib3')
 
         log_dir = os.path.dirname(self.config_values['logging.file_name'])
         mock_makedirs.assert_called_once_with(log_dir, exist_ok=True)
@@ -223,8 +243,11 @@ class TestLogging(unittest.TestCase):
 
         # This should have gotten the logger named 'sat'
         self.mock_get_logger.assert_any_call('sat')
+        # And also the logger named 'csm_api_client'
         self.mock_get_logger.assert_any_call('csm_api_client')
         self.mock_get_logger.assert_any_call('py.warnings')
+        # And finally the logger named 'urllib3'
+        self.mock_get_logger.assert_any_call('urllib3')
 
         # Exactly one handler of type StreamHandler should have been added.
         self.assertEqual(len(self.logger.handlers), 1)


### PR DESCRIPTION
## Summary and Scope

This commit adds two new options, `--api-retries` and `--api-backoff` that control the number of retries and interval between retries. These options can be specified via the config file or on the command line.

To implement these options, the urllib3.util.Retry class is used, which is passed to the requests.Session using an HTTPAdapter class. Retries will only be done for status codes in the 500 range or for network errors, errors like "400 Bad Request" or "403 Forbidden" will not result in any retries.

To ensure that retries are logged, handle log messages from the `urllib3` module.

This commit also documents the new command-line and config file options in the main sat(8) man page.

## Testing

### Test Description:
* I ran `sat status` locally with an authenticated session to ensure normal usage was working.
* I temporarily moved my authentication token aside, resulting in 401 Unauthorized errors from the system when running `sat status`. I verified that it was not possible to add retries in this case.
* I modified my configuration file to specify an incorrect URL for the system's API gateway, resulting in network-level errors when running `sat status`. I verified that I was able to change both the number of retries and backoff factor both by using command-line options as well as configuration file options.
* I ran `sat bootprep` to create images, configurations and session templates on an internal system.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

