### PR TITLE
CRAYSAT-1705: Fix logic for checking when staged BOS session is complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a bug where the `bos-operations` stage of `sat bootsys` would not correctly
   wait for a shutdown or boot operation to complete with BOS v1 and certain versions
   of the `kubectl` command.
+- Fixed a bug where the `bos-operations` stage of `sat bootsys` did not report
+  staged sessions as complete if the sessions did not apply to any components
+  due to a `--bos-limit` parameter that did not overlap with the components in the
+  session template.
 
 ### Security
 - Update the version of oauthlib from 3.2.1 to 3.2.2 to resolve a moderate

--- a/sat/cli/bootsys/bos.py
+++ b/sat/cli/bootsys/bos.py
@@ -212,19 +212,28 @@ def boa_job_successful(boa_job_id):
 class BOSV2SessionWaiter(Waiter):
     """Waiter for monitoring the status of a BOS v2 session."""
 
-    def __init__(self, bos_session_thread, target_state='complete', *args, **kwargs):
+    def __init__(self, bos_session_thread, target_states=None, *args, **kwargs):
+        """
+        Create a new BOSV2SessionWaiter.
+
+        Args:
+            bos_session_thread (BOSSessionThread): the BOS session thread
+            target_states (list, optional): the list of acceptable target state
+                strings. Defaults to ['complete']
+        """
         super().__init__(*args, **kwargs)
         self.bos_client = BOSClientCommon.get_bos_client(SATSession(),
                                                          version='v2')
         self.bos_session_thread = bos_session_thread
-        self.target_state = target_state
+        self.target_states = ['complete'] if target_states is None else target_states
+        self.target_states_desc = INFLECTOR.join(self.target_states, conj='or')
 
         self.pct_successful = 0.0
         self.pct_failed = 0.0
         self.session_status = {}
 
     def condition_name(self):
-        return f'session {self.bos_session_thread.session_id} reached target state {self.target_state}'
+        return f'session {self.bos_session_thread.session_id} reached target state {self.target_states_desc}'
 
     def has_completed(self):
         if self.bos_session_thread.stopped():
@@ -233,7 +242,8 @@ class BOSV2SessionWaiter(Waiter):
         try:
             LOGGER.info(
                 'Waiting for BOS session %s to reach target state %s. Session template: %s',
-                self.bos_session_thread.session_id, self.target_state, self.bos_session_thread.session_template
+                self.bos_session_thread.session_id, self.target_states_desc,
+                self.bos_session_thread.session_template
             )
 
             self.session_status = self.bos_client.get_session_status(
@@ -250,12 +260,11 @@ class BOSV2SessionWaiter(Waiter):
                     self.bos_session_thread.session_id, self.pct_successful, self.pct_failed
                 )
 
-            if self.session_status['status'] == self.target_state:
+            if self.session_status['status'] in self.target_states:
                 if not self.session_status.get('managed_components_count'):
-                    LOGGER.warning(
-                        'Session %s does not manage any components; another session '
-                        'may have been started which targets the same components as '
-                        'this session.', self.bos_session_thread.session_id
+                    LOGGER.info(
+                        'Session %s did not manage any components.',
+                        self.bos_session_thread.session_id
                     )
                 return True
 
@@ -487,10 +496,18 @@ class BOSSessionThread(Thread):
         Returns:
             None
         """
+        target_states = ['complete']
+        # If staged, a BOS session will enter 'running' state if it affects a
+        # non-empty set of components. Otherwise (e.g. when the nodes specified
+        # in the bootsets do not intersect with the limit parameter), it will go
+        # straight to 'complete'.
+        if self.stage:
+            target_states.append('running')
+
         # Pass math.inf as the timeout since timeouts are handled by the
         # `do_parallel_bos_operations()` function, independent of the waiter
         # class here.
-        waiter = BOSV2SessionWaiter(self, target_state='running' if self.stage else 'complete',
+        waiter = BOSV2SessionWaiter(self, target_states=target_states,
                                     timeout=math.inf,
                                     poll_interval=PARALLEL_CHECK_INTERVAL)
 


### PR DESCRIPTION
## Summary and Scope

Normally, a BOS v2 staged session will reach the state "running" when it is considered finished staging. However, if that BOS v2 staged session does not apply to any components (for example, when a limit parameter is used that does not overlap with any of the nodes in the session template), the session will go straight to "complete" instead.

Rename the `target_state` argument to the BOSV2SessionWaiter to `target_states` and change the type to a list of acceptable target states. This allows us to call it with the single state "complete" when waiting on a non-staged session and to call it with the states "complete" and "running" when waiting on a staged session.

## Issues and Related PR

* Resolves [CRAYSAT-1705](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1705)

## Testing

### Tested on:

  * locally on macbook
  * TBD

### Test description:

Added new unit tests. Will test on a real system as follows:

* Run `sat bootsys boot --stage bos-operations --staged-session` using a session template that applies to application nodes, but pass `--bos-limit Compute`. The session should finish and `sat bootsys` should return.
* Run the same test as above but pass two session templates: one for compute nodes and one for UANs. Both should finish and `sat bootsys` should return. Only computes should be staged.
* Run the same test as above but without `--staged-session`. The computes should actually be rebooted.

## Risks and Mitigations

This is a pretty small change that just adds an additional acceptable target state for staged BOS v2 sessions.

Unit tests cover the changed code.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

