### PR TITLE
CRAYSAT-1700: Switch default BOS version to v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   message printed at the end of the `sat bootsys` run. BOS sessions with
   greater than 0% failed components will be logged as warning messages, and all
   other session statuses will be logged as info messages.
+- Changed the default value of the config file option `bos.api_version` to "v2".
 
 ### Fixed
 - Fixed a bug in the `bos-operations` stage of `sat bootsys` where a Bad Request

--- a/sat/config.py
+++ b/sat/config.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -103,7 +103,7 @@ SAT_CONFIG_SPEC = {
         'api_timeout': OptionSpec(int, 60, None, 'api_timeout'),
     },
     'bos': {
-        'api_version': OptionSpec(str, 'v1', validate_bos_api_version, 'bos_version')
+        'api_version': OptionSpec(str, 'v2', validate_bos_api_version, 'bos_version')
     },
     'bootsys': {
         'max_hsn_states': OptionSpec(int, 10, None, None),


### PR DESCRIPTION
## Summary and Scope

This change updates the default version of BOS to "v2" in the config file.

(cherry picked from commit e7dc853bdff03876722bd1c783b2cf4a39467f88)

## Issues and Related PRs

* Resolves [CRAYSAT-1700](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1700)
* A docs-sat PR will be opened to update the docs accordingly.

## Testing

### Tested on:

  * local macbook

### Test description:

Ran `sat status` on local macbook in a Python virtualenv with my sat
config file pointing at Odin's API gateway. Verified that the BOS fields
which require BOS v2 were displayed. Verified that explicitly specifying
BOS v1 worked with `sat status --bos-version v1`.## Risks and Mitigations

## Risks and Mitigations

Low risk. The admin can always change back.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable