### PR TITLE
CRAYSAT-654: Recreate cronjobs which are not being scheduled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added functionality to `sat bootsys boot --stage cabinet-power` to
+  automatically recreate Kubernetes cronjobs which are not being scheduled due
+  to missing too many scheduled start times.
+
 ### Fixed
 - Fixed an unnecessary CAPMC API request and a confusing warning message during
   `sat bootsys shutdown --stage cabinet-power` when there are no non-management

--- a/sat/cronjob.py
+++ b/sat/cronjob.py
@@ -1,0 +1,119 @@
+#
+# MIT License
+#
+# (C) Copyright 2020-2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""
+Utilities for handling Kubernetes cronjobs.
+"""
+import copy
+import datetime
+import logging
+
+import croniter
+from dateutil.tz import tzutc
+from kubernetes.client import ApiException
+
+LOGGER = logging.getLogger(__name__)
+
+
+def cronjob_stuck(cronjob, curr_time=None):
+    """Determine if a cronjob is not being scheduled.
+
+    A cronjob is considered "stuck" if it is not suspended, but its last
+    scheduled time is before the expected most recent scheduled time,
+    based on its cron schedule. If the job is suspended, we expect it not
+    to be scheduled, so we don't treat it as "stuck".
+
+    Args:
+        cronjob (V1CronJob): the cron job object from the Kubernetes API
+        curr_time (datetime): if not None, use this as the current time.
+            Mostly used for testing.
+
+    Returns:
+        Whether the cronjob's last scheduled job was before the
+        calculated most recent scheuled time based on the cron
+        schedule string for the cron job.
+    """
+    if cronjob.spec.suspend:
+        return False
+    it = croniter.croniter(cronjob.spec.schedule)
+    if curr_time is not None:
+        it.set_current(curr_time)
+    if cronjob.status.last_schedule_time is None:
+        last_sched = cronjob.metadata.creation_timestamp
+    else:
+        last_sched = cronjob.status.last_schedule_time
+    prev_expected_sched = datetime.datetime.fromtimestamp(it.get_prev(), tz=tzutc())
+    return last_sched < prev_expected_sched
+
+
+def recreate_cronjob(batch_api, cronjob):
+    """Delete and recreate a cronjob in Kubernetes.
+
+    Args:
+        batch_api (kubernetes.client.BatchV1Api): the Kubernetes API client
+        cronjob (V1CronJob): the cronjob object representing the cronjob to be recreated
+
+    Returns:
+        V1CronJob: the newly created cronjob
+
+    Raises:
+        kubernetes.client.ApiException: if a problem occurs while communicating
+            with the Kubernetes API
+    """
+    cronjob = copy.deepcopy(cronjob)
+    name = cronjob.metadata.name
+    namespace = cronjob.metadata.namespace
+    cronjob.metadata.resource_version = None
+    try:
+        batch_api.delete_namespaced_cron_job(name, namespace)
+    except ApiException as err:
+        if err.status != 404:
+            raise
+
+    return batch_api.create_namespaced_cron_job(namespace, cronjob)
+
+
+def recreate_namespaced_stuck_cronjobs(batch_api, namespace):
+    """Find cronjobs that are not being scheduled and recreate them.
+
+    Args:
+        batch_api (kubernetes.client.BatchV1Api): the Kubernetes API client
+        namespace (str): the namespace to search for cronjobs
+
+    Returns:
+        None
+
+    Raises:
+        kubernetes.client.ApiException: if the Kubernetes API can't be accessed
+    """
+    for cronjob in batch_api.list_namespaced_cron_job(namespace).items:
+        if cronjob_stuck(cronjob):
+            LOGGER.warning('Jobs for cronjob "%s" in namespace "%s" do not appear to be '
+                           'scheduled on time according to the cron job\'s schedule; '
+                           'recreating cron job.',
+                           cronjob.metadata.name, cronjob.metadata.namespace)
+            try:
+                recreate_cronjob(batch_api, cronjob)
+            except ApiException as err:
+                LOGGER.warning('An error occurred while re-creating cronjob "%s" in namespace "%s": %s',
+                               cronjob.metadata.name, cronjob.metadata.namespace, err)

--- a/tests/cli/bootsys/test_cabinet_power.py
+++ b/tests/cli/bootsys/test_cabinet_power.py
@@ -29,8 +29,8 @@ import unittest
 from argparse import Namespace
 from unittest.mock import call, patch
 
-from sat.cli.bootsys.cabinet_power import do_air_cooled_cabinets_power_off, do_cabinets_power_off
-
+from sat.cli.bootsys.cabinet_power import (do_air_cooled_cabinets_power_off,
+                                           do_cabinets_power_off)
 from tests.common import ExtendedTestCase
 
 

--- a/tests/test_cronjob.py
+++ b/tests/test_cronjob.py
@@ -1,0 +1,134 @@
+#
+# MIT License
+#
+# (C) Copyright 2021, 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""
+Unit tests for the sat.cronjob module.
+"""
+import datetime
+import unittest
+from unittest.mock import MagicMock, patch
+
+from croniter import croniter
+from dateutil.tz import tzutc
+from kubernetes.client import (BatchV1Api, V1CronJob, V1CronJobSpec,
+                               V1CronJobStatus, V1JobTemplateSpec,
+                               V1ObjectMeta)
+
+from sat.cronjob import (cronjob_stuck, recreate_cronjob,
+                         recreate_namespaced_stuck_cronjobs)
+
+
+class TestRecreateCronjobs(unittest.TestCase):
+    def setUp(self):
+        now = datetime.datetime.now(tz=tzutc())
+
+        # Truncate the current time to the "top of the hour" time. Since all
+        # the schedule intervals used in the tests are factors of 60, the "top
+        # of the hour" will always be a scheduled time.
+        self.now = datetime.datetime(*now.timetuple()[:4], tzinfo=tzutc())
+        self.mock_batch_api_client = MagicMock(autospec=BatchV1Api)
+
+    @staticmethod
+    def create_cronjob_with_schedule(schedule, last_schedule_time, name=None, namespace=None):
+        template = V1JobTemplateSpec()
+        spec = V1CronJobSpec(job_template=template, schedule=schedule)
+        cronjob = V1CronJob(spec=spec)
+        cronjob.metadata = V1ObjectMeta(name=name, namespace=namespace)
+        cronjob.status = V1CronJobStatus()
+        cronjob.status.last_schedule_time = last_schedule_time
+        return cronjob
+
+    def get_prev_and_most_recent(self, schedule, delta):
+        it = croniter(schedule)
+        it.set_current(self.now)
+        prev = datetime.datetime.fromtimestamp(it.get_prev(), tz=tzutc())
+        return prev, prev + delta
+
+    def test_cron_job_is_stuck(self):
+        """Test detecting if a cronjob is stuck"""
+        schedule = '*/1 * * * *'
+        prev, last_schedule_time = self.get_prev_and_most_recent(schedule, datetime.timedelta(minutes=-2))
+        cj = self.create_cronjob_with_schedule(schedule, last_schedule_time)
+        self.assertTrue(cronjob_stuck(cj, curr_time=prev))
+
+    def test_cron_job_is_not_stuck(self):
+        """Test detecting if a cronjob is not stuck"""
+        schedule = '*/3 * * * *'
+        prev, last_schedule_time = self.get_prev_and_most_recent(schedule, datetime.timedelta(minutes=-1))
+        cj = self.create_cronjob_with_schedule(schedule, last_schedule_time)
+        self.assertFalse(cronjob_stuck(cj, curr_time=prev))
+
+    def test_new_cron_job_is_not_stuck(self):
+        """Test that a newly created cronjob is not stuck"""
+        schedule = '*/3 * * * *'
+        prev, creation = self.get_prev_and_most_recent(schedule, datetime.timedelta(minutes=-1))
+        cj = self.create_cronjob_with_schedule(schedule, None)
+        cj.metadata.creation_timestamp = creation
+        self.assertFalse(cronjob_stuck(cj, curr_time=prev))
+
+    def test_suspended_cron_jobs_not_stuck(self):
+        """Test that suspended cronjobs aren't marked as stuck"""
+        schedule = '*/1 * * * *'
+        prev, last_schedule_time = self.get_prev_and_most_recent(schedule, datetime.timedelta(minutes=-3))
+        cj = self.create_cronjob_with_schedule(schedule, last_schedule_time)
+        cj.spec.suspend = True
+        self.assertFalse(cronjob_stuck(cj, curr_time=prev))
+
+    def test_cron_job_recreation(self):
+        """Test that recreated cron jobs are deleted then created"""
+        name = 'test_cron_job'
+        namespace = 'test'
+        schedule = '*/1 * * * *'
+        prev, last_schedule_time = self.get_prev_and_most_recent(schedule, datetime.timedelta(minutes=-3))
+        cj = self.create_cronjob_with_schedule(schedule, last_schedule_time, name=name, namespace=namespace)
+        recreate_cronjob(self.mock_batch_api_client, cj)
+        self.mock_batch_api_client.delete_namespaced_cron_job.assert_called_once_with(name, namespace)
+        self.mock_batch_api_client.create_namespaced_cron_job.assert_called_once_with(namespace, cj)
+
+    def test_stuck_cron_jobs_recreated(self):
+        """Test that stuck cronjobs are recreated"""
+        name = 'test_cron_job'
+        namespace = 'test'
+        schedule = '*/1 * * * *'
+        prev, last_schedule_time = self.get_prev_and_most_recent(schedule, datetime.timedelta(minutes=-3))
+        cj = self.create_cronjob_with_schedule(schedule, last_schedule_time, name=name, namespace=namespace)
+        self.mock_batch_api_client.list_namespaced_cron_job.return_value.items = [cj]
+        with patch('sat.cronjob.cronjob_stuck', return_value=True) as mock_cronjob_stuck:
+            recreate_namespaced_stuck_cronjobs(self.mock_batch_api_client, namespace)
+            mock_cronjob_stuck.assert_called_once_with(cj)
+        self.mock_batch_api_client.delete_namespaced_cron_job.assert_called_once_with(name, namespace)
+        self.mock_batch_api_client.create_namespaced_cron_job.assert_called_once_with(namespace, cj)
+
+    def test_normal_cron_jobs_left_alone(self):
+        """Test that non-stuck cronjobs are not recreated"""
+        name = 'test_normal_cron_job'
+        namespace = 'test'
+        schedule = '*/1 * * * *'
+        prev, last_schedule_time = self.get_prev_and_most_recent(schedule, datetime.timedelta(seconds=-30))
+        cj = self.create_cronjob_with_schedule(schedule, last_schedule_time, name=name, namespace=namespace)
+        self.mock_batch_api_client.list_namespaced_cron_job.return_value.items = [cj]
+        with patch('sat.cronjob.cronjob_stuck', return_value=False) as mock_cronjob_stuck:
+            recreate_namespaced_stuck_cronjobs(self.mock_batch_api_client, namespace)
+            mock_cronjob_stuck.assert_called_once_with(cj)
+        self.mock_batch_api_client.delete_namespaced_cron_job.assert_not_called()
+        self.mock_batch_api_client.create_namespaced_cron_job.assert_not_called()


### PR DESCRIPTION



## Summary and Scope

This change implements a feature in the cabinet power stage of power on which recreates Kubernetes cronjobs if they are not being scheduled according to their cron schedule. This is determined by checking if the cron job's last scheduled time was prior to the computed prior scheduled time based on its schedule. All cronjobs which are stuck not executing will be deleted and recreated with the same specification.

## Issues and Related PRs

* Resolves [CRAYSAT-654](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-654)

## Testing

### Tested on:

  * Local development environment

### Test description:

Run unit tests. Create cron job which sleeps for longer than its cron schedule with a Forbid concurrency policy (thus causing it to frequently miss its scheduled time.) Run a simple test harness which contains the stuck cronjob check loop from the cabinet power stage and ensure it deletes and recreates the cron jobs.

See https://gist.github.com/jack-stanek-hpe/778b409affc120ff75b4fa8c0e045160 for simple manual testing.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

