### PR TITLE
CRAYSAT-1703: Support multitenancy for SAT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added functionality to `sat bootsys boot --stage cabinet-power` to
   automatically recreate the `hms-discovery` cronjob if it fails to be
   scheduled on time.
+- Added support for multitenancy, which can be configured with the
+  `api_gateway.tenant_name` config file option and `--tenant-name` command line
+  option.
 
 ### Fixed
 - Fixed an unnecessary CAPMC API request and a confusing warning message during

--- a/sat/config.py
+++ b/sat/config.py
@@ -101,6 +101,7 @@ SAT_CONFIG_SPEC = {
         'username': OptionSpec(str, getpass.getuser, None, 'username'),
         'token_file': OptionSpec(str, '', None, 'token_file'),
         'api_timeout': OptionSpec(int, 60, None, 'api_timeout'),
+        'tenant_name': OptionSpec(str, '', None, 'tenant_name'),
     },
     'bos': {
         'api_version': OptionSpec(str, 'v2', validate_bos_api_version, 'bos_version')

--- a/sat/parser.py
+++ b/sat/parser.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -167,6 +167,12 @@ def create_parent_parser():
              'complete before considering them failed.',
         metavar='TIMEOUT',
         type=int)
+
+    parser.add_argument(
+        '--tenant-name',
+        help='The name of the tenant against which to run administrative commands.',
+        metavar='NAME',
+    )
 
     subparsers = parser.add_subparsers(metavar='command', dest='command')
     sat.cli.build_out_subparsers(subparsers)

--- a/sat/session.py
+++ b/sat/session.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -32,6 +32,7 @@ from csm_api_client.session import UserSession
 from sat.config import get_config_value
 from sat.util import get_resource_filename
 
+TENANT_HEADER_NAME = 'Cray-Tenant-Name'
 
 LOGGER = logging.getLogger(__name__)
 
@@ -50,6 +51,7 @@ class SATSession(UserSession):
         host = get_config_value('api_gateway.host')
         cert_verify = get_config_value('api_gateway.cert_verify')
         username = get_config_value('api_gateway.username')
+        tenant_name = get_config_value('api_gateway.tenant_name')
 
         token_filename = get_config_value('api_gateway.token_file')
         if token_filename == '':
@@ -58,6 +60,8 @@ class SATSession(UserSession):
                 '{}.{}.json'.format(host_as_filename, username), 'tokens')
 
         super().__init__(host, cert_verify, username, token_filename)
+        if tenant_name:
+            self.session.headers[TENANT_HEADER_NAME] = tenant_name
 
         if not (self.token or no_unauth_warn):
             LOGGER.warning('Session is not authenticated. ' +

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2021, 2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -24,8 +24,12 @@
 """
 A helper subclass of TestCase that implements additional assertions.
 """
+import contextlib
+import copy
 import re
 import unittest
+
+from sat.util import deep_update_dict
 
 
 class ExtendedTestCase(unittest.TestCase):
@@ -89,3 +93,22 @@ class ExtendedTestCase(unittest.TestCase):
                 return
         self.fail("Regex '{}' does not match any of the elements in "
                   "the given container.".format(regex_str))
+
+
+@contextlib.contextmanager
+def config(sections):
+    """Context manager which can be used to supply a custom config inside the context.
+
+    Args:
+        sections (dict): a nested dict representing the parsed structure of the
+            config file
+    """
+    import sat.config
+    try:
+        _saved = sat.config.CONFIG.sections
+        new = copy.deepcopy(sat.config.CONFIG.sections)
+        deep_update_dict(new, sections)
+        sat.config.CONFIG.sections = new
+        yield
+    finally:
+        sat.config.CONFIG.sections = _saved

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,0 +1,50 @@
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""
+Tests for SAT session handling
+"""
+
+import unittest
+
+from sat.config import load_config
+from sat.session import TENANT_HEADER_NAME, SATSession
+from tests.common import config
+
+
+class TestSessionTenantHandling(unittest.TestCase):
+    def setUp(self):
+        load_config()
+
+    def test_cray_tenant_name_is_set_properly(self):
+        """Test that the Cray-Tenant-Name header is set from the config"""
+        tenant_name = 'some_tenant_name'
+        with config({'api_gateway': {'tenant_name': tenant_name}}):
+            s = SATSession()
+            self.assertEqual(s.session.headers[TENANT_HEADER_NAME], tenant_name)
+
+    def test_cray_tenant_name_not_set(self):
+        """Test that the Cray-Tenant-Name header is not set when not configured"""
+        with config({'api_gateway': {'tenant_name': ''}}):
+            s = SATSession()
+            self.assertIsNone(s.session.headers.get(TENANT_HEADER_NAME))


### PR DESCRIPTION
## Summary and Scope

This change adds a config file option and corresponding command line option to add multitenancy support to SAT. This amounts to sending the configured tenant name as the value of the `Cray-Tenant-Name` header in each request.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CRAYSAT-1703](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1703)

## Testing

### Tested on:

  * Virtual Shasta

### Test description:
Run `sat status --bos-fields` commands with special debug logger and inspect the headers supplied. Run unit tests.

Test script: https://gist.github.com/jack-stanek-hpe/7ab54eaa4a46e77c050d01be6db7ca1d


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

