### PR TITLE
CRAYSAT-1723, CRAYSAT-1738: Backport `lts/csm-1.5` change and declare 3.24.0 version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - The ability to specify the architecture for BOS session templates, either
       at the top level or per boot set
 
+### Changed
+- Changed docker image build to query lts/csm-1.5 branch of metal-provision
+  repo for the kubectl version to use in the cray-sat container.
+
 ### Fixed
 - Fixed extreme slowness with the `sat bootsys shutdown --stage
   platform-services` command when a large SSH `known_hosts` file is in use.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.24.0] - 06-23-2023
 
 ### Added
 - Added support for multiple architectures to `sat bootprep`, which includes the

--- a/docker_scripts/config-docker-sat.sh
+++ b/docker_scripts/config-docker-sat.sh
@@ -30,7 +30,7 @@ SATMANDIR=/usr/share/man/man8
 METAL_PROVISION_REPO="https://github.com/Cray-HPE/metal-provision.git"
 METAL_PROVISION_DIR="metal-provision"
 METAL_PROVISION_BASE_PACKAGES_PATH="roles/node_images_ncn_common/vars/packages/suse.yml"
-METAL_PROVISION_BRANCH="main"
+METAL_PROVISION_BRANCH="lts/csm-1.5"
 
 # create logging directory
 if [ ! -d "$LOGDIR" ]; then


### PR DESCRIPTION
## Summary and Scope

Backport the change to get the `kubectl` version from the `lts/csm-1.5` branch of the `metal-provision` repo, and declare version 3.24.0.

## Issues and Related PRs

* Resolves [CRAYSAT-1723](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1723)
* Partially resolves [CRAYSAT-1738](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1738)


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

