### PR TITLE
CRAYSAT-1697: Add `wildcard` filtering option in bootprep input file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- Added ability to filter images provided by a product using a wildcard pattern
+  to specify the base input image in a `sat bootprep` input file
+
 ### Changed
 - Changed logging in `sat bootsys` such that all sessions will have a logging
   message printed at the end of the `sat bootsys` run. BOS sessions with

--- a/sat/data/schema/bootprep_schema.yaml
+++ b/sat/data/schema/bootprep_schema.yaml
@@ -41,7 +41,7 @@ $schema: "https://json-schema.org/draft/2020-12/schema"
 # ... patch component when all input files that were valid under the old schema
 #     are still valid under the new schema
 #
-version: '1.0.3'
+version: '1.0.4'
 title: Bootprep Input File
 description: >
   A description of the set of CFS configurations to create, the set of IMS
@@ -275,7 +275,8 @@ properties:
                         Filter the image or recipe to use from the given version of the given product
                         in case this product provides more than one image or recipe and one must be
                         selected.
-                      required: ['prefix']
+                      maxProperties: 1
+                      minProperties: 1
                       additionalProperties: false
                       properties:
                         prefix:
@@ -284,6 +285,17 @@ properties:
                             A prefix that must match the beginning of the name of an image or recipe
                             from the given version of the given product. If there are multiple matches,
                             or if there are no matches, it is an error.
+
+                            Supports rendering as a Jinja template.
+                        wildcard:
+                          type: string
+                          description: >
+                            A string using glob-style wildcards which must match the name of an image
+                            or recipe from the given version of the given product. If there are multiple
+                            matches, or if there are no matches, it is an error.
+
+                            Supports rendering as a Jinja template.
+                          minLength: 1
             - type: object
               required: ['image_ref']
               additionalProperties: false


### PR DESCRIPTION
## Summary and Scope

This change adds a `wildcard` option to product-supplied images in bootprep input files. The `wildcard` option can be specified under a `base.product.filter` clause to select the base image from a product. Wildcard pattern matching is performed using standard glob syntax. See documentation of the Python `fnmatch` module for more information.

## Issues and Related PRs

* Resolves [CRAYSAT-1697](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1697)

## Testing

### Tested on:

  * `rocket`
  
### Test description:

Run unit tests. Run on a system against a simple bootprep input file with a single COS image selected using a wildcard.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

