### PR TITLE
CRAYSAT-1761: Update metal-provision file path to fix build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.25.3] - 2023-08-31
+
+### Fixed
+- Fixed a build issue were the kubectl version ref file updated 
+  to pick from all.yml
+
 ## [3.25.2] - 2023-08-07
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [3.25.3] - 2023-08-31
 
 ### Fixed
-- Fixed a build issue were the kubectl version ref file updated 
-  to pick from all.yml
+- Fixed a build issue which occurred when trying to get the kubectl version
+  from the `metal-provision` repo.
 
 ## [3.25.2] - 2023-08-07
 

--- a/docker_scripts/config-docker-sat.sh
+++ b/docker_scripts/config-docker-sat.sh
@@ -29,7 +29,7 @@ SATMANDIR=/usr/share/man/man8
 
 METAL_PROVISION_REPO="https://github.com/Cray-HPE/metal-provision.git"
 METAL_PROVISION_DIR="metal-provision"
-METAL_PROVISION_BASE_PACKAGES_PATH="roles/node_images_ncn_common/vars/packages/suse.yml"
+METAL_PROVISION_BASE_PACKAGES_PATH="group_vars/all.yml"
 METAL_PROVISION_BRANCH="lts/csm-1.5"
 
 # create logging directory
@@ -67,21 +67,17 @@ cd $METAL_PROVISION_DIR
 git checkout $METAL_PROVISION_BRANCH
 
 KUBERNETES_PULL_VERSION=$(python3 <<EOF
-import re
 import sys
 
-import semver
 import yaml
 
 
 with open("${METAL_PROVISION_BASE_PACKAGES_PATH}") as pkgs:
     pkgs = yaml.safe_load(pkgs)
-    for line in pkgs.get("packages", []):
-        name, version = re.split(r'(?:(?:<|>)=?|=)', line)
-        if name == "kubectl":
-            version = semver.VersionInfo.parse(version).finalize_version()
-            print(str(version))
-            sys.exit(0)
+    version = pkgs.get("kubernetes_release")
+    if version:
+        print(version.strip())
+        sys.exit(0)
 print("Could not determine kubectl version")
 sys.exit(1)
 EOF


### PR DESCRIPTION
## Summary and Scope

build failure of SAT was observed due to non fetch of kube version from metal-provision repo.
Script has been updated to fetch the version from different yml file  and verified


## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* [Resolves [CRAYSAT-1761](https://jira-pro.it.hpe.com:8443/browse)]


## Testing

need to verify the build

### Tested on:

NA

### Test description:

Yet to verify the build

## Risks and Mitigations

Low risk

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

