### PR TITLE
CRAYSAT-1705: Fix logic for checking when staged BOS session is complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.21.4] - 2023-04-07
+
+### Fixed
+- Fixed a bug where the `bos-operations` stage of `sat bootsys` did not report
+  staged sessions as complete if the sessions did not apply to any components
+  due to a `--bos-limit` parameter that did not overlap with the components in the
+  session template.
+
 ## [3.21.3] - 2023-03-24
 
 ### Changed


### PR DESCRIPTION
## Summary and Scope

Normally, a BOS v2 staged session will reach the state "running" when it is considered finished staging. However, if that BOS v2 staged session does not apply to any components (for example, when a limit parameter is used that does not overlap with any of the nodes in the session template), the session will go straight to "complete" instead.

Rename the `target_state` argument to the BOSV2SessionWaiter to `target_states` and change the type to a list of acceptable target states. This allows us to call it with the single state "complete" when waiting on a non-staged session and to call it with the states "complete" and "running" when waiting on a staged session.

## Issues and Related PR

* Resolves [CRAYSAT-1705](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1705)

## Testing

### Tested on:

  * locally on macbook
  * TBD

### Test description:

Added new unit tests. Will test on a real system as follows:

* Run `sat bootsys boot --stage bos-operations --staged-session` using a session template that applies to application nodes, but pass `--bos-limit Compute`. The session should finish and `sat bootsys` should return.
* Run the same test as above but pass two session templates: one for compute nodes and one for UANs. Both should finish and `sat bootsys` should return. Only computes should be staged.
* Run the same test as above but without `--staged-session`. The computes should actually be rebooted.

## Risks and Mitigations

This is a pretty small change that just adds an additional acceptable target state for staged BOS v2 sessions.

Unit tests cover the changed code.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
