### PR TITLE
CRAYSAT-1656: Bump csm-api-client version to 1.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Update the version of `cs-api-client` to improve config loading when running in
+  the Kubernetes cluster.
+
 ### Fixed
 - Fixed a bug in the `bos-operations` stage of `sat bootsys` where a Bad Request
   error could appear in the output when checking node states.

--- a/requirements-dev.lock.txt
+++ b/requirements-dev.lock.txt
@@ -14,7 +14,7 @@ coverage==6.3.2
 cray-product-catalog==1.6.0
 croniter==0.3.37
 cryptography==36.0.1
-csm-api-client==1.1.2
+csm-api-client==1.1.3
 dataclasses-json==0.5.6
 docutils==0.17.1
 google-auth==2.6.0

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -11,7 +11,7 @@ click==8.0.4
 cray-product-catalog==1.6.0
 croniter==0.3.37
 cryptography==36.0.1
-csm-api-client==1.1.2
+csm-api-client==1.1.3
 dataclasses-json==0.5.6
 google-auth==2.6.0
 htmlmin==0.1.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ argcomplete
 boto3
 botocore
 cray-product-catalog >= 1.6.0
-csm-api-client >= 1.1.2, <2.0
+csm-api-client >= 1.1.3, <2.0
 croniter >= 0.3, < 1.0
 inflect >= 0.2.5, < 3.0
 Jinja2 >= 3.0, < 4.0


### PR DESCRIPTION
Note that this depends on https://github.com/Cray-HPE/python-csm-api-client/pull/12.


## Summary and Scope

Bump the version of the csm-api-client dependency to 1.1.3 in order to prioritize loading the Kubernetes config from the in-cluster config, and to fall back to the config file if not running in the K8s cluster.

## Issues and Related PRs

* Resolves [CRAYSAT-1656](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1656)

## Testing

### Test description:

Run in k8s cluster with DEBUG logging, ensure no message logged. Check running directly on management NCN and make sure DEBUG message was logged.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

