### PR TITLE
CRAYSAT-1625: Fixes for bos-sessions stage of sat bootsys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Fixed a bug in the `bos-operations` stage of `sat bootsys` where a Bad Request
+  error could appear in the output when checking node states.
+- Fixed a bug where the `bos-operations` stage of `sat bootsys` would not correctly
+  wait for a shutdown or boot operation to complete with BOS v1 and certain versions
+  of the `kubectl` command.
+
 ## [3.21.2] - 2023-02-13
 
 ### Fixed


### PR DESCRIPTION
## Summary and Scope

* Ensure Role_Subrole form found in BOS boot sets is translated to the appropriate HSM parameters.
* Change waiter code to accept either form of 'timed out' indication in the k8s CLI. Add a comment justifying why we continue to scrape CLI output.
* Add unit tests in TestGetTemplatesNeedingOperation that mock out the behavior of HSM to test more thoroughly.
* Add unit tests for the BOSSessionThread.run() method that call the monitor_status_kubectl method.

## Testing

Test Description:
* Used `sat bootsys boot --stage bos-operations` with a UAN session template that used the 'Application_UAN' format.
* Tested new monitor_status_kubectl behavior by adding unit tests.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable