### PR TITLE
CRAYSAT-1691: Limit CFS config name length to 63 chars in bootprep

### DIFF
--- a/sat/cli/bootprep/constants.py
+++ b/sat/cli/bootprep/constants.py
@@ -50,3 +50,6 @@ CONFIGURATIONS_KEY = 'configurations'
 IMAGES_KEY = 'images'
 SESSION_TEMPLATES_KEY = 'session_templates'
 ALL_KEYS = [CONFIGURATIONS_KEY, IMAGES_KEY, SESSION_TEMPLATES_KEY]
+
+# The maximum length of a label allowed by Kubernetes
+KUBERNETES_MAX_LABEL_LENGTH = 63


### PR DESCRIPTION
## Summary and Scope
Limit the name of the CFS configurations which can be created with `sat bootprep` to 63 characters, which is the limit for Kubernetes labels. In CFS v2, if a CFS configuration with a name longer than this is used in an image customization session, the CFS session fails in a mysterious way. In CFS v3, such CFS configuration names are not allowed.

Enforcing this limit in `sat bootprep` should result in less confusion for admins.

## Issues and Related PRs

* Resolves [CRAYSAT-1691](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1691)

## Testing

### Tested on:

  * mug

### Test description:

New unit tests added. Executed `sat bootprep` on mug with valid and invalid configuration names, both in dry-run and regular mode.

## Risks and Mitigations

Low risk as it's just a simple name length validation that should improve error messages for the admin when they use too long of a CFS configuration name.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

