### PR TITLE
CRAYSAT-1751: Resolve CVEs in cray-sat:3.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.21.7] - 2023-08-08
+
+### Added
+- Added a `cert_verify` parameter to the `s3` section of the configuration file.
+
+### Changed
+- Reduced the number of log messages when insecure HTTPS requests are made.
+
 ## [3.21.6] - 2023-06-23
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Reduced the number of log messages when insecure HTTPS requests are made.
+- Update the version of `csm-api-client` to 1.1.4 to simplify loading of the
+  Kubernetes configuration when running in a container inside the cluster and
+  remove code duplication.
 
 ## [3.21.6] - 2023-06-23
 
@@ -56,6 +59,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   staged sessions as complete if the sessions did not apply to any components
   due to a `--bos-limit` parameter that did not overlap with the components in the
   session template.
+- Fixed a bug which caused the wrong container name to be logged when a CFS
+  image customization failed in newer versions of CSM.
 
 ## [3.21.3] - 2023-03-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Update PyYAML to 6.0.1 and csm-api-client to 1.1.5 to resolve build issues.
 
+### Security
+- Update the version of cryptography from 41.0.0 to 41.0.3 to address
+  CVE-2023-38325.
+- Update the version of pygments from 2.11.2 to 2.15.0 to address
+  CVE-2022-40896.
+- Update the version of certifi from 2022.12.7 to 2023.7.22 to address
+  CVE-2023-37920.
+
 ## [3.21.6] - 2023-06-23
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Kubernetes configuration when running in a container inside the cluster and
   remove code duplication.
 
+### Fixed
+- Update PyYAML to 6.0.1 and csm-api-client to 1.1.5 to resolve build issues.
+
 ## [3.21.6] - 2023-06-23
 
 ### Changed

--- a/docs/man/sat.8.rst
+++ b/docs/man/sat.8.rst
@@ -7,7 +7,7 @@ The System Admin Toolkit
 ------------------------
 
 :Author: Hewlett Packard Enterprise Development LP.
-:Copyright: Copyright 2019-2021 Hewlett Packard Enterprise Development LP.
+:Copyright: Copyright 2019-2023 Hewlett Packard Enterprise Development LP.
 :Manual section: 8
 
 SYNOPSIS
@@ -257,6 +257,30 @@ LOGGING
         SAT also prints log messages to stderr, and this parameter sets the
         minimum log severity that will cause a log to be printed to stderr.
         Defaults to "INFO".
+
+S3
+--
+
+**endpoint**
+        The URL of the S3 endpoint. The default is "https://rgw-vip.nmn"
+
+**bucket**
+        The S3 bucket where SAT should store data. The default is "sat".
+
+**access_key**
+        The path to the S3 access key SAT should use to access S3. The default
+        is "~/.config/sat/s3_access_key".
+
+**secret_key**
+        The path to the S3 secret key SAT should use to access S3. The default
+        is "~/.config/sat/s3_secret_key".
+
+**cert_verify**
+        If "true", then SAT will validate the authenticity of the S3 host
+        via a signed certificate before communicating.
+
+        This parameter is set to "false" by default.
+
 
 SEE ALSO
 ========

--- a/requirements-dev.lock.txt
+++ b/requirements-dev.lock.txt
@@ -13,7 +13,7 @@ click==8.0.4
 coverage==6.3.2
 cray-product-catalog==1.6.0
 croniter==0.3.37
-cryptography==41.0.0
+cryptography==41.0.3
 csm-api-client==1.1.5
 dataclasses-json==0.5.6
 docutils==0.17.1

--- a/requirements-dev.lock.txt
+++ b/requirements-dev.lock.txt
@@ -13,8 +13,8 @@ click==8.0.4
 coverage==6.3.2
 cray-product-catalog==1.6.0
 croniter==0.3.37
-cryptography==39.0.1
-csm-api-client==1.1.4
+cryptography==41.0.0
+csm-api-client==1.1.5
 dataclasses-json==0.5.6
 docutils==0.17.1
 google-auth==2.6.0
