### PR TITLE
CRAYSAT-1738: Fix date in 3.24.0 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.24.0] - 06-23-2023
+## [3.24.0] - 2023-06-23
 
 ### Added
 - Added support for multiple architectures to `sat bootprep`, which includes the


### PR DESCRIPTION
The date must be in format YYYY-MM-DD in order for the `changelog.py` script to correctly identify the latest release version. Currently, it identifies 3.23.0 as the latest version, whis is incorrect.

Test Description:
Ran `./bin/changelog.py CHANGELOG.md` and confirmed it displayed 3.24.0