### PR TITLE
CRAYSAT-1523: Update testing infrastructure to use nose2

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,7 @@
-# Top-level requirements for building SAT and running unit tests.
-# (C) Copyright 2019-2021 Hewlett Packard Enterprise Development LP.
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -13,13 +15,18 @@
 #
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
 # THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
 # OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
-docutils
-sphinx >= 2.2.1, < 3.0.0
-nose2[coverage_plugin] >= 0.12.0
-coverage
-pycodestyle
+#
+
+[run]
+source = sat
+omit = tests/*
+       tools/*
+       setup.py
+
+[html]
+directory = coverage

--- a/.github/workflows/license-check.yaml
+++ b/.github/workflows/license-check.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -41,7 +41,7 @@ jobs:
 
     - name: Get changed files
       id: changed-files
-      uses: tj-actions/changed-files@v34
+      uses: tj-actions/changed-files@v35
 
     - name: License Check
       if: ${{ steps.changed-files.outputs.all_changed_files }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed the default value of the config file option `bos.api_version` to "v2".
 - Modified logging for SAT such that multi-line log messages will now be logged
   with consistent formatting for each line.
+- Updated unit test infrastructure to use `nose2`.
 
 ### Fixed
 - Fixed a bug in the `bos-operations` stage of `sat bootsys` where a Bad Request

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ RUN --mount=type=secret,id=netrc,target=/root/.netrc \
     pip3 install --no-cache-dir -U pip && \
     pip3 install -r requirements.txt
 
-COPY CHANGELOG.md README.md setup.cfg setup.py ./
+COPY CHANGELOG.md README.md setup.py ./
 # This file is used to get the version of docutils needed
 COPY requirements-dev.lock.txt requirements-dev.lock.txt
 COPY docker_scripts/config-docker-sat.sh ./
@@ -87,8 +87,9 @@ FROM ci_base as testing
 # when they succeed natively, so disable those in CI.
 ENV SAT_SKIP_PERF_TESTS=1
 COPY tests tests
-COPY setup.cfg setup.cfg
-CMD nosetests
+COPY unittest.cfg ./
+# Omit test coverage in CI, coverage reports are discarded anyway.
+CMD nose2 --exclude-plugin='nose2.plugins.coverage'
 
 # This stage runs pycodestyle in the container so we are again using the same
 # production environment to check our code style.

--- a/requirements-dev.lock.txt
+++ b/requirements-dev.lock.txt
@@ -33,7 +33,7 @@ marshmallow==3.14.1
 marshmallow-enum==1.5.1
 mypy-extensions==0.4.3
 natsort==8.1.0
-nose==1.3.7
+nose2==0.12.0
 oauthlib==3.2.2
 packaging==21.3
 paramiko==2.10.1

--- a/requirements-dev.lock.txt
+++ b/requirements-dev.lock.txt
@@ -36,7 +36,7 @@ natsort==8.1.0
 nose2==0.12.0
 oauthlib==3.2.2
 packaging==21.3
-paramiko==2.10.1
+paramiko==2.11.0
 parsec==3.5
 prettytable==0.7.2
 pyasn1==0.4.8

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -29,7 +29,7 @@ marshmallow-enum==1.5.1
 mypy-extensions==0.4.3
 natsort==8.1.0
 oauthlib==3.2.2
-paramiko==2.10.1
+paramiko==2.11.0
 parsec==3.5
 prettytable==0.7.2
 pyasn1==0.4.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ Jinja2 >= 3.0, < 4.0
 json-schema-for-humans
 jsonschema >= 4.0, < 5.0
 kubernetes
-paramiko >= 2.4.2
+paramiko >= 2.11.0
 parsec == 3.5.0
 prettytable >= 0.7.2, < 1.0
 python-dateutil >= 2.7.3, < 3.0

--- a/unittest.cfg
+++ b/unittest.cfg
@@ -1,4 +1,4 @@
-# (C) Copyright 2019-2020 Hewlett Packard Enterprise Development LP.
+# (C) Copyright 2019-2020, 2023 Hewlett Packard Enterprise Development LP.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -18,18 +18,25 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-[nosetests]
-verbosity=3
-with-coverage=1
-cover-package=sat
-cover-erase=1
-cover-xml=1
-cover-xml-file=coverage.xml
-cover-html=1
-cover-html-dir=coverage
-with-xunit=1
-xunit-file=nosetests.xml
-all-modules=1
+[unittest]
+verbosity = 3
 # Only look for tests in this directory to prevent trying to import the actual
 # sat package when searching for tests.
-tests=tests
+start-dir = tests
+
+[log-capture]
+always-on = true
+clear-handlers = true
+
+[output-buffer]
+always-on = true
+stderr = true
+
+[test-result]
+descriptions = false
+
+[coverage]
+always-on = true
+coverage-config = .coveragerc
+coverage-report = html
+                  term


### PR DESCRIPTION
## Summary and Scope

This change modifies this repo's testing infrastructure in order to use
nose2 for running unit tests instead of nosetests. This should
future-proof our unit tests as nosetests breaks after Python 3.10 and
will not be updated to support it (the nose project is in maintenance
mode.)

This change also bumps the version of paramiko in use to 2.11.0 in order to
fix a warning about deprecated Blowfish ciphers. This was caused by an
updated version of the underlying cryptography library which added those
warnings.

## Issues and Related PRs

* Resolves [CRAYSAT-1523](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1523)

## Testing

### Tested on:

  * Local development environment

### Test description:

Run unit tests.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

