### PR TITLE
CRAYSAT-1673: Update csm-api-client version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   staged sessions as complete if the sessions did not apply to any components
   due to a `--bos-limit` parameter that did not overlap with the components in the
   session template.
+- Use version 1.1.3 of the `csm-api-client` library in order to fix the suggested
+  container logs if a bootprep image configuration run fails.
 
 ### Security
 - Update the version of oauthlib from 3.2.1 to 3.2.2 to resolve a moderate

--- a/requirements-dev.lock.txt
+++ b/requirements-dev.lock.txt
@@ -14,7 +14,7 @@ coverage==6.3.2
 cray-product-catalog==1.6.0
 croniter==0.3.37
 cryptography==39.0.1
-csm-api-client==1.1.2
+csm-api-client==1.1.3
 dataclasses-json==0.5.6
 docutils==0.17.1
 google-auth==2.6.0

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -11,7 +11,7 @@ click==8.0.4
 cray-product-catalog==1.6.0
 croniter==0.3.37
 cryptography==39.0.1
-csm-api-client==1.1.2
+csm-api-client==1.1.3
 dataclasses-json==0.5.6
 google-auth==2.6.0
 htmlmin==0.1.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ argcomplete
 boto3
 botocore
 cray-product-catalog >= 1.6.0
-csm-api-client >= 1.1.2, <2.0
+csm-api-client >= 1.1.3, <2.0
 croniter >= 0.3, < 1.0
 inflect >= 0.2.5, < 3.0
 Jinja2 >= 3.0, < 4.0


### PR DESCRIPTION
## Summary and Scope

Use the 1.1.3 version of the csm-api-client dependency in order to pull in the fixed suggested debug container logs functionality to accomodate new versions of CFS with only one ansible container.

## Issues and Related PRs

* Resolves [CASMTRIAGE-4983](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-4983)

## Testing

### Tested on:

  * `gamora`

### Test description:
Test with intentionally failing bootprep image configuration session and confirm that the `ansible` container is returned instead of the `teardown` container.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

