### PR TITLE
CRAYSAT-1310: Capture and filter InsecureRequestWarning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added ability to filter images provided by a product using a wildcard pattern
   to specify the base input image in a `sat bootprep` input file
+- Added a `cert_verify` parameter to the `s3` section of the configuration file.
 
 ### Changed
 - Changed logging in `sat bootsys` such that all sessions will have a logging
@@ -40,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Modified logging for SAT such that multi-line log messages will now be logged
   with consistent formatting for each line.
 - Updated unit test infrastructure to use `nose2`.
+- Reduced the number of log messages when insecure HTTPS requests are made.
 
 ### Fixed
 - Fixed a bug in the `bos-operations` stage of `sat bootsys` where a Bad Request

--- a/docs/man/sat.8.rst
+++ b/docs/man/sat.8.rst
@@ -7,7 +7,7 @@ The System Admin Toolkit
 ------------------------
 
 :Author: Hewlett Packard Enterprise Development LP.
-:Copyright: Copyright 2019-2021 Hewlett Packard Enterprise Development LP.
+:Copyright: Copyright 2019-2023 Hewlett Packard Enterprise Development LP.
 :Manual section: 8
 
 SYNOPSIS
@@ -257,6 +257,30 @@ LOGGING
         SAT also prints log messages to stderr, and this parameter sets the
         minimum log severity that will cause a log to be printed to stderr.
         Defaults to "INFO".
+
+S3
+--
+
+**endpoint**
+        The URL of the S3 endpoint. The default is "https://rgw-vip.nmn"
+
+**bucket**
+        The S3 bucket where SAT should store data. The default is "sat".
+
+**access_key**
+        The path to the S3 access key SAT should use to access S3. The default
+        is "~/.config/sat/s3_access_key".
+
+**secret_key**
+        The path to the S3 secret key SAT should use to access S3. The default
+        is "~/.config/sat/s3_secret_key".
+
+**cert_verify**
+        If "true", then SAT will validate the authenticity of the S3 host
+        via a signed certificate before communicating.
+
+        This parameter is set to "false" by default.
+
 
 SEE ALSO
 ========

--- a/sat/cli/auth/main.py
+++ b/sat/cli/auth/main.py
@@ -28,7 +28,6 @@ Entry point for the auth subcommand.
 import getpass
 import logging
 
-from sat.config import get_config_value
 from sat.session import SATSession
 from sat.util import pester
 
@@ -44,7 +43,7 @@ def do_auth(args):
     getpass.getuser() is called to get the system username of the user invoking sat.
 
     The token is saved to $HOME/.config/sat/tokens/hostname.username.json,
-    unless overriden by --token-file on the command line or in the config file.
+    unless overridden by --token-file on the command line or in the config file.
 
     Args:
         args: The argparse.Namespace object containing the parsed arguments

--- a/sat/cli/setrev/main.py
+++ b/sat/cli/setrev/main.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2021,2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -28,8 +28,6 @@ The main entry point for the setrev subcommand.
 import logging
 import os
 import sys
-from urllib3.exceptions import InsecureRequestWarning
-import warnings
 
 from boto3.exceptions import Boto3Error
 from botocore.exceptions import BotoCoreError, ClientError
@@ -61,10 +59,7 @@ def get_site_data(sitefile):
 
     try:
         LOGGER.debug('Downloading %s from S3 (bucket: %s)', sitefile, s3_bucket)
-        # TODO(SAT-926): Start verifying HTTPS requests
-        with warnings.catch_warnings():
-            warnings.filterwarnings('ignore', category=InsecureRequestWarning)
-            s3.Object(s3_bucket, sitefile).download_file(sitefile)
+        s3.Object(s3_bucket, sitefile).download_file(sitefile)
     except (BotoCoreError, ClientError, Boto3Error) as err:
         # It is not an error if this file doesn't already exist
         # TODO: it would be nice to differentiate between successfully connecting to S3
@@ -137,10 +132,7 @@ def write_site_data(sitefile, data):
         with open(sitefile, 'w') as of:
             of.write(yaml_dump(data))
         LOGGER.debug('Uploading %s to S3 (bucket: %s)', sitefile, s3_bucket)
-        # TODO(SAT-926): Start verifying HTTPS requests
-        with warnings.catch_warnings():
-            warnings.filterwarnings('ignore', category=InsecureRequestWarning)
-            s3.Object(s3_bucket, sitefile).upload_file(sitefile)
+        s3.Object(s3_bucket, sitefile).upload_file(sitefile)
         LOGGER.info(f'Successfully wrote site info file {sitefile} to S3.')
     except OSError as err:
         LOGGER.error('Unable to write %s. Error: %s', sitefile, err)

