### PR TITLE
CRAYSAT-1722: Speed up known_hosts loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - The ability to specify the architecture for BOS session templates, either
       at the top level or per boot set
 
+### Fixed
+- Fixed extreme slowness with the `sat bootsys shutdown --stage
+  platform-services` command when a large SSH `known_hosts` file is in use.
+
 ## [3.23.0] - 2023-06-08
 
 ### Added

--- a/sat/cli/bootsys/etcd.py
+++ b/sat/cli/bootsys/etcd.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021, 2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -52,11 +52,13 @@ class EtcdInactiveFailure(EtcdSnapshotFailure):
     pass
 
 
-def save_etcd_snapshot_on_host(hostname):
+def save_etcd_snapshot_on_host(hostname, host_keys=None):
     """Connect to the given host and save an etcd snapshot to a file.
 
     Args:
         hostname (str): the hostname to connect to
+        host_keys (paramiko.HostKeys or None): the hostkeys to use when
+            connecting over SSH
 
     Raises:
         EtcdInactiveFailure: if the etcd service is inactive, indicating that
@@ -64,7 +66,7 @@ def save_etcd_snapshot_on_host(hostname):
         EtcdSnapshotFailure: if there is a failure to create the directory for
             the snapshot or a failure to create the snapshot
     """
-    ssh_client = get_ssh_client()
+    ssh_client = get_ssh_client(host_keys=host_keys)
 
     try:
         ssh_client.connect(hostname)

