### PR TITLE
CRAYSAT-1680: Format each log line separately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   greater than 0% failed components will be logged as warning messages, and all
   other session statuses will be logged as info messages.
 - Changed the default value of the config file option `bos.api_version` to "v2".
+- Modified logging for SAT such that multi-line log messages will now be logged
+  with consistent formatting for each line.
 
 ### Fixed
 - Fixed a bug in the `bos-operations` stage of `sat bootsys` where a Bad Request

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -21,15 +21,75 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+""" Unit tests for sat.logging
 """
-Unit tests for sat.logging
-"""
+import itertools
 import logging
 import os
 import unittest
 from unittest import mock
 
-from sat.logging import bootstrap_logging, configure_logging
+from sat.logging import LineSplittingFormatter, bootstrap_logging, configure_logging
+
+
+class MockHandler(logging.Handler):
+    """Simple handler which records formatted messages in a list"""
+    def __init__(self, level):
+        super().__init__(level)
+        self.messages = []
+        self.records = []
+
+    def emit(self, record):
+        self.records.append(record)
+        self.messages.append(self.format(record))
+
+
+class TestLineSplittingFormatter(unittest.TestCase):
+    def setUp(self):
+        fmt = '%(levelname)s: %(message)s'  # Omit time since that complicates testing
+        self.logger = logging.getLogger(f'{__name__}:{type(self).__name__}')
+        self.handler = MockHandler(logging.INFO)
+        self.handler.setFormatter(LineSplittingFormatter(fmt))
+        self.logger.addHandler(self.handler)
+
+    def test_logging_single_lines(self):
+        """Test logging a single line"""
+        msg = 'something happened'
+        self.logger.info(msg)
+        self.assertEqual(len(self.handler.messages), 1)
+        self.assertEqual(self.handler.messages[0], f'INFO: {msg}')
+
+    def test_logging_multiple_lines(self):
+        """Test logging multiple lines with individual formatting"""
+        line1 = 'This is a test.'
+        line2 = 'There is no need to be alarmed.'
+        msg = f'{line1}\n{line2}'
+        self.logger.info(msg)
+        self.assertEqual(len(self.handler.messages), 1)
+        self.assertEqual(self.handler.messages[0], f"INFO: {line1}\nINFO: {line2}")
+
+    @mock.patch('logging.time.time', side_effect=itertools.count())
+    def test_logging_multiple_lines_with_dates(self, _):
+        """Test logging multiple lines with a date in the format string"""
+        fmt = '%(asctime)s - %(levelname)s - %(message)s'
+        line1 = 'This is a test.'
+        line2 = 'This is another line logged at the same time.'
+        msg = f'{line1}\n{line2}'
+        formatter = LineSplittingFormatter(fmt)
+        self.handler.setFormatter(formatter)
+
+        self.logger.info(msg)
+        self.assertEqual(len(self.handler.messages), 1)
+        self.assertEqual(len(self.handler.records), 1)
+        first_time = formatter.formatTime(self.handler.records[0])
+        self.assertEqual(self.handler.messages[0], f"{first_time} - INFO - {line1}\n{first_time} - INFO - {line2}")
+
+        self.logger.info(msg)
+        self.assertEqual(len(self.handler.messages), 2)
+        self.assertEqual(len(self.handler.records), 2)
+        second_time = formatter.formatTime(self.handler.records[1])
+        self.assertNotEqual(first_time, second_time)
+        self.assertEqual(self.handler.messages[1], f"{second_time} - INFO - {line1}\n{second_time} - INFO - {line2}")
 
 
 class TestLogging(unittest.TestCase):


### PR DESCRIPTION


Test Description:


## Summary and Scope
This change adds a new logging formatter which splits each log message at each line break, and formats each line separately using the given format. Each log record is still semantically a separate log event, but the formatted output has consistent formatting across lines. This resolves an issue with the IUF omitting console log messages which did not have proper prefixes.

## Issues and Related PRs

* Resolves [CRAYSAT-1680](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1680)

## Testing

### Tested on:

  * Local development environment

### Test description:
Run unit tests. Run `sat bootprep` against an invalid bootprep input file to make sure the `ERROR:` prefix is applied to each line properly.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