@@ -49,8 +49,8 @@ pyparsing==3.0.9
 pyrsistent==0.18.1
 python-dateutil==2.8.2
 pytz==2021.3
-PyYAML==5.4.1
-requests==2.27.1
+PyYAML==6.0.1
+requests==2.31.0
 requests-oauthlib==1.3.1
 rsa==4.8
 s3transfer==0.5.2

--- a/requirements-dev.lock.txt
+++ b/requirements-dev.lock.txt
@@ -43,7 +43,7 @@ pyasn1==0.4.8
 pyasn1-modules==0.2.8
 pycodestyle==2.8.0
 pycparser==2.21
-Pygments==2.11.2
+Pygments==2.15.0
 PyNaCl==1.5.0
 pyparsing==3.0.9
 pyrsistent==0.18.1

--- a/requirements-dev.lock.txt
+++ b/requirements-dev.lock.txt
@@ -6,7 +6,7 @@ bcrypt==3.2.0
 boto3==1.21.16
 botocore==1.24.16
 cachetools==5.0.0
-certifi==2022.12.7
+certifi==2023.7.22
 cffi==1.15.0
 charset-normalizer==2.0.12
 click==8.0.4

--- a/requirements-dev.lock.txt
+++ b/requirements-dev.lock.txt
@@ -14,7 +14,7 @@ coverage==6.3.2
 cray-product-catalog==1.6.0
 croniter==0.3.37
 cryptography==39.0.1
-csm-api-client==1.1.2
+csm-api-client==1.1.4
 dataclasses-json==0.5.6
 docutils==0.17.1
 google-auth==2.6.0

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -11,7 +11,7 @@ click==8.0.4
 cray-product-catalog==1.6.0
 croniter==0.3.37
 cryptography==39.0.1
-csm-api-client==1.1.2
+csm-api-client==1.1.4
 dataclasses-json==0.5.6
 google-auth==2.6.0
 htmlmin==0.1.12

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -35,7 +35,7 @@ prettytable==0.7.2
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
 pycparser==2.21
-Pygments==2.11.2
+Pygments==2.15.0
 PyNaCl==1.5.0
 pyrsistent==0.18.1
 python-dateutil==2.8.2

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -10,8 +10,8 @@ charset-normalizer==2.0.12
 click==8.0.4
 cray-product-catalog==1.6.0
 croniter==0.3.37
-cryptography==39.0.1
-csm-api-client==1.1.4
+cryptography==41.0.0
+csm-api-client==1.1.5
 dataclasses-json==0.5.6
 google-auth==2.6.0
 htmlmin==0.1.12
@@ -40,8 +40,8 @@ PyNaCl==1.5.0
 pyrsistent==0.18.1
 python-dateutil==2.8.2
 pytz==2021.3
-PyYAML==5.4.1
-requests==2.27.1
+PyYAML==6.0.1
+requests==2.31.0
 requests-oauthlib==1.3.1
 rsa==4.8
 s3transfer==0.5.2

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -10,7 +10,7 @@ charset-normalizer==2.0.12
 click==8.0.4
 cray-product-catalog==1.6.0
 croniter==0.3.37
-cryptography==41.0.0
+cryptography==41.0.3
 csm-api-client==1.1.5
 dataclasses-json==0.5.6
 google-auth==2.6.0

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -4,7 +4,7 @@ bcrypt==3.2.0
 boto3==1.21.16
 botocore==1.24.16
 cachetools==5.0.0
-certifi==2022.12.7
+certifi==2023.7.22
 cffi==1.15.0
 charset-normalizer==2.0.12
 click==8.0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ paramiko >= 2.4.2
 parsec == 3.5.0
 prettytable >= 0.7.2, < 1.0
 python-dateutil >= 2.7.3, < 3.0
