### PR TITLE
CRAYSAT-1698, CRAYSAT-1699, CRAYSAT-1700: Backport to release/3.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 - Update the version of oauthlib from 3.2.1 to 3.2.2 to resolve a moderate
   dependabot alert for CVE-2022-36087.
+- Update the version of cryptography from 36.0.1 to 39.0.1 to address
+  CVE-2023-23931.
 
 ## [3.21.2] - 2023-02-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.21.3] - 2023-03-24
 
+### Changed
+- Changed the default value of the config file option `bos.api_version` to "v2".
+
 ### Security
 - Update the version of oauthlib from 3.2.1 to 3.2.2 to resolve a moderate
   dependabot alert for CVE-2022-36087.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.21.3] - 2023-03-24
+
+### Security
+- Update the version of oauthlib from 3.2.1 to 3.2.2 to resolve a moderate
+  dependabot alert for CVE-2022-36087.
+
 ## [3.21.2] - 2023-02-13
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -68,7 +68,8 @@ COPY sat sat
 COPY docs/man docs/man
 COPY tools tools
 
-RUN pip3 install --no-cache-dir pip && \
+RUN --mount=type=secret,id=netrc,target=/root/.netrc \
+    pip3 install --no-cache-dir pip && \
     pip3 install --no-cache-dir --timeout=300 . && \
     ./config-docker-sat.sh
 

--- a/requirements-dev.lock.txt
+++ b/requirements-dev.lock.txt
@@ -13,7 +13,7 @@ click==8.0.4
 coverage==6.3.2
 cray-product-catalog==1.6.0
 croniter==0.3.37
-cryptography==36.0.1
+cryptography==39.0.1
 csm-api-client==1.1.2
 dataclasses-json==0.5.6
 docutils==0.17.1

--- a/requirements-dev.lock.txt
+++ b/requirements-dev.lock.txt
@@ -34,7 +34,7 @@ marshmallow-enum==1.5.1
 mypy-extensions==0.4.3
 natsort==8.1.0
 nose==1.3.7
-oauthlib==3.2.1
+oauthlib==3.2.2
 packaging==21.3
 paramiko==2.10.1
 parsec==3.5

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -28,7 +28,7 @@ marshmallow==3.14.1
 marshmallow-enum==1.5.1
 mypy-extensions==0.4.3
 natsort==8.1.0
-oauthlib==3.2.1
+oauthlib==3.2.2
 paramiko==2.10.1
 parsec==3.5
 prettytable==0.7.2

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -10,7 +10,7 @@ charset-normalizer==2.0.12
 click==8.0.4
 cray-product-catalog==1.6.0
 croniter==0.3.37
-cryptography==36.0.1
+cryptography==39.0.1
 csm-api-client==1.1.2
 dataclasses-json==0.5.6
 google-auth==2.6.0

--- a/sat/config.py
+++ b/sat/config.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -103,7 +103,7 @@ SAT_CONFIG_SPEC = {
         'api_timeout': OptionSpec(int, 60, None, 'api_timeout'),
     },
     'bos': {
-        'api_version': OptionSpec(str, 'v1', validate_bos_api_version, 'bos_version')
+        'api_version': OptionSpec(str, 'v2', validate_bos_api_version, 'bos_version')
     },
     'bootsys': {
         'max_hsn_states': OptionSpec(int, 10, None, None),


### PR DESCRIPTION
## Summary and Scope

Backport needed fixes to release/3.21 branch, so an official 3.21.3 release is created and can be included in SAT 2.5 product stream and CSM 1.4.0.

## Issues and Related PRs

* Resolves [CRAYSAT-1698](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1698)
* Resolves [CRAYSAT-1699](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1699)
* [CRAYSAT-1700](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1700)
* Documentation PR is coming.

## Testing

Still need to do a sanity test with the cray-sat container image resulting from the Jenkins build.

### Tested on:

  * odin (TODO)

### Test description:

Will test `sat status` and `sat bash`.

## Risks and Mitigations

Low risk changes. The BOS version can still be configured to be BOS v1 at the admin's discretion.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
