### PR TITLE
CRAYSAT-654: Remove cronjob recreate step from cabinet-power stage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added functionality to `sat bootsys boot --stage platform-services` to
+  automatically recreate all Kubernetes cronjobs which are not being scheduled
+  due to missing too many scheduled start times.
 - Added functionality to `sat bootsys boot --stage cabinet-power` to
-  automatically recreate Kubernetes cronjobs which are not being scheduled due
-  to missing too many scheduled start times.
+  automatically recreate the `hms-discovery` cronjob if it fails to be
+  scheduled on time.
 
 ### Fixed
 - Fixed an unnecessary CAPMC API request and a confusing warning message during

--- a/sat/cli/bootsys/cabinet_power.py
+++ b/sat/cli/bootsys/cabinet_power.py
@@ -206,13 +206,6 @@ def do_cabinets_power_on(args):
                      f'rescheduled after resume: {err}')
         raise SystemExit(1)
 
-    LOGGER.info('Recreating cronjobs which have failed to have been scheduled on time.')
-    try:
-        batch_api = load_kube_api(api_cls=BatchV1Api)
-        recreate_namespaced_stuck_cronjobs(batch_api, 'services')
-    except ConfigException as err:
-        LOGGER.warning('Could not load Kubernetes configuration: %s', err)
-
     hms_discovery_scheduled = hms_discovery_waiter.wait_for_completion()
     if not hms_discovery_scheduled:
         LOGGER.error(f'The {HMSDiscoveryCronJob.FULL_NAME} was not scheduled '


### PR DESCRIPTION
## Summary and Scope

This change removes recreating all "stuck" cronjobs from the cabinet-power stage since there was specific functionality added to recreate the hms-discovery cronjob in that stage, which would cause the cronjob to be recreated unconditionally. This removes this recreating step from cabinet-power so that the bootsys behavior is in line with docs-csm.


## Issues and Related PRs

* Resolves [CRAYSAT-654](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-654)

## Testing

### Tested on:

  * Local development environment

### Test description:

Run unit tests.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

