### PR TITLE
CRAYSAT-1741: Add `sat bootprep` DKMS support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.25.0] - 2023-06-26
+
+### Added
+- Added support for specifying new DKMS special parameter in CFS configuration
+  layers created by `sat bootprep`
+
 ## [3.24.0] - 2023-06-23
 
 ### Added

--- a/sat/cli/bootprep/input/configuration.py
+++ b/sat/cli/bootprep/input/configuration.py
@@ -41,6 +41,7 @@ from sat.cli.bootprep.input.base import (
     jinja_rendered,
 )
 from sat.config import get_config_value
+from sat.util import get_val_by_path, set_val_by_path
 
 LOGGER = logging.getLogger(__name__)
 
@@ -54,11 +55,13 @@ class InputConfigurationLayer(ABC):
     }
     # Mapping from CFS property name to class property name for optional properties
     # If the property value is None, the property will be omitted from the CFS layer
+    # Nested CFS properties are specified by separating each property name with '.'
     OPTIONAL_CFS_PROPERTIES = {
         'branch': 'branch',
         'commit': 'commit',
         'name': 'name',
-        'playbook': 'playbook'
+        'playbook': 'playbook',
+        'specialParameters.imsRequireDkms': 'ims_require_dkms'
     }
 
     # CRAYSAT-1174: Specifying a 'branch' in a CFS configuration layer is not
@@ -91,6 +94,11 @@ class InputConfigurationLayer(ABC):
     def name(self):
         """str or None: the name specified for the layer"""
         return self.layer_data.get('name')
+
+    @property
+    def ims_require_dkms(self):
+        """str or None: whether to enable DKMS when this layer customizes an IMS image"""
+        return get_val_by_path(self.layer_data, 'special_parameters.ims_require_dkms')
 
     @property
     @abstractmethod
@@ -130,7 +138,7 @@ class InputConfigurationLayer(ABC):
 
             property_value = getattr(self, self_property)
             if property_value is not None:
-                cfs_layer_data[cfs_property] = property_value
+                set_val_by_path(cfs_layer_data, cfs_property, property_value)
 
         return cfs_layer_data
 

--- a/sat/data/schema/bootprep_schema.yaml
+++ b/sat/data/schema/bootprep_schema.yaml
@@ -41,7 +41,7 @@ $schema: "https://json-schema.org/draft/2020-12/schema"
 # ... patch component when all input files that were valid under the old schema
 #     are still valid under the new schema
 #
-version: '1.0.5'
+version: '1.0.6'
 title: Bootprep Input File
 description: >
   A description of the set of CFS configurations to create, the set of IMS
@@ -80,7 +80,7 @@ properties:
         current version.
 
       - If the input version matches the current version, it is compatible.
-    default: '1.0.5'
+    default: '1.0.6'
     type: string
 
   configurations:
@@ -120,6 +120,8 @@ properties:
                   $ref: '#/$defs/CFSLayerName'
                 playbook:
                   $ref: '#/$defs/CFSLayerPlaybook'
+                special_parameters:
+                  $ref: '#/$defs/CFSLayerSpecialParameters'
                 git:
                   oneOf:
                   - description: >
@@ -155,6 +157,8 @@ properties:
                   $ref: '#/$defs/CFSLayerName'
                 playbook:
                   $ref: '#/$defs/CFSLayerPlaybook'
+                special_parameters:
+                  $ref: '#/$defs/CFSLayerSpecialParameters'
                 product:
                   oneOf:
                   - description: >
@@ -375,7 +379,6 @@ properties:
           configuration_group_names:
             $ref: '#/$defs/ImageConfigurationGroupNames'
 
-
   session_templates:
     description: The BOS session templates to create.
     type: array
@@ -587,6 +590,16 @@ $defs:
 
       Supports rendering as a Jinja template.
     type: string
+  CFSLayerSpecialParameters:
+    type: object
+    additionalProperties: false
+    properties:
+      ims_require_dkms:
+        description: >
+          If true, any image customization sessions that use this configuration will
+          enable DKMS in IMS.
+        type: boolean
+        default: false
   ImageName:
     description: >
       The name of the image that will be created in IMS. The image name

