### PR TITLE
CRAYSAT-1733: Adjust bootprep multi-arch feature to match BOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,8 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
       architecture of the image or recipe in IMS
     - The ability to combine multiple base image or recipe filters when
       specifying a base image from a product
-    - The ability to specify the architecture for BOS session templates, either
-      at the top level or per boot set
+    - The ability to specify the architecture for each boot set in a BOS
+      session template
 
 ### Fixed
 - Fixed extreme slowness with the `sat bootsys shutdown --stage

--- a/sat/cli/bootprep/input/session_template.py
+++ b/sat/cli/bootprep/input/session_template.py
@@ -98,12 +98,6 @@ class InputSessionTemplate(BaseInputItem):
         return self.data['configuration']
 
     @property
-    @jinja_rendered
-    def arch(self):
-        """str or None: the architecture at the top level of the session template or None"""
-        return self.data.get('arch')
-
-    @property
     def boot_sets(self):
         """dict: the boot sets specified for the session template"""
         # the 'bos_parameters' property is required, and 'boot_sets' is required within that
@@ -165,9 +159,6 @@ class InputSessionTemplate(BaseInputItem):
             'name': self.name,
             'boot_sets': {}
         }
-
-        if self.arch:
-            api_data['arch'] = self.arch
 
         for boot_set_name, boot_set_data in self.boot_sets.items():
             # Must deepcopy to avoid every boot set sharing the same dict

--- a/sat/data/schema/bootprep_schema.yaml
+++ b/sat/data/schema/bootprep_schema.yaml
@@ -462,14 +462,6 @@ properties:
 
             Supports rendering as a Jinja template.
           type: string
-        arch:
-          description: >
-            The architecture of the nodes that should be targeted by this BOS
-            session template. Can be overridden on a per-boot-set basis.
-
-            If omitted, all architectures will be targeted.
-          type: string
-          examples: ['x86_64', 'aarch64']
         bos_parameters:
           description: >
             The parameters specified here will be passed through to BOS.
@@ -496,12 +488,17 @@ properties:
                   arch:
                     description: >
                       The architecture of the nodes that should be targeted by this
-                      boot set. Overrides the architecture specified at the top level
-                      of the session template, if any.
+                      boot set. The valid values accepted by BOS are the same as the
+                      valid values in the components array returned by the Hardware
+                      State Manager (HSM) API's /State/Components endpoint.
 
-                      If omitted, all architectures will be targeted.
+                      If omitted, BOS will treat this as a boot set targeting nodes
+                      with architecture X86. This is done to preserve functionality
+                      of BOS session templates which were created prior to the addition
+                      of multi-architecture support in BOS.
                     type: string
-                    examples: ['x86_64', 'aarch64']
+                    enum: ['X86', 'ARM', 'Other', 'Unknown']
+                    default: 'X86'
                   kernel_parameters:
                     description: >
                       Starting in CSM 1.0, which is to be released in Shasta v1.5,

--- a/tests/cli/bootprep/input/test_session_template.py
+++ b/tests/cli/bootprep/input/test_session_template.py
@@ -83,7 +83,7 @@ class TestInputSessionTemplateV2(unittest.TestCase):
 
     def get_input_and_expected_bos_data(self, name='my-session-template',
                                         image_name='my-image', configuration='my-config',
-                                        arch=None, arch_by_bootset=None):
+                                        arch_by_bootset=None):
         """Get input data and the expected BOS request payload with given parameters"""
         if not arch_by_bootset:
             arch_by_bootset = {'compute': None}
@@ -120,10 +120,6 @@ class TestInputSessionTemplateV2(unittest.TestCase):
             'boot_sets': bos_payload_bootsets
         }
 
-        if arch:
-            input_data['arch'] = arch
-            bos_payload['arch'] = arch
-
         return input_data, bos_payload
 
     def test_get_create_item_data_no_arch(self):
@@ -138,42 +134,11 @@ class TestInputSessionTemplateV2(unittest.TestCase):
         self.assertEqual(expected_bos_data,
                          input_session_template.get_create_item_data())
 
-    def test_get_create_item_data_top_level_arch(self):
-        """Test get_create_item_data method with architecture specified at top level"""
-        input_data, expected_bos_data = self.get_input_and_expected_bos_data(arch='aarch64')
-
-        input_session_template = self.simplified_session_template_v2(
-            input_data, self.input_instance, 0, self.jinja_env,
-            self.bos_client, self.cfs_client, self.ims_client
-        )
-
-        self.assertEqual(expected_bos_data,
-                         input_session_template.get_create_item_data())
-
     def test_get_create_item_data_arch_per_bootset(self):
         """Test get_create_item_data with a different arch per boot set"""
         input_data, expected_bos_data = self.get_input_and_expected_bos_data(
             arch_by_bootset={'compute_x86_64': 'x86_64',
                              'compute_aarch64': 'aarch64'}
-        )
-
-        input_session_template = self.simplified_session_template_v2(
-            input_data, self.input_instance, 0, self.jinja_env,
-            self.bos_client, self.cfs_client, self.ims_client
-        )
-
-        self.assertEqual(expected_bos_data,
-                         input_session_template.get_create_item_data())
-
-    def test_get_create_item_data_arch_with_bootset_override(self):
-        """Test get_create_item_data with a top-level arch overridden in one boot set."""
-        input_data, expected_bos_data = self.get_input_and_expected_bos_data(
-            arch='x86_64',
-            arch_by_bootset={
-                # Results in it not being specified in the input data for this boot set
-                'compute_x86_64': None,
-                # Results in it being specified in the input data for this boot set
-                'compute_aarch64': 'aarch64'}
         )
 
         input_session_template = self.simplified_session_template_v2(

--- a/tests/cli/bootprep/test_validate.py
+++ b/tests/cli/bootprep/test_validate.py
@@ -583,35 +583,31 @@ class TestValidateInstance(ExtendedTestCase):
         }
         self.assert_valid_instance(instance)
 
-    def test_valid_session_template_top_level_arch(self):
-        """Valid session template with arch at the top level"""
-        session_template = deepcopy(VALID_SESSION_TEMPLATE_COMPUTE_V2)
-        session_template['arch'] = 'aarch64'
-        instance = {
-            'session_templates': [session_template]
-        }
-        self.assert_valid_instance(instance)
-
     def test_valid_session_template_boot_set_arch(self):
-        """Valid session template with arch at the boot-set level"""
+        """Valid session template with a valid arch specified for a boot set"""
         session_template = deepcopy(VALID_SESSION_TEMPLATE_COMPUTE_V2)
-        session_template['bos_parameters']['boot_sets']['compute']['arch'] = 'x86_64'
-        instance = {
-            'session_templates': [session_template]
-        }
-        self.assert_valid_instance(instance)
+        valid_arch_vals = ['X86', 'ARM', 'Other', 'Unknown']
+        for valid_arch in valid_arch_vals:
+            session_template['bos_parameters']['boot_sets']['compute']['arch'] = valid_arch
+            instance = {
+                'session_templates': [session_template]
+            }
+            self.assert_valid_instance(instance)
 
-    def test_valid_session_template_arch_at_both_levels(self):
-        """Valid session template with arch at both the top level and boot-set level"""
+    def test_invalid_session_template_boot_set_arch(self):
+        """Invalid session template with an invalid arch specified for a boot set"""
         session_template = deepcopy(VALID_SESSION_TEMPLATE_COMPUTE_V2)
-        session_template['arch'] = 'x86_64'
-        aarch64_bootset = deepcopy(session_template['bos_parameters']['boot_sets']['compute'])
-        aarch64_bootset['arch'] = 'aarch64'
-        session_template['bos_parameters']['boot_sets']['compute_aarch64'] = aarch64_bootset
-        instance = {
-            'session_templates': [session_template]
-        }
-        self.assert_valid_instance(instance)
+        invalid_arch_vals = ['aarch64', 'x86_64']
+        for invalid_arch in invalid_arch_vals:
+            session_template['bos_parameters']['boot_sets']['compute']['arch'] = invalid_arch
+            instance = {
+                'session_templates': [session_template]
+            }
+            expected_errs = [
+                (('session_templates', 0, 'bos_parameters', 'boot_sets', 'compute', 'arch'),
+                 f"'{invalid_arch}' is not one of", 1)
+            ]
+            self.assert_invalid_instance(instance, expected_errs)
 
     def test_valid_full_instance(self):
         """Valid instance with configurations, images, and session_templates"""

--- a/tests/common.py
+++ b/tests/common.py
@@ -91,8 +91,10 @@ class ExtendedTestCase(unittest.TestCase):
         for item in container:
             if regex.match(item):
                 return
-        self.fail("Regex '{}' does not match any of the elements in "
-                  "the given container.".format(regex_str))
+
+        container_elements = '\n'.join(container)
+        self.fail(f"Regex ({regex_str}) does not match any of the string "
+                  f"elements in the given container:\n{container_elements}")
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
## Summary and Scope

Adjust the implementation of `sat bootprep` support for multiple
architectures to match the implementation of BOS. This includes:

* Remove the ability to specify the `arch` at the top level of the BOS
  session template. BOS will not support this for now.
* Change the guidance in the `sat bootprep` input file schema to say
  that the BOS session template architecture values should match what
  HSM returns for its components API endpoint.
* Add an enum for validation of the `arch` field in a boot set in a BOS
  session template to provide clear guidance to the user when an invalid
  value is used.
* Update the description of BOS's default behavior when no value is
  specified for the `arch` field. It now treats this as "X86".

Update the unit tests accordingly for the above changes.

Note that technically, this is a backwards-incompatible schema change,
and the bootprep input file schema's version would normally need to be
updated accordingly. However, that previous version was not part of a
stable sat build yet, so it's preferable not to unnecessarily bump the
schema major version and unnecessarily cause issues for existing input
files.

Add more detail when the `assert_regex_matches_element` method of the
`ExtendedTestCase` class fails. Include the elements in the container,
so that we can see which elements are actually present and being
compared against the regular expression.

This was useful in debugging an incorrect unit test in
`tests.cli.bootprep.test_validate`.

## Issues and Related PRs

* Resolves [CRAYSAT-1733](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1733)

## Testing

### Tested on:

   * Local development environment
  * mug

### Test description:

Unit tests pass. Tested creation of a BOS session template in dry-run
mode on mug (TODO).

Built bootprep input file schema documentation with `sat bootprep
generate-docs` and viewed in browser.

Tested with an intentional failure of a unit test in `test_validate` and
got output like the following:

```
AssertionError: Regex (    \['images'\]\[0\]\['bos_parameters'\]\['boot_sets'\]\['compute'\]\['arch'\]:.*'aarch64' is not one of) does not match any of the string elements in the given container:
Input file is invalid with the following validation errors:
    ['session_templates'][0]['bos_parameters']['boot_sets']['compute']['arch']: 'aarch64' is not one of ['X86', 'ARM', 'Other', 'Unknown']
```

## Risks and Mitigations

Low risk. Just updating to match BOS behavior.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

