### PR TITLE
CRAYSAT-1513: ncn shutdown timeout increase and hard powering off handle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Updated `sat bootsys` to increase the default management NCN shutdown timeout
+  to 900 seconds.
+- Updated `sat bootsys` to include a prompt for input before proceeding with
+  hard power off of management NCNs after timeout.
+
 ## [3.25.5] - 2023-10-12
 
 ### Security

--- a/docs/man/sat-bootsys.8.rst
+++ b/docs/man/sat-bootsys.8.rst
@@ -247,7 +247,7 @@ These options set the timeouts of various parts of the stages of the
 **--ncn-shutdown-timeout** *NCN_SHUTDOWN_TIMEOUT*
         Timeout, in seconds, to wait until management NCNs
         have completed a graceful shutdown and have reached the
-        powered off state according to IPMI. Defaults to 300.
+        powered off state according to IPMI. Defaults to 900.
         Overrides the option bootsys.ncn_shutdown_timeout in
         the config file.
 

--- a/sat/cli/bootsys/parser.py
+++ b/sat/cli/bootsys/parser.py
@@ -55,7 +55,7 @@ TIMEOUT_SPECS = [
                 'compute and application nodes have completed their BOS shutdown.'),
     TimeoutSpec('bos-boot', ['boot', 'reboot'], 900,
                 'compute and application nodes have completed their BOS boot.'),
-    TimeoutSpec('ncn-shutdown', ['shutdown'], 300,
+    TimeoutSpec('ncn-shutdown', ['shutdown'], 900,
                 'management NCNs have completed a graceful shutdown and have reached '
                 'the powered off state according to IPMI.'),
 ]


### PR DESCRIPTION
## Summary and Scope

ncn shutdown timeout is increased and hard powering off is handling taking i/p from user 

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CRAYSAT-1513](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1513)


## Testing

Yet to be testing as its need a ncn node to be brought down and verified
### Tested on:

Yet to be performed

### Test description:

will update once tested

## Risks and Mitigations

Low risk


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [ ] Target branch correct
- [x] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