--- a/sat/cli/showrev/system.py
+++ b/sat/cli/showrev/system.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -29,7 +29,7 @@ import logging
 import warnings
 import shlex
 import subprocess
-from urllib3.exceptions import InsecureRequestWarning, MaxRetryError
+from urllib3.exceptions import MaxRetryError
 from collections import defaultdict
 
 from boto3.exceptions import Boto3Error
@@ -72,10 +72,7 @@ def get_site_data(sitefile):
 
     try:
         LOGGER.debug('Downloading %s from S3 (bucket: %s)', sitefile, s3_bucket)
-        # TODO(SAT-926): Start verifying HTTPS requests
-        with warnings.catch_warnings():
-            warnings.filterwarnings('ignore', category=InsecureRequestWarning)
-            s3.Object(s3_bucket, sitefile).download_file(sitefile)
+        s3.Object(s3_bucket, sitefile).download_file(sitefile)
     except (BotoCoreError, ClientError, Boto3Error) as err:
         LOGGER.error('Unable to download site info file %s from S3. Attempting to read from cached copy. '
                      'Error: %s', sitefile, err)

--- a/sat/config.py
+++ b/sat/config.py
@@ -127,6 +127,8 @@ SAT_CONFIG_SPEC = {
         'stderr_level': OptionSpec(str, 'INFO', validate_log_level, 'loglevel_stderr'),
     },
     's3': {
+        # TODO (CRAYSAT-926): When rgw cert can be verified, change the default to True.
+        'cert_verify': OptionSpec(bool, False, None, None),
         'endpoint': OptionSpec(str, 'https://rgw-vip.nmn', None, None),
         'bucket': OptionSpec(str, 'sat', None, None),
         'access_key_file': OptionSpec(str, '~/.config/sat/s3_access_key', None, None),

--- a/sat/logging.py
+++ b/sat/logging.py
@@ -32,6 +32,7 @@ from logging import Formatter, LogRecord
 from sat.config import get_config_value
 
 CSM_CLIENT_MODULE_NAME = 'csm_api_client'
+WARNINGS_MODULE_NAME = 'py.warnings'
 CONSOLE_LOG_FORMAT = '%(levelname)s: %(message)s'
 FILE_LOG_FORMAT = '%(asctime)s - %(levelname)s - %(name)s - %(message)s'
 LOGGER = logging.getLogger(__name__)
@@ -101,10 +102,14 @@ def configure_logging():
     """
     sat_logger_name = __name__.split('.', 1)[0]
     sat_logger = logging.getLogger(sat_logger_name)
+
     # Handle log messages from the CSM API client with the same
     # handlers and log levels as log messages from SAT.
     csm_client_logger = logging.getLogger(CSM_CLIENT_MODULE_NAME)
     csm_client_logger.setLevel(logging.DEBUG)
+    # Handle log messages from the warnings module too
+    warnings_logger = logging.getLogger(WARNINGS_MODULE_NAME)
+    warnings_logger.setLevel(logging.WARNING)
 
     log_file_name = get_config_value('logging.file_name')
     log_file_level = get_config_value('logging.file_level')
@@ -119,6 +124,7 @@ def configure_logging():
 
     _add_console_handler(sat_logger, log_stderr_level)
     _add_console_handler(csm_client_logger, log_stderr_level)
+    _add_console_handler(warnings_logger, log_stderr_level)
 
     # Create log directories if needed
     log_dir = os.path.dirname(log_file_name)
@@ -138,3 +144,4 @@ def configure_logging():
         file_handler.setFormatter(file_formatter)
         sat_logger.addHandler(file_handler)
         csm_client_logger.addHandler(file_handler)
+        warnings_logger.addHandler(file_handler)

--- a/sat/main.py
+++ b/sat/main.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -33,6 +33,7 @@ import sys
 import argcomplete
 
 from sat.config import ConfigFileExistsError, DEFAULT_CONFIG_PATH, generate_default_config, load_config
+from sat.warnings import configure_insecure_request_warnings
 from sat.logging import bootstrap_logging, configure_logging
 from sat.parser import create_parent_parser
 from sat.util import ensure_permissions, get_resource_section_path
@@ -96,6 +97,7 @@ def main():
                 pass
             load_config(args)
             configure_logging()
+            configure_insecure_request_warnings()
 
         # Dynamically importing here affords the following
         # advantages:

--- a/sat/util.py
+++ b/sat/util.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -657,7 +657,7 @@ def get_s3_resource():
                 aws_access_key_id=access_key,
                 aws_secret_access_key=secret_key,
                 region_name='',
-                verify=False
+                verify=get_config_value('s3.cert_verify')
             )
     except OSError as err:
         LOGGER.error(f'Unable to load configuration: {err}')

--- a/sat/warnings.py
+++ b/sat/warnings.py
@@ -1,0 +1,67 @@
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""
+Configure how warnings from the warnings module should be logged.
+"""
+
+import logging
+import re
+import warnings
+
+from urllib3.exceptions import InsecureRequestWarning
+
+from sat.config import get_config_value
+
+
+def configure_insecure_request_warnings():
+    """Configure the handling of InsecureRequestWarning.
+
+    Returns:
+        None.
+    """
+    logging.captureWarnings(True)
+
+    # Use filters with regexes matching the API gateway and s3 host parameters, so that
+    # the 'once' action will log one warning per host to which an insecure request is made,
+    # rather than just one warning after the first insecure request.
+    warnings.filterwarnings(
+        action='once', category=InsecureRequestWarning,
+        message=rf'^.*\'{re.escape(get_config_value("api_gateway.host"))}\''
+    )
+    s3_hostname = re.sub(r'https?://', '', get_config_value("s3.endpoint"))
+    warnings.filterwarnings(
+        action='once', category=InsecureRequestWarning,
+        message=rf'.*\'{re.escape(s3_hostname)}\''
+    )
+
+    # Overriding format_warning makes the format of the insecure request warnings
+    # look much nicer.
+    orig_format_warning = warnings.formatwarning
+
+    def format_warning(warning, *args, **kwargs):
+        if not isinstance(warning, InsecureRequestWarning):
+            return orig_format_warning(warning, *args, **kwargs)
+
+        return str(warning)
+    warnings.formatwarning = format_warning

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -106,7 +106,7 @@ class TestLogging(unittest.TestCase):
         self.sub_logger = logging.getLogger('submodule')
         self.mock_get_logger = mock.patch(
             'sat.logging.logging.getLogger',
-            side_effect=(self.logger, self.sub_logger)
+            side_effect=(self.logger, self.sub_logger, self.sub_logger)
         ).start()
 
         config_values = self.config_values = {
@@ -189,6 +189,8 @@ class TestLogging(unittest.TestCase):
         self.mock_get_logger.assert_any_call('sat')
         # And also the logger named 'csm_api_client'
         self.mock_get_logger.assert_any_call('csm_api_client')
+        # And finally, the 'py.warnings' module
+        self.mock_get_logger.assert_any_call('py.warnings')
 
         log_dir = os.path.dirname(self.config_values['logging.file_name'])
         mock_makedirs.assert_called_once_with(log_dir, exist_ok=True)
@@ -219,6 +221,7 @@ class TestLogging(unittest.TestCase):
         # This should have gotten the logger named 'sat'
         self.mock_get_logger.assert_any_call('sat')
         self.mock_get_logger.assert_any_call('csm_api_client')
+        self.mock_get_logger.assert_any_call('py.warnings')
 
         # Exactly one handler of type StreamHandler should have been added.
         self.assertEqual(len(self.logger.handlers), 1)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -644,14 +644,15 @@ class TestGetS3Resource(ExtendedTestCase):
         result = util.get_s3_resource()
         self.assertEqual([mock.call('s3.access_key_file'), mock.call('s3.secret_key_file')],
                          self.mock_read_config_value_file.mock_calls)
-        self.mock_get_config_value.assert_called_once_with('s3.endpoint')
+        self.mock_get_config_value.assert_any_call('s3.endpoint')
+        self.mock_get_config_value.assert_any_call('s3.cert_verify')
         self.mock_boto3.assert_called_once_with(
             's3',
             endpoint_url=self.mock_get_config_value.return_value,
             aws_access_key_id=self.access_key,
             aws_secret_access_key=self.secret_key,
             region_name='',
-            verify=False
+            verify=self.mock_get_config_value.return_value
         )
         self.assertEqual(result, self.mock_boto3.return_value)
 


### PR DESCRIPTION
## Summary and Scope

Add a new warnings.py module with a function to configure warnings.
* Uses 'once' filters and matches API gateway and S3 endpoint parameters
  so that we can get one warning per host.
* Add s3.cert_verify parameter but unfortunately it needs to remain
  False for now.
* Remove TODO references except in config.py where we should eventually
  change the default value of s3.cert_verify.
* Add missing documentation on s3 config file section to the man page.

## Testing

Test Description:
* I ran `sat status` with certificate verification enabled and disabled.
* I ran `sat showrev` with rgw certificate verification enabled and
  disabled.
* I visually inspected the resulting warnings.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

