### PR TITLE
CRAYSAT-1735: Bump cryptography and requests (merged dependabot PRs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed extreme slowness with the `sat bootsys shutdown --stage
   platform-services` command when a large SSH `known_hosts` file is in use.
 
+### Security
+- Update the version of cryptography from 39.0.1 to 41.0.0 to address
+  CVE-2023-2650.
+- Update the version of requests from 2.27.0 to 2.31.0 to address
+  CVE-2023-32681.
+
 ## [3.23.0] - 2023-06-08
 
 ### Added

--- a/requirements-dev.lock.txt
+++ b/requirements-dev.lock.txt
@@ -50,7 +50,7 @@ pyrsistent==0.18.1
 python-dateutil==2.8.2
 pytz==2021.3
 PyYAML==5.4.1
-requests==2.27.1
+requests==2.31.0
 requests-oauthlib==1.3.1
 rsa==4.8
 s3transfer==0.5.2

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -41,7 +41,7 @@ pyrsistent==0.18.1
 python-dateutil==2.8.2
 pytz==2021.3
 PyYAML==5.4.1
-requests==2.27.1
+requests==2.31.0
 requests-oauthlib==1.3.1
 rsa==4.8
 s3transfer==0.5.2


### PR DESCRIPTION
## Summary and Scope

Combine https://github.com/Cray-HPE/sat/pull/136 and https://github.com/Cray-HPE/sat/pull/134 into one PR.

## Issues and Related PRs

* Resolves [CRAYSAT-1735](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1735)

## Testing

### Tested on:

  * `mug`

### Test description:

To quickly do a regression test of the new libraries:
  * Load updated image to system, run `sat status` to check that
    requests are made to the CSM APIs correctly
  * In a `sat bash` session, launch a Python interpreter and use
    the `sat.cli.bootsys.util.get_ssh_client()` function to test
    that Paramiko clients work properly

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

