### PR TITLE
CRAYSAT-1719: Update kubectl version lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.21.5] - 2023-05-08
+
+### Fixed
+- Updated container build script to pull in the correct kubectl version from the
+  metal-provision repository instead of the csm-rpms repository.
+
+### Security
+- Rebuilt the cray-sat container image to address CVE-2023-27536 in
+  curl/libcurl present in the cray-sat:3.21.4 container image.
+
 ## [3.21.4] - 2023-04-07
 
 ### Fixed

--- a/docker_scripts/config-docker-sat.sh
+++ b/docker_scripts/config-docker-sat.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -27,11 +27,10 @@ LOGDIR=/var/log/cray/sat
 
 SATMANDIR=/usr/share/man/man8
 
-CSM_RPMS_REPO="https://github.com/Cray-HPE/csm-rpms.git"
-CSM_RPMS_DIR="csm-rpms"
-CSM_RPMS_BASE_PACKAGES_PATH="packages/node-image-ncn-common/base.packages"
-CSM_RPMS_BRANCH="main"
-KUBERNETES_VERSION_REGEX="[0-9]+\.[0-9]+\.[0-9]+"
+METAL_PROVISION_REPO="https://github.com/Cray-HPE/metal-provision.git"
+METAL_PROVISION_DIR="metal-provision"
+METAL_PROVISION_BASE_PACKAGES_PATH="roles/node-images-ncn-common/vars/packages/suse.yml"
+METAL_PROVISION_BRANCH="main"
 
 # create logging directory
 if [ ! -d "$LOGDIR" ]; then
@@ -63,16 +62,36 @@ echo "export PATH=$VIRTUAL_ENV/bin:\$PATH" > /etc/profile.d/sat_path.sh
 
 # install kubectl using same version used in ncn image
 cd /sat
-git clone $CSM_RPMS_REPO $CSM_RPMS_DIR
-cd $CSM_RPMS_DIR
-git checkout $CSM_RPMS_BRANCH
+git clone $METAL_PROVISION_REPO $METAL_PROVISION_DIR
+cd $METAL_PROVISION_DIR
+git checkout $METAL_PROVISION_BRANCH
 
-KUBERNETES_PULL_VERSION="$(grep ^kubectl= "$CSM_RPMS_BASE_PACKAGES_PATH" | sed -E "s/.*=(${KUBERNETES_VERSION_REGEX})-.*/\1/")"
+KUBERNETES_PULL_VERSION=$(python3 <<EOF
+import re
+import sys
+
+import semver
+import yaml
+
+
+with open("${METAL_PROVISION_BASE_PACKAGES_PATH}") as pkgs:
+    pkgs = yaml.safe_load(pkgs)
+    for line in pkgs.get("packages", []):
+        name, version = re.split(r'(?:(?:<|>)=?|=)', line)
+        if name == "kubectl":
+            version = semver.VersionInfo.parse(version).finalize_version()
+            print(str(version))
+            sys.exit(0)
+print("Could not determine kubectl version")
+sys.exit(1)
+EOF
+)
+
 if [ -z "$KUBERNETES_PULL_VERSION" ]; then
-    echo >&2 "Unable to determine version of kubectl to use from ${CSM_RPMS_REPO}"
+    echo >&2 "Unable to determine version of kubectl to use from ${METAL_PROVISION_REPO}"
     exit 1
 fi
 
-curl -LO "https://storage.googleapis.com/kubernetes-release/release/v${KUBERNETES_PULL_VERSION#v}/bin/linux/amd64/kubectl"
+curl -fLO "https://storage.googleapis.com/kubernetes-release/release/v${KUBERNETES_PULL_VERSION#v}/bin/linux/amd64/kubectl"
 chmod +x ./kubectl
 mv ./kubectl /usr/bin


### PR DESCRIPTION
## Summary and Scope

This change updates the process used to retrieve the appropriate version of kubectl to download into the container. A Python script is now used to parse out the semantic version of kubectl listed in the metal-provision repository instead of the deprecated csm-rpms repository.

## Issues and Related PRs

* Resolves [CRAYSAT-1719](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1719)

## Testing

### Tested on:
  * Local development environment

### Test description:
Build cray-sat container image. Check kubectl version in image.

