### PR TITLE
CRAYSAT-1750: Update PyYAML to 6.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.25.1] - 2023-08-01
+
+### Fixed
+- Update PyYAML to 6.0.1 and csm-api-client to 1.1.5 to resolve build issues.
+
 ## [3.25.0] - 2023-06-26
 
 ### Added

--- a/requirements-dev.lock.txt
+++ b/requirements-dev.lock.txt
@@ -14,7 +14,7 @@ coverage==6.3.2
 cray-product-catalog==1.6.0
 croniter==0.3.37
 cryptography==41.0.0
-csm-api-client==1.1.4
+csm-api-client==1.1.5
 dataclasses-json==0.5.6
 docutils==0.17.1
 google-auth==2.6.0
@@ -49,7 +49,7 @@ pyparsing==3.0.9
 pyrsistent==0.18.1
 python-dateutil==2.8.2
 pytz==2021.3
-PyYAML==5.4.1
+PyYAML==6.0.1
 requests==2.31.0
 requests-oauthlib==1.3.1
 rsa==4.8

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -11,7 +11,7 @@ click==8.0.4
 cray-product-catalog==1.6.0
 croniter==0.3.37
 cryptography==41.0.0
-csm-api-client==1.1.4
+csm-api-client==1.1.5
 dataclasses-json==0.5.6
 google-auth==2.6.0
 htmlmin==0.1.12
@@ -40,7 +40,7 @@ PyNaCl==1.5.0
 pyrsistent==0.18.1
 python-dateutil==2.8.2
 pytz==2021.3
-PyYAML==5.4.1
+PyYAML==6.0.1
 requests==2.31.0
 requests-oauthlib==1.3.1
 rsa==4.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ paramiko >= 2.11.0
 parsec == 3.5.0
 prettytable >= 0.7.2, < 1.0
 python-dateutil >= 2.7.3, < 3.0
-pyyaml >= 5.4.1, < 6.0
+pyyaml >= 6.0.1, < 7.0
 requests < 3.0
 requests-oauthlib
 semver >= 2.13.0, < 3.0


### PR DESCRIPTION
## Summary and Scope
Update PyYAML to 6.0.1 to fix a build error. This build error was due to an incompatible change introduced in Cython 3.0. The PyYAML package has worked around this in version 6.0.1 by restricting to Cython<3.0.

Also update the pinned version of csm-api-client to 1.1.5, which relaxed the PyYAML constraint to allow versions greater than or equal to 6.0. Without this change, `pip` is unable to resolve sat's dependencies.

* Resolves [CRAYSAT-1750](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1750)

## Testing

### Tested on:

  * mug

### Test description:

Ran the following `sat` commands to exercise relevant code:

* `sat showrev --products` (config map access)
* `sat bootprep run` (YAML loading, API access, config map access)
* `sat status` (multiple API access)

## Risks and Mitigations

Low risk since we're just pulling in new PyYAML.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

