### PR TITLE
CRAYSAT-1678: Update csm-api-client library version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,11 +25,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.21.2] - 2023-02-13
+
+### Fixed
+- Updated `csm-api-client` library version to fix authentication with `sat auth`
+  for new tokens.
+
 ## [3.21.1] - 2023-01-30
 
 ### Fixed
 - Fixed missing `--bos-boot-timeout` and `--bos-shutdown-timeout` options
-  for `sat bootsys reboot`. 
+  for `sat bootsys reboot`.
 
 ## [3.21.0] - 2023-01-27
 

--- a/requirements-dev.lock.txt
+++ b/requirements-dev.lock.txt
@@ -14,7 +14,7 @@ coverage==6.3.2
 cray-product-catalog==1.6.0
 croniter==0.3.37
 cryptography==36.0.1
-csm-api-client==1.1.1
+csm-api-client==1.1.2
 dataclasses-json==0.5.6
 docutils==0.17.1
 google-auth==2.6.0

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -11,7 +11,7 @@ click==8.0.4
 cray-product-catalog==1.6.0
 croniter==0.3.37
 cryptography==36.0.1
-csm-api-client==1.1.1
+csm-api-client==1.1.2
 dataclasses-json==0.5.6
 google-auth==2.6.0
 htmlmin==0.1.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ argcomplete
 boto3
 botocore
 cray-product-catalog >= 1.6.0
-csm-api-client >= 1.1.1, <2.0
+csm-api-client >= 1.1.2, <2.0
 croniter >= 0.3, < 1.0
 inflect >= 0.2.5, < 3.0
 Jinja2 >= 3.0, < 4.0

--- a/sat/cli/auth/main.py
+++ b/sat/cli/auth/main.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -63,7 +63,7 @@ def do_auth(args):
     password = getpass.getpass('Password for {}: '.format(session.username))
 
     session.fetch_token(password)
-    if session.token:
+    if session.fetched_token:
         LOGGER.info('Succeeded!')
         session.save()
     else:


### PR DESCRIPTION
## Summary and Scope
Updating the csm-api-client library version fixes a bug which prevented new token files from being written, breaking authentication.

## Issues and Related PRs

* Resolves [CRAYSAT-1678](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1678)

## Testing

### Tested on:

  * `gamora`

### Test description:
Run `sat auth` against empty config directory and test that the token files are properly created.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