-pyyaml >= 5.4.1, < 6.0
+pyyaml >= 6.0.1, < 7.0
 requests < 3.0
 requests-oauthlib
 semver >= 2.13.0, < 3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Top-level requirements for sat package to function.
-# (C) Copyright 2019-2022 Hewlett Packard Enterprise Development LP.
+# (C) Copyright 2019-2023 Hewlett Packard Enterprise Development LP.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -22,7 +22,7 @@ argcomplete
 boto3
 botocore
 cray-product-catalog >= 1.6.0
-csm-api-client >= 1.1.2, <2.0
+csm-api-client >= 1.1.4, <2.0
 croniter >= 0.3, < 1.0
 inflect >= 0.2.5, < 3.0
 Jinja2 >= 3.0, < 4.0

--- a/sat/cli/bootsys/k8s.py
+++ b/sat/cli/bootsys/k8s.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020, 2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -25,13 +25,11 @@
 Waits for k8s API availability and for k8s pods to appear to be healthy.
 """
 import logging
-import warnings
 
+from csm_api_client.k8s import load_kube_api
 import inflect
-from kubernetes.client import CoreV1Api
-from kubernetes.config import load_kube_config, ConfigException
+from kubernetes.config import ConfigException
 import urllib3
-from yaml import YAMLLoadWarning
 
 from sat.cached_property import cached_property
 from sat.cli.bootsys.state_recorder import PodStateRecorder, StateError
@@ -173,33 +171,6 @@ class KubernetesAPIAvailableWaiter(Waiter):
             return False
         else:
             return True
-
-
-def load_kube_api():
-    """Get a Kubernetes CoreV1Api object.
-
-    This helper function loads the kube config and then instantiates
-    an API object.
-
-    Returns:
-        CoreV1Api: the API object from the kubernetes library.
-
-    Raises:
-        kubernetes.config.config_exception.ConfigException: if failed to load
-            kubernetes configuration.
-    """
-    try:
-        with warnings.catch_warnings():
-            warnings.filterwarnings('ignore', category=YAMLLoadWarning)
-            load_kube_config()
-    # Earlier versions: FileNotFoundError; later versions: ConfigException
-    except (FileNotFoundError, ConfigException) as err:
-        raise ConfigException(
-            'Failed to load kubernetes config to get pod status: '
-            '{}'.format(err)
-        )
-
-    return CoreV1Api()
 
 
 def do_k8s_check(args):

--- a/sat/cli/setrev/main.py
+++ b/sat/cli/setrev/main.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2021,2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -28,8 +28,6 @@ The main entry point for the setrev subcommand.
 import logging
 import os
 import sys
-from urllib3.exceptions import InsecureRequestWarning
-import warnings
 
 from boto3.exceptions import Boto3Error
 from botocore.exceptions import BotoCoreError, ClientError
@@ -61,10 +59,7 @@ def get_site_data(sitefile):
 
     try:
         LOGGER.debug('Downloading %s from S3 (bucket: %s)', sitefile, s3_bucket)
-        # TODO(SAT-926): Start verifying HTTPS requests
-        with warnings.catch_warnings():
-            warnings.filterwarnings('ignore', category=InsecureRequestWarning)
-            s3.Object(s3_bucket, sitefile).download_file(sitefile)
+        s3.Object(s3_bucket, sitefile).download_file(sitefile)
     except (BotoCoreError, ClientError, Boto3Error) as err:
         # It is not an error if this file doesn't already exist
         # TODO: it would be nice to differentiate between successfully connecting to S3
@@ -137,10 +132,7 @@ def write_site_data(sitefile, data):
         with open(sitefile, 'w') as of:
             of.write(yaml_dump(data))
         LOGGER.debug('Uploading %s to S3 (bucket: %s)', sitefile, s3_bucket)
-        # TODO(SAT-926): Start verifying HTTPS requests
-        with warnings.catch_warnings():
-            warnings.filterwarnings('ignore', category=InsecureRequestWarning)
-            s3.Object(s3_bucket, sitefile).upload_file(sitefile)
+        s3.Object(s3_bucket, sitefile).upload_file(sitefile)
         LOGGER.info(f'Successfully wrote site info file {sitefile} to S3.')
     except OSError as err:
         LOGGER.error('Unable to write %s. Error: %s', sitefile, err)

--- a/sat/cli/showrev/system.py
+++ b/sat/cli/showrev/system.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -29,7 +29,7 @@ import logging
 import warnings
 import shlex
 import subprocess
-from urllib3.exceptions import InsecureRequestWarning, MaxRetryError
+from urllib3.exceptions import MaxRetryError
 from collections import defaultdict
 
 from boto3.exceptions import Boto3Error
@@ -72,10 +72,7 @@ def get_site_data(sitefile):
 
     try:
         LOGGER.debug('Downloading %s from S3 (bucket: %s)', sitefile, s3_bucket)
-        # TODO(SAT-926): Start verifying HTTPS requests
-        with warnings.catch_warnings():
-            warnings.filterwarnings('ignore', category=InsecureRequestWarning)
-            s3.Object(s3_bucket, sitefile).download_file(sitefile)
+        s3.Object(s3_bucket, sitefile).download_file(sitefile)
     except (BotoCoreError, ClientError, Boto3Error) as err:
         LOGGER.error('Unable to download site info file %s from S3. Attempting to read from cached copy. '
                      'Error: %s', sitefile, err)

--- a/sat/config.py
+++ b/sat/config.py
@@ -127,6 +127,8 @@ SAT_CONFIG_SPEC = {
         'stderr_level': OptionSpec(str, 'INFO', validate_log_level, 'loglevel_stderr'),
     },
     's3': {
+        # TODO (CRAYSAT-926): When rgw cert can be verified, change the default to True.
+        'cert_verify': OptionSpec(bool, False, None, None),
         'endpoint': OptionSpec(str, 'https://rgw-vip.nmn', None, None),
         'bucket': OptionSpec(str, 'sat', None, None),
         'access_key_file': OptionSpec(str, '~/.config/sat/s3_access_key', None, None),

--- a/sat/hms_discovery.py
+++ b/sat/hms_discovery.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -26,12 +26,11 @@ Functionality related to the hms-discovery cronjob in k8s.
 """
 from datetime import datetime
 import logging
