### PR TITLE
CRAYSAT-956: Replace CAPMC calls with PCS calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.27.12] - 2024-04-14
+
+### Added
+- Added support for the Power Control Service (PCS). Functionality using CAPMC
+  was changed to use PCS instead.
+
 ## [3.27.11] - 2024-02-28
 
 ### Fixed

--- a/sat/apiclient/pcs.py
+++ b/sat/apiclient/pcs.py
@@ -1,0 +1,189 @@
+#
+# MIT License
+#
+# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+"""
+Basic client library for PCS.
+"""
+from collections import defaultdict
+
+from csm_api_client.service.gateway import APIError, APIGatewayClient
+from csm_api_client.service.hsm import HSMClient
+from sat.xname import XName
+
+
+class PCSError(APIError):
+    """An error occurred in PCS."""
+
+    def __init__(self, message, xname_errs=None):
+        """Create a new PCSError with the given message and info about the failing xnames.
+
+        Args:
+            message (str): the error message
+            xname_errs (list): a list of dictionaries representing the failures for
+                the individual components that failed. Each dict should have the
+                following keys:
+                    e: the error code
+                    err_msg: the error message
+                    xname: the actual xname which failed
+        """
+        self.message = message
+        self.xname_errs = xname_errs if xname_errs is not None else []
+        self.xnames = [xname_err['xname'] for xname_err in self.xname_errs
+                       if 'xname' in xname_err]
+
+    def __str__(self):
+        """Convert to str."""
+        if not self.xname_errs:
+            return self.message
+        else:
+            # A mapping from a tuple of (err_code, err_msg) to a list of xnames
+            # with that combination of err_code and err_msg.
+            xnames_by_err = defaultdict(list)
+            for xname_err in self.xname_errs:
+                xnames_by_err[(xname_err.get('e'), xname_err.get('err_msg'))].append(xname_err.get('xname'))
+
+            xname_err_summary = '\n'.join([f'xname(s) ({", ".join(xnames)}) failed with '
+                                           f'e={err_info[0]} and err_msg="{err_info[1]}"'
+                                           for err_info, xnames in xnames_by_err.items()])
+
+            return f'{self.message}\n{xname_err_summary}'
+
+
+class PCSClient(APIGatewayClient):
+    """Client for the Power Control Service."""
+    base_resource_path = 'power-control/v1/'
+
+    def set_xnames_power_state(self, xnames, power_state, force=False, recursive=False):
+        """Set the power state of the given xnames.
+
+        Args:
+            xnames (list): the xnames (str) to perform the power operation
+                against.
+            power_state (str): the desired power state. Either "on" or "off".
+            force (bool): if True, disable checks and force the power operation.
+            recursive (bool): if True, power on component and its descendants.
+            prereq (bool): if True, power on component and its ancestors.
+
+        Returns:
+            None
+
+        Raises:
+            ValueError: if the given `power_state` is not one of 'on' or 'off'
+            PCSError: if the attempt to power on/off the given xnames with PCS
+                fails. This exception contains more specific information about
+                the failure, which will be included in its __str__.
+        """
+        allowed_states = {'on', 'off', 'soft-off', 'soft-restart', 'hard-restart', 'init', 'force-off'}
+        power_state = power_state.lower()
+        if power_state not in allowed_states:
+            allowed_states_str = ", ".join("\"" + state + "\"" for state in allowed_states)
+            raise ValueError(f'Invalid power state {power_state} given. Must be {allowed_states_str}')
+
+        if force:
+            if power_state in {'off', 'soft-off'}:
+                power_state = 'force-off'
+            elif power_state == 'soft-restart':
+                power_state = 'hard-restart'
+
+        target_xnames = set(xnames)
+        if recursive:
+            hsm_client = HSMClient(self.session)
+
+            try:
+                for xname in xnames:
+                    xname_instance = XName(xname)
+                    if xname_instance.get_type() == 'Chassis':
+                        target_xnames.update(
+                            hsm_client.query_components(
+                                xname,
+                                type=['chassis', 'computemodule', 'node', 'routermodule']
+                            )
+                        )
+                    elif xname_instance.get_type() == 'ComputeModule':
+                        target_xnames.update(hsm_client.query_components(xname, type=['computemodule', 'node']))
+            except APIError as err:
+                raise PCSError(f'Could not retrieve descendant components for xnames: {err}') from err
+
+        params = {
+            'operation': power_state,
+            'taskDeadlineMinutes': -1,
+            'location': [
+                {'xname': xname}
+                for xname in target_xnames
+            ]
+        }
+        try:
+            self.post('transitions', json=params).json()
+        except APIError as err:
+            raise PCSError(f'Power {power_state} operation failed for xname(s).',
+                           xname_errs=xnames) from err
+
+    def get_xnames_power_state(self, xnames):
+        """Get the power state of the given xnames from PCS.
+
+        Args:
+            xnames (list): the xnames (str) to get power state for.
+
+        Returns:
+            dict: a dictionary whose keys are the power states and whose values
+                are lists of xnames in those power states.
+
+        Raises:
+            PCSError: if the request to get power state fails.
+        """
+        xnames = set(xnames)
+        try:
+            resp = self.get('power-status', params={'xname': xnames}).json().get('status')
+            nodes_by_power_state = defaultdict(list)
+            for node in resp:
+                nodes_by_power_state[node['powerState']].append(node['xname'])
+            return nodes_by_power_state
+        except APIError as err:
+            raise PCSError(f'Failed to get power state of xname(s): {", ".join(xnames)}') from err
+
+    def get_xname_power_state(self, xname):
+        """Get the power state of a single xname from PCS.
+
+        Args:
+            xname (str): the xname to get power state of
+
+        Returns:
+            str: the power state of the node
+
+        Raises:
+            PCSError: if the request to PCS fails or the expected information
+                is not returned by the PCS API.
+        """
+        try:
+            resp = self.get('power-status', params={'xname': xname}).json().get('status')
+        except APIError as err:
+            raise PCSError(f'Failed to get power state for xname {xname}: {err}') from err
+
+        matching_states = [node['powerState'] for node in resp
+                           if node['xname'] == xname]
+        if not matching_states:
+            raise PCSError(f'Unable to determine power state of {xname}. Not '
+                           f'present in response from PCS: {resp}')
+        elif len(matching_states) > 1:
+            raise PCSError(f'Unable to determine power state of {xname}. PCS '
+                           f'reported multiple power states: {", ".join(matching_states)}')
+        return matching_states.pop()

--- a/sat/cli/bootsys/cabinet_power.py
+++ b/sat/cli/bootsys/cabinet_power.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/sat/cli/bootsys/parser.py
+++ b/sat/cli/bootsys/parser.py
@@ -33,8 +33,8 @@ TimeoutSpec = namedtuple('TimeoutSpec', ['option_prefix', 'applicable_actions',
 
 
 TIMEOUT_SPECS = [
-    TimeoutSpec('capmc', ['shutdown'], 120,
-                'components reach powered off state after they are shutdown with CAPMC.'),
+    TimeoutSpec('pcs', ['shutdown'], 120,
+                'components reach powered off state after they are shutdown with PCS.'),
     TimeoutSpec('discovery', ['boot'], 600,
                 'compute modules reach the powered on state '
                 'after the HMS Discovery cronjob is resumed.'),

--- a/sat/cli/bootsys/parser.py
+++ b/sat/cli/bootsys/parser.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/sat/cli/swap/blade.py
+++ b/sat/cli/swap/blade.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/tests/apiclient/test_pcs.py
+++ b/tests/apiclient/test_pcs.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/tests/apiclient/test_pcs.py
+++ b/tests/apiclient/test_pcs.py
@@ -1,0 +1,99 @@
+#
+# MIT License
+#
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+"""
+Tests for the PCSClient class.
+"""
+
+import unittest
+from unittest.mock import MagicMock
+
+from csm_api_client.service.gateway import APIError
+
+from sat.apiclient.pcs import PCSClient, PCSError
+from sat.session import SATSession
+
+
+class TestPCSClient(unittest.TestCase):
+    """Tests for the PCSClient class"""
+
+    def setUp(self):
+        self.power_status_retval = {
+            'status': [
+                {
+                    'xname': 'x3000c0s0b0n0',
+                    'powerState': 'on',
+                    'managementState': 'available',
+                    'error': None,
+                    'supportedPowerTransitions': [
+                        'off',
+                        'soft-restart',
+                        'hard-restart',
+                        'force-off',
+                        'soft-off',
+                    ],
+                    'lastUpdated': '2022-08-24T16:45:53.953811137Z',
+                },
+                {
+                    'xname': 'x3000c0s0b0n1',
+                    'powerState': 'off',
+                    'managementState': 'available',
+                    'error': None,
+                    'supportedPowerTransitions': [
+                        'off',
+                        'soft-restart',
+                        'hard-restart',
+                        'force-off',
+                        'soft-off',
+                    ],
+                    'lastUpdated': '2022-08-24T16:45:53.953811137Z',
+                },
+            ],
+        }
+        self.mock_session = MagicMock(autospec=SATSession)
+        self.mock_session.session.get.return_value.json.return_value = self.power_status_retval
+        self.mock_session.host = 'api-service-gw-nmn.local'
+        self.pcs_client = PCSClient(self.mock_session)
+        self.xnames = [f'x3000c0s0b0n{n}' for n in [0, 1]]
+
+    def test_get_xname_power_state(self):
+        """Test getting power state for an xname"""
+        status = self.pcs_client.get_xname_power_state('x3000c0s0b0n0')
+        self.assertEqual(status, 'on')
+
+    def test_get_xname_power_state_fails(self):
+        """Test error handling when PCS can't be queried"""
+        self.mock_session.session.get.side_effect = APIError
+        with self.assertRaises(PCSError):
+            self.pcs_client.get_xname_power_state('x3000c0s0b0n0')
+
+    def test_get_xnames_power_state(self):
+        """Test getting power state for multiple xnames"""
+        status = self.pcs_client.get_xnames_power_state(self.xnames)
+        self.assertEqual(['x3000c0s0b0n0'], status['on'])
+        self.assertEqual(['x3000c0s0b0n1'], status['off'])
+
+    def test_get_xnames_power_state_fails(self):
+        """Test error handling when getting power state for multiple xnames"""
+        self.mock_session.session.get.side_effect = APIError
+        with self.assertRaises(PCSError):
+            self.pcs_client.get_xnames_power_state(self.xnames)

