### PR TITLE
Merge dependabot updates for cryptography and urllib3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.25.5] - 2023-10-12
+
+### Security
+- Update the version of urllib3 from 1.26.8 to 1.26.17 to address
+  CVE-2023-43804.
+- Update the version of cryptography from 41.0.3 to 41.0.4 to address
+  a low-severity dependabot alert.
+
 ## [3.25.4] - 2023-09-01
 
 ### Fixed

--- a/requirements-dev.lock.txt
+++ b/requirements-dev.lock.txt
@@ -68,5 +68,5 @@ sseclient-py==1.7.2
 toml==0.10.0
 typing-inspect==0.7.1
 typing_extensions==4.1.1
-urllib3==1.26.8
+urllib3==1.26.17
 websocket-client==1.3.1

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -51,5 +51,5 @@ sseclient-py==1.7.2
 toml==0.10.0
 typing-inspect==0.7.1
 typing_extensions==4.1.1
-urllib3==1.26.8
+urllib3==1.26.17
 websocket-client==1.3.1


### PR DESCRIPTION
## Summary and Scope
Merge two dependabot updates at once and add a changelog entry. These address vulnerabilities in the urllib3 and cryptography packages.

## Issues and Related PRs

* Resolves [CRAYSAT-1778](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1778)

## Testing

### Tested on:

  * mug

### Test description:

Simple smoke test performed on mug. Ran `sat status` and `sat showrev` commands.

## Risks and Mitigations

Low risk change. Just bumps patch versions of a couple dependencies.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