-import warnings
-from yaml import YAMLLoadWarning
 
 from croniter import croniter
+from csm_api_client.k8s import load_kube_api
 from dateutil.tz import tzutc
-from kubernetes.config import ConfigException, load_kube_config
+from kubernetes.config import ConfigException
 from kubernetes.client import BatchV1beta1Api
 from kubernetes.client.rest import ApiException
 
@@ -62,14 +61,9 @@ class HMSDiscoveryCronJob:
             HMSDiscoveryError: if there is an error loading k8s config
         """
         try:
-            with warnings.catch_warnings():
-                warnings.filterwarnings('ignore', category=YAMLLoadWarning)
-                load_kube_config()
-        # Earlier versions: FileNotFoundError; later versions: ConfigException
-        except (FileNotFoundError, ConfigException) as err:
+            return load_kube_api(api_cls=BatchV1beta1Api)
+        except ConfigException as err:
             raise HMSDiscoveryError('Failed to load kubernetes config: {}'.format(err)) from err
-
-        return BatchV1beta1Api()
 
     # Intentionally not cached so we can get live state
     @property

--- a/sat/logging.py
+++ b/sat/logging.py
@@ -30,6 +30,7 @@ import os
 from sat.config import get_config_value
 
 CSM_CLIENT_MODULE_NAME = 'csm_api_client'
+WARNINGS_MODULE_NAME = 'py.warnings'
 CONSOLE_LOG_FORMAT = '%(levelname)s: %(message)s'
 FILE_LOG_FORMAT = '%(asctime)s - %(levelname)s - %(name)s - %(message)s'
 LOGGER = logging.getLogger(__name__)
@@ -88,10 +89,14 @@ def configure_logging():
     """
     sat_logger_name = __name__.split('.', 1)[0]
     sat_logger = logging.getLogger(sat_logger_name)
