### PR TITLE
CRAYSAT-1721: Fix YAML file path config-docker-sat.sh script

### DIFF
--- a/docker_scripts/config-docker-sat.sh
+++ b/docker_scripts/config-docker-sat.sh
@@ -29,7 +29,7 @@ SATMANDIR=/usr/share/man/man8
 
 METAL_PROVISION_REPO="https://github.com/Cray-HPE/metal-provision.git"
 METAL_PROVISION_DIR="metal-provision"
-METAL_PROVISION_BASE_PACKAGES_PATH="roles/node-images-ncn-common/vars/packages/suse.yml"
+METAL_PROVISION_BASE_PACKAGES_PATH="roles/node_images_ncn_common/vars/packages/suse.yml"
 METAL_PROVISION_BRANCH="main"
 
 # create logging directory


### PR DESCRIPTION
## Summary and Scope

Update the location of the suse.yml file in the metal-provision repository containing the kubectl version.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CRAYSAT-1721](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1721)