--- a/sat/cli/bootsys/hostkeys.py
+++ b/sat/cli/bootsys/hostkeys.py
@@ -1,0 +1,79 @@
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""
+Support for filtering large host keys files
+"""
+
+import tempfile
+
+from paramiko import HostKeys
+from paramiko.hostkeys import HostKeyEntry
+
+
+class FilteredHostKeys(HostKeys):
+    """
+    Host keys loader which filters all hosts except the specified ones.
+
+    This is needed to speed up known_hosts file parsing as paramiko's implementation
+    (up to and including 3.2.0) has quadratic time complexity. To get around this,
+    we can hackily cut down a large known hosts file to just a few hosts in linear
+    time before parsing, which should help tremendously in the case of a very large
+    known_hosts file with non-hashed hostnames.
+    """
+    def __init__(self, filename=None, hostnames=None):
+        """Construct a FilteredHostKeys object.
+
+        Args:
+            filename (str): path to the known hosts file
+            hostnames ([str]): list of hostnames for which to load host keys from the
+                known_hosts file
+        """
+        self.hostnames = hostnames
+        super().__init__(filename)
+
+    def load(self, filename):
+        """Load known hosts from the specified known_hosts file.
+
+        Args:
+            filename (str): path to the known_hosts file
+        """
+        if not self.hostnames:
+            return super().load(filename)
+
+        with open(filename) as known_hosts, \
+                tempfile.NamedTemporaryFile(mode='w+') as tmp_known_hosts:
+            for line in known_hosts:
+                entry = HostKeyEntry.from_line(line)
+                if any(hn in entry.hostnames for hn in self.hostnames):
+                    tmp_known_hosts.write(entry.to_line())
+            tmp_known_hosts.flush()
+            super().load(tmp_known_hosts.name)
+
+    def save(self, filename):
+        """(Don't) save the known_hosts file.
+
+        This is a no-op since we don't want to accidentally destructively
+        modify the user's known hosts file.
+        """
+        return

--- a/sat/cli/bootsys/util.py
+++ b/sat/cli/bootsys/util.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2021, 2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -25,12 +25,12 @@
 Generic common utilities for the bootsys subcommand.
 """
 
-from collections import defaultdict
 import logging
 import re
+from collections import defaultdict
 
-from paramiko import SSHClient, WarningPolicy
 import yaml
+from paramiko import SSHClient, WarningPolicy
 
 from sat.util import pester_choices
 
@@ -215,7 +215,7 @@ def get_and_verify_ncn_groups(excluded_ncns=None):
     return incl_ncns_by_subrole
 
 
-def get_ssh_client():
+def get_ssh_client(host_keys=None):
     """Get a paramiko SSH client.
 
     Returns:
@@ -223,6 +223,8 @@ def get_ssh_client():
         missing host keys set to warn rather than fail.
     """
     ssh_client = SSHClient()
+    if host_keys is not None:
+        ssh_client._system_host_keys = host_keys
     ssh_client.load_system_host_keys()
     ssh_client.set_missing_host_key_policy(WarningPolicy)
 

--- a/tests/cli/bootsys/test_etcd.py
+++ b/tests/cli/bootsys/test_etcd.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021, 2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -30,11 +30,8 @@ from unittest import mock
 
 from paramiko import SSHException
 
-from sat.cli.bootsys.etcd import (
-    save_etcd_snapshot_on_host,
-    EtcdInactiveFailure,
-    EtcdSnapshotFailure
-)
+from sat.cli.bootsys.etcd import (EtcdInactiveFailure, EtcdSnapshotFailure,
+                                  save_etcd_snapshot_on_host)
 
 
 class TestSaveEtcdSnapshotOnHost(unittest.TestCase):
@@ -89,7 +86,7 @@ class TestSaveEtcdSnapshotOnHost(unittest.TestCase):
 
     def assert_ssh_client_connect(self):
         """Assert the SSHClient was created and connected to the hostname."""
-        self.mock_get_ssh_client.assert_called_once_with()
+        self.mock_get_ssh_client.assert_called_once()
         self.mock_ssh_client.connect.assert_called_once_with(self.hostname)
 
     def assert_exec_commands(self):

--- a/tests/cli/bootsys/test_hostkeys.py
+++ b/tests/cli/bootsys/test_hostkeys.py
@@ -1,0 +1,61 @@
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""
+Unit tests for the sat.cli.bootsys.hostkeys module.
+"""
+import os
+import tempfile
+import unittest
+
+from sat.cli.bootsys.hostkeys import FilteredHostKeys
+
+host_keys = b"""\
+host1,host1-alt ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILDDtImwzXDR/R6rYn56D1ycKuGRPx8mCLqqAVM/60z+
+host10,host10-alt ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOeEKLY8+G+TPZirATL6JlFYFw46KLdvOkxpJPlnt30E
+host100,host100-alt ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAN65RI9aIzKbBmreFlk7jB63+RAsWZ/CXDqX/h/Hyzs
+"""
+
+
+class TestFilteredHostKeys(unittest.TestCase):
+    """Tests for the FilteredHostKeys class"""
+    def setUp(self):
+        with tempfile.NamedTemporaryFile(delete=False) as tmp:
+            tmp.write(host_keys)
+            self.known_hosts_path = tmp.name
+
+    def tearDown(self):
+        os.unlink(self.known_hosts_path)
+
+    def test_filtered_host_keys_loading(self):
+        """Test filtering a known_hosts file"""
+        hk = FilteredHostKeys(filename=self.known_hosts_path, hostnames=['host1'])
+        self.assertIn('host1', hk)
+        for host in ['host10', 'host100']:
+            self.assertNotIn(host, hk.keys())
+
+    def test_unfiltered_host_keys_loading(self):
+        """Test that filtering is opt-in"""
+        hk = FilteredHostKeys(filename=self.known_hosts_path)
+        for host in ['host1', 'host10', 'host100']:
+            self.assertIn(host, hk)


### PR DESCRIPTION
## Summary and Scope

This change filters the known_hosts file prior to loading it into a paramiko SSHClient object in order to improve performance. Paramiko's implementation of known_hosts parsing has quadratic time complexity, which causes very poor performance in general when a large known_hosts file is used. In our particular case, it was causing additional slowdown due to the GIL since we were using the `threading` module and parsing the known hosts file several times on different threads, causing GIL thrashing.

To address this, this change pre-filters the known_hosts file to just the hosts needed in a given stage, and also changes the container stop threads to use `multiprocessing` instead, so that multiple SSH connections can occur simultaneously without compromising (as much) performance.


## Issues and Related PRs

* Resolves [CRAYSAT-1710](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1710)

## Testing

### Tested on:

  * Local development environment

### Test description:
Run unit tests. Use benchmark test harness to check runtimes of filtered host keys to ensure performance is at least 1 order of magnitude improved.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