--- a/tests/cli/bootsys/test_cabinet_power.py
+++ b/tests/cli/bootsys/test_cabinet_power.py
@@ -42,8 +42,8 @@ class TestAirCooledCabinetsPowerOff(unittest.TestCase):
         patch_prefix = 'sat.cli.bootsys.cabinet_power'
         self.mock_sat_session = patch(f'{patch_prefix}.SATSession').start().return_value
         self.mock_hsm_client = patch(f'{patch_prefix}.HSMClient').start().return_value
-        self.mock_capmc_client = patch(f'{patch_prefix}.CAPMCClient').start().return_value
-        self.mock_capmc_waiter = patch(f'{patch_prefix}.CAPMCPowerWaiter').start().return_value
+        self.mock_pcs_client = patch(f'{patch_prefix}.PCSClient').start().return_value
+        self.mock_pcs_waiter = patch(f'{patch_prefix}.PCSPowerWaiter').start().return_value
 
         # Mock as if we have nodes in slots 1-15 as Management nodes, and the node in slot 17 not
         self.mock_river_nodes = [f'x3000c0s{slot}b0n0' for slot in [1, 3, 5, 7, 9, 11, 13, 15, 17]]
@@ -62,7 +62,7 @@ class TestAirCooledCabinetsPowerOff(unittest.TestCase):
                 return []
 
         self.mock_hsm_client.get_component_xnames.side_effect = mock_get_component_xnames
