### PR TITLE
CRAYSAT-1623: Improve hms-discovery scheduled check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `sat bootsys shutdown --stage cabinet-power` when there are no non-management
   nodes in air-cooled cabinets.
 
+### Changed
+- Improved the check procedure to determine whether the `hms-discovery` cronjob
+  has been scheduled during the `cabinet-power` stage of `sat bootsys`, as well
+  as the `sat swap blade` subcommand.
+- Update the hms-discovery cronjob manipulation functionality to use the
+  BatchV1 Kubernetes API instead of the BatchV1beta1 API.
+
 ## [3.22.0] - 2023-05-08
 
 ### Added


### PR DESCRIPTION
## Summary and Scope

This change modifies the logic in the HMSDiscoveryScheduledWaiter to
check which Kubernetes jobs exist for the hms-discovery cronjob, and
checks if their creation timestamp is after the time that waiting began.
If it was, then waiting finishes; if no job is created within the
timeout duration, then the waiter will time out as normal.

A fix is also included to update the location of kubectl version in the metal-provision repo.

## Issues and Related PRs

* Resolves [CRAYSAT-1623](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1623)
* Also resolves [CRAYSAT-1631](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1631)

## Testing

### Tested on:
  * Local development environment

### Test description:

Create stub version of hms-discovery cron job in minikube. Use waiter to
wait until the job is scheduled. Modify cron job such that it will never
schedule, and make sure that the waiter times out.

Run unit tests.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