+
     # Handle log messages from the CSM API client with the same
     # handlers and log levels as log messages from SAT.
     csm_client_logger = logging.getLogger(CSM_CLIENT_MODULE_NAME)
     csm_client_logger.setLevel(logging.DEBUG)
+    # Handle log messages from the warnings module too
+    warnings_logger = logging.getLogger(WARNINGS_MODULE_NAME)
+    warnings_logger.setLevel(logging.WARNING)
 
     log_file_name = get_config_value('logging.file_name')
     log_file_level = get_config_value('logging.file_level')
@@ -106,6 +111,7 @@ def configure_logging():
 
     _add_console_handler(sat_logger, log_stderr_level)
     _add_console_handler(csm_client_logger, log_stderr_level)
+    _add_console_handler(warnings_logger, log_stderr_level)
 
     # Create log directories if needed
     log_dir = os.path.dirname(log_file_name)
@@ -125,3 +131,4 @@ def configure_logging():
         file_handler.setFormatter(file_formatter)
         sat_logger.addHandler(file_handler)
         csm_client_logger.addHandler(file_handler)
+        warnings_logger.addHandler(file_handler)

--- a/sat/main.py
+++ b/sat/main.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -33,6 +33,7 @@ import sys
 import argcomplete
 
 from sat.config import ConfigFileExistsError, DEFAULT_CONFIG_PATH, generate_default_config, load_config
+from sat.warnings import configure_insecure_request_warnings
 from sat.logging import bootstrap_logging, configure_logging
 from sat.parser import create_parent_parser
 from sat.util import ensure_permissions, get_resource_section_path
@@ -96,6 +97,7 @@ def main():
                 pass
             load_config(args)
             configure_logging()
+            configure_insecure_request_warnings()
 
         # Dynamically importing here affords the following
         # advantages:

--- a/sat/util.py
+++ b/sat/util.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -657,7 +657,7 @@ def get_s3_resource():
                 aws_access_key_id=access_key,
                 aws_secret_access_key=secret_key,
                 region_name='',
-                verify=False
+                verify=get_config_value('s3.cert_verify')
             )
     except OSError as err:
         LOGGER.error(f'Unable to load configuration: {err}')