--- a/tests/cli/bootprep/input/test_configuration.py
+++ b/tests/cli/bootprep/input/test_configuration.py
@@ -212,7 +212,7 @@ class TestGitInputConfigurationLayer(TestInputConfigurationLayerBase):
         self.assertIsNone(layer.commit)
 
     def test_get_cfs_api_data_optional_properties(self):
-        """Test get_create_item_data method with all optional properties present."""
+        """Test get_create_item_data method with optional name and playbook properties present."""
         branch_layer = GitInputConfigurationLayer(self.branch_layer_data, self.jinja_env)
         commit_layer = GitInputConfigurationLayer(self.commit_layer_data, self.jinja_env)
         subtests = (('branch', branch_layer), ('commit', commit_layer))
@@ -226,6 +226,23 @@ class TestGitInputConfigurationLayer(TestInputConfigurationLayerBase):
                     expected[key] = value
                 del expected['git']
                 self.assertEqual(expected, layer.get_cfs_api_data())
+
+    def test_get_cfs_api_data_special_parameters(self):
+        """Test get_create_item_data method with special_parameters present."""
+        layer_data = deepcopy(self.branch_layer_data)
+        require_dkms = True
+        layer_data['special_parameters'] = {'ims_require_dkms': require_dkms}
+        layer = GitInputConfigurationLayer(layer_data, self.jinja_env)
+
+        expected_api_data = deepcopy(layer_data)
+        # Move these values to where CFS expects them
+        expected_api_data['cloneUrl'] = expected_api_data['git']['url']
+        expected_api_data['branch'] = expected_api_data['git']['branch']
+        del expected_api_data['git']
+        expected_api_data['specialParameters'] = {'imsRequireDkms': require_dkms}
+        del expected_api_data['special_parameters']
+
+        self.assertEqual(expected_api_data, layer.get_cfs_api_data())
 
     def test_commit_property_branch_commit_lookup(self):
         """Test looking up commit hash from branch in VCS when branch not supported in CSM"""

--- a/tests/cli/bootprep/test_validate.py
+++ b/tests/cli/bootprep/test_validate.py
@@ -58,6 +58,9 @@ VALID_CONFIG_LAYER_PRODUCT_BRANCH = {
     'product': {
         'name': 'cos',
         'branch': 'integration'
+    },
+    'special_parameters': {
+        'ims_require_dkms': True
     }
 }
 
@@ -74,6 +77,9 @@ VALID_CONFIG_LAYER_GIT_COMMIT = {
     'git': {
         'url': 'https://api-gw-service-nmn.local/vcs/cray/analytics-config-management.git',
         'commit': '323fae03f4606ea9991df8befbb2fca795e648fa'
+    },
+    'special_parameters': {
+        'ims_require_dkms': True
     }
 }
 


### PR DESCRIPTION
## Summary and Scope

CFS has added a new property to CFS configuration layers that allows the layer to specify whether IMS should enable DKMS support when the configuration is applied to an image during image customization. CFS added the new property `imsRequireDkms` under the new property `specialParameters` in each CFS configuration layer.

The `sat bootprep` input file schema has been updated to add a new `ims_require_dkms` property under a new `special_parameters` property under each CFS configuration layer. This maintains as much consistency as possible with CFS while adhering to the naming convention used for properties in the `sat bootprep` input file schema.

Unit tests have been modified accordingly to test this new functionality.

## Issues and Related PRs

* Resolves [CRAYSAT-1741](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1741)

## Testing

### Tested on:

  * mug
  * Local development environment

### Test description:

Unit tests and pycodestyle pass.

Tested against a newer version of CFS deployed on mug to ensure this new version of `sat bootprep` can specify the new `imsRequireDkms` property in a CFS configuration layer. More details in the pull request.

## Risks and Mitigations

Low risk as it's just adding a new field to the bootprep input file schema.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
