### PR TITLE
CRAYSAT-1723: Use lts/csm-1.5 branch of metal-provision repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.23.1] - 2023-06-22
+
+### Changed
+- Changed docker image build to query lts/csm-1.5 branch of metal-provision
+  repo for the kubectl version to use in the cray-sat container.
+
 ## [3.23.0] - 2023-06-08
 
 ### Added

--- a/docker_scripts/config-docker-sat.sh
+++ b/docker_scripts/config-docker-sat.sh
@@ -30,7 +30,7 @@ SATMANDIR=/usr/share/man/man8
 METAL_PROVISION_REPO="https://github.com/Cray-HPE/metal-provision.git"
 METAL_PROVISION_DIR="metal-provision"
 METAL_PROVISION_BASE_PACKAGES_PATH="roles/node_images_ncn_common/vars/packages/suse.yml"
-METAL_PROVISION_BRANCH="main"
+METAL_PROVISION_BRANCH="lts/csm-1.5"
 
 # create logging directory
 if [ ! -d "$LOGDIR" ]; then


### PR DESCRIPTION



## Summary and Scope
Use the lts/csm-1.5 branch of metal-provision so that we are using CSM 1.5's version of kubectl, and so that the integration version doesn't go past the version for 1.5.

## Issues and Related PRs

* Resolves [CRAYSAT-1723](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1723)

## Testing

### Tested on:
  * Local development environment

### Test description:

Build cray-sat image.



## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