-        self.mock_capmc_waiter.wait_for_completion.return_value = self.timed_out_xnames
+        self.mock_pcs_waiter.wait_for_completion.return_value = self.timed_out_xnames
 
     def tearDown(self):
         patch.stopall()
@@ -83,10 +83,10 @@ class TestAirCooledCabinetsPowerOff(unittest.TestCase):
             do_air_cooled_cabinets_power_off(self.args)
 
         self.assert_hsm_client_calls()
-        self.mock_capmc_client.set_xnames_power_state.assert_called_once_with(
+        self.mock_pcs_client.set_xnames_power_state.assert_called_once_with(
             self.mock_river_non_mgmt_nodes, 'off', force=True
         )
-        self.mock_capmc_waiter.wait_for_completion.assert_called_once_with()
+        self.mock_pcs_waiter.wait_for_completion.assert_called_once_with()
         self.assertEqual(3, len(logs_cm.records))
         self.assertRegex(logs_cm.records[0].message,
                          f'Powering off {self.num_non_mgmt_river_nodes}')
@@ -104,10 +104,10 @@ class TestAirCooledCabinetsPowerOff(unittest.TestCase):
                 do_air_cooled_cabinets_power_off(self.args)
 
         self.assert_hsm_client_calls()
-        self.mock_capmc_client.set_xnames_power_state.assert_called_once_with(
+        self.mock_pcs_client.set_xnames_power_state.assert_called_once_with(
             self.mock_river_non_mgmt_nodes, 'off', force=True
         )
-        self.mock_capmc_waiter.wait_for_completion.assert_called_once_with()
+        self.mock_pcs_waiter.wait_for_completion.assert_called_once_with()
         self.assertEqual(1, len(logs_cm.records))
         self.assertRegex(logs_cm.records[0].message,
                          'non-management nodes failed to reach the powered off state.*'
@@ -122,8 +122,8 @@ class TestAirCooledCabinetsPowerOff(unittest.TestCase):
             do_air_cooled_cabinets_power_off(self.args)
 
         self.assert_hsm_client_calls()
-        self.mock_capmc_client.set_xnames_power_state.assert_not_called()
-        self.mock_capmc_waiter.wait_for_completion.assert_not_called()
+        self.mock_pcs_client.set_xnames_power_state.assert_not_called()
+        self.mock_pcs_waiter.wait_for_completion.assert_not_called()
         self.assertEqual(logs_cm.records[0].message,
                          'No non-management nodes in air-cooled cabinets to power off.')
 

--- a/tests/cli/bootsys/test_cabinet_power.py
+++ b/tests/cli/bootsys/test_cabinet_power.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021, 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/tests/cli/bootsys/test_power.py
+++ b/tests/cli/bootsys/test_power.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020, 2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -29,21 +29,19 @@ import unittest
 from unittest.mock import patch
 
 from sat.apiclient import APIError
-from sat.cli.bootsys.power import (
-    CAPMCError,
-    CAPMCPowerWaiter,
-    do_nodes_power_off,
-    get_nodes_by_role_and_state)
+from sat.cli.bootsys.power import (PCSError, PCSPowerWaiter,
+                                   do_nodes_power_off,
+                                   get_nodes_by_role_and_state)
 from tests.common import ExtendedTestCase
 
 
-class TestCAPMCPowerWaiter(ExtendedTestCase):
-    """Tests for the CAPMCPowerWaiter."""
+class TestPCSPowerWaiter(ExtendedTestCase):
+    """Tests for the PCSPowerWaiter."""
 
     def setUp(self):
         """Set up some patches and shared objects."""
-        self.mock_capmc_client_cls = patch('sat.cli.bootsys.power.CAPMCClient').start()
-        self.mock_capmc_client = self.mock_capmc_client_cls.return_value
+        self.mock_pcs_client_cls = patch('sat.cli.bootsys.power.PCSClient').start()
+        self.mock_pcs_client = self.mock_pcs_client_cls.return_value
         self.mock_sat_session = patch('sat.cli.bootsys.power.SATSession').start()
 
         self.members = {'x5000c0s0b0n0', 'x5000c0s1b0n0'}
@@ -51,49 +49,48 @@ class TestCAPMCPowerWaiter(ExtendedTestCase):
         self.timeout = 60
         self.poll_interval = 5
         self.suppress_warnings = True
-        self.waiter = CAPMCPowerWaiter(self.members, self.power_state,
-                                       self.timeout, self.poll_interval, self.suppress_warnings)
+        self.waiter = PCSPowerWaiter(self.members, self.power_state,
+                                     self.timeout, self.poll_interval, self.suppress_warnings)
 
     def tearDown(self):
         """Stop all patches."""
         patch.stopall()
 
     def test_init(self):
-        """Test creation of a CAPMCPowerWaiter"""
+        """Test creation of a PCSPowerWaiter"""
         self.assertEqual(self.members, self.waiter.members)
         self.assertEqual(self.power_state, self.waiter.power_state)
         self.assertEqual(self.timeout, self.waiter.timeout)
         self.assertEqual(self.poll_interval, self.waiter.poll_interval)
-        self.mock_capmc_client_cls.assert_called_once_with(self.mock_sat_session.return_value,
-                                                           suppress_warnings=self.suppress_warnings)
-        self.assertEqual(self.mock_capmc_client, self.waiter.capmc_client)
+        self.mock_pcs_client_cls.assert_called_once_with(self.mock_sat_session.return_value)
+        self.assertEqual(self.mock_pcs_client, self.waiter.pcs_client)
 
     def test_condition_name(self):
-        """Test the condition_name of the CAPMCPowerWaiter"""
-        self.assertEqual(f'CAPMC power {self.power_state}', self.waiter.condition_name())
+        """Test the condition_name of the PCSPowerWaiter"""
+        self.assertEqual(f'PCS power {self.power_state}', self.waiter.condition_name())
 
     def test_member_has_completed_complete(self):
         """Test member_has_completed when it has reached desired power state."""
         member = 'x5000c0s0b0n0'
-        self.mock_capmc_client.get_xname_power_state.return_value = self.power_state
+        self.mock_pcs_client.get_xname_power_state.return_value = self.power_state
         self.assertTrue(self.waiter.member_has_completed(member))
-        self.mock_capmc_client.get_xname_power_state.assert_called_once_with(member)
+        self.mock_pcs_client.get_xname_power_state.assert_called_once_with(member)
 
     def test_member_has_completed_incomplete(self):
         """Test member_has_completed when it has not reach desired power state."""
         member = 'x5000c0s0b0n0'
         power_state = 'on'
-        self.mock_capmc_client.get_xname_power_state.return_value = power_state
+        self.mock_pcs_client.get_xname_power_state.return_value = power_state
         # This assertion ensures that later edits to these tests don't invalidate this test case
         self.assertNotEqual(power_state, self.power_state)
         self.assertFalse(self.waiter.member_has_completed(member))
-        self.mock_capmc_client.get_xname_power_state.assert_called_once_with(member)
+        self.mock_pcs_client.get_xname_power_state.assert_called_once_with(member)
 
     def test_member_has_completed_api_error(self):
-        """Test member_has_completed when the CAPMCClient raises and APIError."""
+        """Test member_has_completed when the PCSClient raises and APIError."""
         member = 'x5000c0s0b0n0'
-        api_err_msg = 'CAPMC failure'
-        self.mock_capmc_client.get_xname_power_state.side_effect = APIError(api_err_msg)
+        api_err_msg = 'PCS failure'
+        self.mock_pcs_client.get_xname_power_state.side_effect = APIError(api_err_msg)
         with self.assertLogs(level=logging.DEBUG) as cm:
             self.assertFalse(self.waiter.member_has_completed(member))
         self.assert_in_element(f'Failed to query power state: {api_err_msg}', cm.output)
@@ -104,7 +101,7 @@ class TestDoNodesPowerOff(ExtendedTestCase):
 
     def setUp(self):
         """Set up some mocks."""
-        self.mock_capmc_client = patch('sat.cli.bootsys.power.CAPMCClient').start().return_value
+        self.mock_pcs_client = patch('sat.cli.bootsys.power.PCSClient').start().return_value
         self.mock_sat_session = patch('sat.cli.bootsys.power.SATSession').start()
 
         self.timeout = 10  # does not actually affect duration; just for asserts
@@ -124,9 +121,9 @@ class TestDoNodesPowerOff(ExtendedTestCase):
         self.mock_get_nodes = patch('sat.cli.bootsys.power.get_nodes_by_role_and_state',
                                     mock_get_nodes).start()
 
-        self.mock_capmc_waiter_cls = patch('sat.cli.bootsys.power.CAPMCPowerWaiter').start()
-        self.mock_capmc_waiter = self.mock_capmc_waiter_cls.return_value
-        self.mock_capmc_waiter.wait_for_completion.return_value = self.timed_out_nodes
+        self.mock_pcs_waiter_cls = patch('sat.cli.bootsys.power.PCSPowerWaiter').start()
+        self.mock_pcs_waiter = self.mock_pcs_waiter_cls.return_value
+        self.mock_pcs_waiter.wait_for_completion.return_value = self.timed_out_nodes
 
         self.mock_print = patch('builtins.print').start()
 
@@ -150,13 +147,13 @@ class TestDoNodesPowerOff(ExtendedTestCase):
                  f'nodes still powered on: {", ".join(self.all_nodes)}']
         if include_wait_call:
             calls.append(f'Waiting {self.timeout} seconds until {num_wait} nodes '
-                         f'reach powered off state according to CAPMC.')
+                         f'reach powered off state according to PCS.')
         for c in calls:
             self.assert_in_element(c, logs.output)
 
-    def assert_capmc_client_call(self):
-        """Assert the call is made to the CAPMCClient to power off nodes."""
-        self.mock_capmc_client.set_xnames_power_state.assert_called_once_with(
+    def assert_pcs_client_call(self):
+        """Assert the call is made to the PCSClient to power off nodes."""
+        self.mock_pcs_client.set_xnames_power_state.assert_called_once_with(
             list(self.all_nodes), 'off', force=True
         )
 
@@ -169,21 +166,21 @@ class TestDoNodesPowerOff(ExtendedTestCase):
         self.assertEqual(set(), timed_out)
         self.assertEqual(set(), failed)
 
-        self.mock_capmc_client.set_xnames_power_state.assert_not_called()
-        self.mock_capmc_waiter_cls.assert_not_called()
+        self.mock_pcs_client.set_xnames_power_state.assert_not_called()
+        self.mock_pcs_waiter_cls.assert_not_called()
 
     def test_do_nodes_power_off_success(self):
         """Test do_nodes_power_off in the successful case."""
         with self.assertLogs(level=logging.INFO) as cm:
             timed_out, failed = do_nodes_power_off(self.timeout)
 
-        self.assert_capmc_client_call()
+        self.assert_pcs_client_call()
         self.assertEqual(set(), timed_out)
         self.assertEqual(set(), failed)
-        self.mock_capmc_waiter_cls.assert_called_once_with(
+        self.mock_pcs_waiter_cls.assert_called_once_with(
             self.all_nodes, 'off', self.timeout
         )
-        self.mock_capmc_waiter.wait_for_completion.assert_called_once_with()
+        self.mock_pcs_waiter.wait_for_completion.assert_called_once_with()
         self.assert_log_calls(cm)
 
     def test_do_nodes_power_off_one_failed(self):
@@ -196,56 +193,56 @@ class TestDoNodesPowerOff(ExtendedTestCase):
                 'xname': self.compute_nodes[0]
             }
         ]
-        capmc_err_msg = 'Power off operation failed.'
-        capmc_err = CAPMCError(capmc_err_msg, xname_errs=failed_xname_errs)
-        self.mock_capmc_client.set_xnames_power_state.side_effect = capmc_err
+        pcs_err_msg = 'Power off operation failed.'
+        pcs_err = PCSError(pcs_err_msg, xname_errs=failed_xname_errs)
+        self.mock_pcs_client.set_xnames_power_state.side_effect = pcs_err
 
         with self.assertLogs(level=logging.INFO) as cm:
             timed_out, failed = do_nodes_power_off(self.timeout)
 
-        self.assert_in_element(f'{capmc_err_msg}\n'
+        self.assert_in_element(f'{pcs_err_msg}\n'
                                f'xname(s) ({self.compute_nodes[0]}) failed with '
                                f'e={failed_xname_errs[0]["e"]} and '
                                f'err_msg="{failed_xname_errs[0]["err_msg"]}"',
                                cm.output)
-        self.assert_capmc_client_call()
+        self.assert_pcs_client_call()
         self.assertEqual(set(), timed_out)
         self.assertEqual(expected_failed, failed)
-        self.mock_capmc_waiter_cls.assert_called_once_with(
+        self.mock_pcs_waiter_cls.assert_called_once_with(
             self.all_nodes - expected_failed, 'off', self.timeout
         )
-        self.mock_capmc_waiter.wait_for_completion.assert_called_once_with()
+        self.mock_pcs_waiter.wait_for_completion.assert_called_once_with()
         self.assert_log_calls(cm, num_wait=len(self.all_nodes - expected_failed))
 
-    def test_do_nodes_power_off_capmc_failed(self):
-        """Test do_nodes_power_off when the CAPMC power off request fails."""
-        capmc_err_msg = 'CAPMC did not respond'
-        capmc_err = CAPMCError(capmc_err_msg)
+    def test_do_nodes_power_off_pcs_failed(self):
+        """Test do_nodes_power_off when the PCS power off request fails."""
+        pcs_err_msg = 'PCS did not respond'
+        pcs_err = PCSError(pcs_err_msg)
         expected_failed = self.all_nodes
-        self.mock_capmc_client.set_xnames_power_state.side_effect = capmc_err
+        self.mock_pcs_client.set_xnames_power_state.side_effect = pcs_err
 
         with self.assertLogs(level=logging.INFO) as cm:
             timed_out, failed = do_nodes_power_off(self.timeout)
 
-        self.assert_in_element(capmc_err_msg, cm.output)
-        self.assert_capmc_client_call()
+        self.assert_in_element(pcs_err_msg, cm.output)
+        self.assert_pcs_client_call()
         self.assertEqual(set(), timed_out)
         self.assertEqual(expected_failed, failed)
-        self.mock_capmc_waiter_cls.assert_not_called()
+        self.mock_pcs_waiter_cls.assert_not_called()
         self.assert_log_calls(cm, include_wait_call=False)
 
     def test_do_nodes_power_off_one_timed_out(self):
         """Test do_node_power_off when one node times out."""
         expected_timed_out = {self.compute_nodes[0]}
-        self.mock_capmc_waiter.wait_for_completion.return_value = expected_timed_out
+        self.mock_pcs_waiter.wait_for_completion.return_value = expected_timed_out
 
         with self.assertLogs(level=logging.INFO) as cm:
             timed_out, failed = do_nodes_power_off(self.timeout)
 
-        self.assert_capmc_client_call()
+        self.assert_pcs_client_call()
         self.assertEqual(expected_timed_out, timed_out)
         self.assertEqual(set(), failed)
-        self.mock_capmc_waiter_cls.assert_called_once_with(self.all_nodes, 'off', self.timeout)
+        self.mock_pcs_waiter_cls.assert_called_once_with(self.all_nodes, 'off', self.timeout)
         self.assert_log_calls(cm)
 
 
@@ -278,8 +275,8 @@ class TestGetNodesByRoleAndState(unittest.TestCase):
 
         self.mock_hsm_client = patch('sat.cli.bootsys.power.HSMClient').start().return_value
         self.mock_hsm_client.get_component_xnames = mock_get_xnames
-        self.mock_capmc_client = patch('sat.cli.bootsys.power.CAPMCClient').start().return_value
-        self.mock_capmc_client.get_xnames_power_state = mock_get_xnames_power_state
+        self.mock_pcs_client = patch('sat.cli.bootsys.power.PCSClient').start().return_value
+        self.mock_pcs_client.get_xnames_power_state = mock_get_xnames_power_state
         self.mock_sat_session = patch('sat.cli.bootsys.power.SATSession').start()
 
     def tearDown(self):

--- a/tests/cli/bootsys/test_service_activity.py
+++ b/tests/cli/bootsys/test_service_activity.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/tests/cli/bootsys/test_service_activity.py
+++ b/tests/cli/bootsys/test_service_activity.py
@@ -202,7 +202,7 @@ class TestBOSV1ActivityChecker(ExtendedTestCase):
         self.bos_session_details = {
             '1': {
                 'bos_launch': 'bos_launch_1',
-                'computes': 'boot_capmc_finished',
+                'computes': 'boot_pcs_finished',
                 'session_template_id': self.session_template_id,
                 'operation': 'shutdown',
                 'boa_launch': 'boa_launch_1',
@@ -210,7 +210,7 @@ class TestBOSV1ActivityChecker(ExtendedTestCase):
             },
             '2': {
                 'bos_launch': 'bos_launch_2',
-                'computes': 'boot_capmc_finished',
+                'computes': 'boot_pcs_finished',
                 'session_template_id': self.session_template_id,
                 'operation': 'configure',
                 'boa_launch': 'boa_launch_2',
@@ -218,7 +218,7 @@ class TestBOSV1ActivityChecker(ExtendedTestCase):
             },
             '3': {
                 'bos_launch': 'bos_launch_3',
-                'computes': 'boot_capmc_finished',
+                'computes': 'boot_pcs_finished',
                 'session_template_id': self.session_template_id,
                 'operation': 'reboot',
                 'boa_launch': 'boa_launch_3',

--- a/tests/cli/swap/test_blade.py
+++ b/tests/cli/swap/test_blade.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/tests/cli/swap/test_blade.py
+++ b/tests/cli/swap/test_blade.py
@@ -36,7 +36,7 @@ from csm_api_client.service.gateway import APIError
 from csm_api_client.service.hsm import HSMClient
 from kubernetes.client.exceptions import ApiException
 
-from sat.apiclient.capmc import CAPMCClient
+from sat.apiclient.pcs import PCSClient
 from sat.cli.swap.blade import (
     blade_swap_stage,
     BladeSwapError,
@@ -127,8 +127,8 @@ class BaseBladeSwapProcedureTest(unittest.TestCase):
         self.mock_hsm_client = MagicMock(autospec=HSMClient)
         patch('sat.cli.swap.blade.HSMClient', return_value=self.mock_hsm_client).start()
 
-        self.mock_capmc_client = MagicMock(autospec=CAPMCClient)
-        patch('sat.cli.swap.blade.CAPMCClient', return_value=self.mock_capmc_client).start()
+        self.mock_pcs_client = MagicMock(autospec=PCSClient)
+        patch('sat.cli.swap.blade.PCSClient', return_value=self.mock_pcs_client).start()
 
         self.mock_sat_session = patch('sat.cli.swap.blade.SATSession').start()
 
@@ -369,7 +369,7 @@ class TestPowerOffSlot(BaseBladeSwapProcedureTest):
     def test_slot_power_off_command_sent_mountain_blades(self):
         """Test that the slot power off command is sent properly for Mountain blades"""
         self.swap_out.power_off_slot()
-        self.mock_capmc_client.set_xnames_power_state.assert_called_once_with(
+        self.mock_pcs_client.set_xnames_power_state.assert_called_once_with(
             [self.blade_xname],
             'off',
             recursive=True,
@@ -382,10 +382,10 @@ class TestPowerOffSlot(BaseBladeSwapProcedureTest):
         patch('sat.cli.swap.blade.BladeSwapProcedure.blade_class', 'river').start()
 
         node_xnames = [n['ID'] for n in self.nodes]
-        self.mock_capmc_client.get_xnames_power_state.return_value = {'on': node_xnames}
+        self.mock_pcs_client.get_xnames_power_state.return_value = {'on': node_xnames}
 
         self.swap_out.power_off_slot()
-        self.mock_capmc_client.set_xnames_power_state.assert_called_once_with(
+        self.mock_pcs_client.set_xnames_power_state.assert_called_once_with(
             node_xnames,
             'off',
             recursive=True,
@@ -552,7 +552,7 @@ class TestPoweringOnSlot(BaseBladeSwapProcedureTest):
     def test_power_on_slot(self):
         """Test powering on the slot"""
         self.swap_in.power_on_slot()
-        self.mock_capmc_client.set_xnames_power_state.assert_called_once_with(
+        self.mock_pcs_client.set_xnames_power_state.assert_called_once_with(
             [self.blade_xname],
             'on',
             recursive=True,


### PR DESCRIPTION
## Summary and Scope

Replace calls to the CAPMC API with equivalent calls to the PCS API.

I tried to keep the software API of `PCSClient` mostly compatible with `CAPMCClient`, though there may be differences that aren't covered in the tests.

This hasn't been tested on a real system with PCS installed yet.

## Issues and Related PRs

* Resolves [CRAYSAT-956](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-956)

## Testing

### Tested on:

  * Local development environment

### Test description:

Run unit tests.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

