### PR TITLE
CRAYSAT-1714: Skip CAPMC request when empty set of nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Fixed an unnecessary CAPMC API request and a confusing warning message during
+  `sat bootsys shutdown --stage cabinet-power` when there are no non-management
+  nodes in air-cooled cabinets.
+
 ## [3.22.0] - 2023-05-08
 
 ### Added

--- a/sat/cli/bootsys/cabinet_power.py
+++ b/sat/cli/bootsys/cabinet_power.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -63,6 +63,11 @@ def do_air_cooled_cabinets_power_off(args):
         raise SystemExit(1)
 
     node_xnames = list(set(river_nodes) - set(river_mgmt_nodes))
+
+    if not node_xnames:
+        LOGGER.info(f'No non-management nodes in air-cooled cabinets to power off.')
+        return
+
     LOGGER.info(f'Powering off {len(node_xnames)} non-management nodes in air-cooled cabinets.')
     capmc_client = CAPMCClient(SATSession())
     try:

--- a/tests/cli/bootsys/test_cabinet_power.py
+++ b/tests/cli/bootsys/test_cabinet_power.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021, 2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -24,13 +24,108 @@
 """
 Unit tests for the sat.cli.bootsys.cabinet_power module.
 """
-
+import logging
+import unittest
 from argparse import Namespace
-from unittest.mock import patch
+from unittest.mock import call, patch
 
-from sat.cli.bootsys.cabinet_power import do_cabinets_power_off
+from sat.cli.bootsys.cabinet_power import do_air_cooled_cabinets_power_off, do_cabinets_power_off
 
 from tests.common import ExtendedTestCase
+
+
+class TestAirCooledCabinetsPowerOff(unittest.TestCase):
+    """Tests for do_air_cooled_cabinets_power_off function."""
+
+    def setUp(self):
+        self.args = Namespace()
+        patch_prefix = 'sat.cli.bootsys.cabinet_power'
+        self.mock_sat_session = patch(f'{patch_prefix}.SATSession').start().return_value
+        self.mock_hsm_client = patch(f'{patch_prefix}.HSMClient').start().return_value
+        self.mock_capmc_client = patch(f'{patch_prefix}.CAPMCClient').start().return_value
+        self.mock_capmc_waiter = patch(f'{patch_prefix}.CAPMCPowerWaiter').start().return_value
+
+        # Mock as if we have nodes in slots 1-15 as Management nodes, and the node in slot 17 not
+        self.mock_river_nodes = [f'x3000c0s{slot}b0n0' for slot in [1, 3, 5, 7, 9, 11, 13, 15, 17]]
+        self.num_non_mgmt_river_nodes = 1
+        self.mock_river_mgmt_nodes = self.mock_river_nodes[:-self.num_non_mgmt_river_nodes]
+        self.mock_river_non_mgmt_nodes = self.mock_river_nodes[-self.num_non_mgmt_river_nodes:]
+        self.timed_out_xnames = []
+
+        def mock_get_component_xnames(params):
+            if params.get('class') == 'River':
+                if params.get('role') == 'Management':
+                    return self.mock_river_mgmt_nodes
+                else:
+                    return self.mock_river_nodes
+            else:
+                return []
+
+        self.mock_hsm_client.get_component_xnames.side_effect = mock_get_component_xnames
+        self.mock_capmc_waiter.wait_for_completion.return_value = self.timed_out_xnames
+
+    def tearDown(self):
+        patch.stopall()
+
+    def assert_hsm_client_calls(self):
+        """Helper function to assert the expected HSMClient method calls are made."""
+        river_call_params = {'type': 'Node', 'class': 'River'}
+        mgmt_call_params = {'type': 'Node', 'class': 'River', 'role': 'Management'}
+
+        self.mock_hsm_client.get_component_xnames.assert_has_calls([
+            call(river_call_params),
+            call(mgmt_call_params)
+        ])
+
+    def test_do_ac_cab_off_non_empty_success(self):
+        """Test do_air_cooled_cabinets_power_off with a non-empty set of non-mgmt river nodes"""
+        with self.assertLogs(level=logging.INFO) as logs_cm:
+            do_air_cooled_cabinets_power_off(self.args)
+
+        self.assert_hsm_client_calls()
+        self.mock_capmc_client.set_xnames_power_state.assert_called_once_with(
+            self.mock_river_non_mgmt_nodes, 'off', force=True
+        )
+        self.mock_capmc_waiter.wait_for_completion.assert_called_once_with()
+        self.assertEqual(3, len(logs_cm.records))
+        self.assertRegex(logs_cm.records[0].message,
+                         f'Powering off {self.num_non_mgmt_river_nodes}')
+        self.assertRegex(logs_cm.records[1].message,
+                         f'Waiting for {self.num_non_mgmt_river_nodes}')
+        self.assertRegex(logs_cm.records[2].message,
+                         f'All {self.num_non_mgmt_river_nodes}.*reached powered off')
+
+    def test_do_ac_cab_off_non_empty_failure(self):
+        """Test do_air_cooled_cabinets_power_off with a non-empty set of non-mgmt river nodes failing"""
+        self.timed_out_xnames.append(self.mock_river_non_mgmt_nodes[0])
+
+        with self.assertLogs(level=logging.ERROR) as logs_cm:
+            with self.assertRaises(SystemExit):
+                do_air_cooled_cabinets_power_off(self.args)
+
+        self.assert_hsm_client_calls()
+        self.mock_capmc_client.set_xnames_power_state.assert_called_once_with(
+            self.mock_river_non_mgmt_nodes, 'off', force=True
+        )
+        self.mock_capmc_waiter.wait_for_completion.assert_called_once_with()
+        self.assertEqual(1, len(logs_cm.records))
+        self.assertRegex(logs_cm.records[0].message,
+                         'non-management nodes failed to reach the powered off state.*'
+                         f'{self.timed_out_xnames}')
+
+    def test_do_ac_cab_off_empty(self):
+        """Test do_air_cooled_cabinets_power_off with an empty set of non-mgmt river nodes"""
+        self.mock_river_mgmt_nodes = self.mock_river_nodes
+        self.mock_river_non_mgmt_nodes = []
+
+        with self.assertLogs(level=logging.INFO) as logs_cm:
+            do_air_cooled_cabinets_power_off(self.args)
+
+        self.assert_hsm_client_calls()
+        self.mock_capmc_client.set_xnames_power_state.assert_not_called()
+        self.mock_capmc_waiter.wait_for_completion.assert_not_called()
+        self.assertEqual(logs_cm.records[0].message,
+                         'No non-management nodes in air-cooled cabinets to power off.')
 
 
 class TestCabinetsPowerOff(ExtendedTestCase):


### PR DESCRIPTION
## Summary and Scope

During `sat bootsys shutdown --stage cabinet-power`, skip making a request to CAPMC and waiting on the power state of nodes when there are no non-management nodes in air-cooled cabinets to ensure are powered off. Instead, simply log an info message to that effect. Before this check, we were making a request to CAPMC to power off an empty set of xnames, which resulted in a confusing warning, and then we were waiting on a set of zero components, which also looked confusing.

Add unit tests for `do_air_cooled_cabinets_power_off`.

## Issues and Related PRs

* Resolves [CRAYSAT-1714](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1714)

## Testing

### Tested on:

  * Local development environment

### Test description:

Unit tests should be sufficient here until we can do a test on a real or vshasta system.

## Risks and Mitigations

Pretty low-risk change. Will be tested in the full context of a real system power off before release.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