--- a/sat/warnings.py
+++ b/sat/warnings.py
@@ -1,0 +1,67 @@
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""
+Configure how warnings from the warnings module should be logged.
+"""
+
+import logging
+import re
+import warnings
+
+from urllib3.exceptions import InsecureRequestWarning
+
+from sat.config import get_config_value
+
+
+def configure_insecure_request_warnings():
+    """Configure the handling of InsecureRequestWarning.
+
+    Returns:
+        None.
+    """
+    logging.captureWarnings(True)
+
+    # Use filters with regexes matching the API gateway and s3 host parameters, so that
+    # the 'once' action will log one warning per host to which an insecure request is made,
+    # rather than just one warning after the first insecure request.
+    warnings.filterwarnings(
+        action='once', category=InsecureRequestWarning,
+        message=rf'^.*\'{re.escape(get_config_value("api_gateway.host"))}\''
+    )
+    s3_hostname = re.sub(r'https?://', '', get_config_value("s3.endpoint"))
+    warnings.filterwarnings(
+        action='once', category=InsecureRequestWarning,
+        message=rf'.*\'{re.escape(s3_hostname)}\''
+    )
+
+    # Overriding format_warning makes the format of the insecure request warnings
+    # look much nicer.
+    orig_format_warning = warnings.formatwarning
+
+    def format_warning(warning, *args, **kwargs):
+        if not isinstance(warning, InsecureRequestWarning):
+            return orig_format_warning(warning, *args, **kwargs)
+
+        return str(warning)
+    warnings.formatwarning = format_warning

--- a/tests/cli/bootsys/test_k8s.py
+++ b/tests/cli/bootsys/test_k8s.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020, 2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -41,8 +41,7 @@ def generate_mock_pod(namespace, name, phase):
 
 class TestK8sPodWaiter(unittest.TestCase):
     def setUp(self):
-        self.mock_k8s_api = patch('sat.cli.bootsys.k8s.CoreV1Api').start()
-        self.mock_load_kube_config = patch('sat.cli.bootsys.k8s.load_kube_config').start()
+        self.mock_k8s_api = patch('sat.cli.bootsys.k8s.load_kube_api').start()
 
         self.mocked_pod_dump = {
             'galaxies': {

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -46,7 +46,7 @@ class TestLogging(unittest.TestCase):
         self.sub_logger = logging.getLogger('submodule')
         self.mock_get_logger = mock.patch(
             'sat.logging.logging.getLogger',
-            side_effect=(self.logger, self.sub_logger)
+            side_effect=(self.logger, self.sub_logger, self.sub_logger)
         ).start()
 
         config_values = self.config_values = {
@@ -129,6 +129,8 @@ class TestLogging(unittest.TestCase):
         self.mock_get_logger.assert_any_call('sat')
         # And also the logger named 'csm_api_client'
         self.mock_get_logger.assert_any_call('csm_api_client')
+        # And finally, the 'py.warnings' module
+        self.mock_get_logger.assert_any_call('py.warnings')
 
         log_dir = os.path.dirname(self.config_values['logging.file_name'])
         mock_makedirs.assert_called_once_with(log_dir, exist_ok=True)
@@ -159,6 +161,7 @@ class TestLogging(unittest.TestCase):
         # This should have gotten the logger named 'sat'
         self.mock_get_logger.assert_any_call('sat')
         self.mock_get_logger.assert_any_call('csm_api_client')
+        self.mock_get_logger.assert_any_call('py.warnings')
 
         # Exactly one handler of type StreamHandler should have been added.
         self.assertEqual(len(self.logger.handlers), 1)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -644,14 +644,15 @@ class TestGetS3Resource(ExtendedTestCase):
         result = util.get_s3_resource()
         self.assertEqual([mock.call('s3.access_key_file'), mock.call('s3.secret_key_file')],
                          self.mock_read_config_value_file.mock_calls)
-        self.mock_get_config_value.assert_called_once_with('s3.endpoint')
+        self.mock_get_config_value.assert_any_call('s3.endpoint')
+        self.mock_get_config_value.assert_any_call('s3.cert_verify')
         self.mock_boto3.assert_called_once_with(
             's3',
             endpoint_url=self.mock_get_config_value.return_value,
             aws_access_key_id=self.access_key,
             aws_secret_access_key=self.secret_key,
             region_name='',
-            verify=False
+            verify=self.mock_get_config_value.return_value
         )
         self.assertEqual(result, self.mock_boto3.return_value)
 


### PR DESCRIPTION
## Summary and Scope

Backport the following fixes to release/3.21:

* CRAYSAT-1310: Capture and filter InsecureRequestWarning
* CRAYSAT-1656: Use updated load_kube_api() implementation
* CRAYSAT-1750: Update PyYAML to 6.0.1
* Bump pygments from 2.11.2 to 2.15.0
* Bump certifi from 2022.12.7 to 2023.7.22
* Bump cryptography from 41.0.0 to 41.0.3
* CRAYSAT-1751: Add changelog entry for dependabot updates

These first two changes are required to make  the PyYAML change apply cleanly. It seems like lower risk to backport those two minor changes than to try to manually resolve the merge conflicts.

## Issues and Related PRs

* Resolves [CRAYSAT-1751](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1751)

## Testing

### Tested on:

  * mug

### Test description:

Downloaded the cray-sat container image built from this branch and ran through `satverify.py` on mug.

## Risks and Mitigations

Although lots of dependency versions are changing here, I think this is still pretty low risk. These changes are working in the main branch, and I ran `satverify.py` against the container image built from this branch.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable