### PR TITLE
CRAYSAT-1780: Retain image arch in `sat bootprep`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.25.6] - 2023-10-18
+
+### Fixed
+- Fixed `sat bootprep` to ensure image architecture is retained when customizing
+  IMS images.
+
 ## [3.25.5] - 2023-10-12
 
 ### Security


### PR DESCRIPTION
## Summary and Scope

When renaming images in `sat bootprep`, ensure the image architecture is retained in the new image. This field is important to IMS, so it knows how to handle any future customization operations on that image.

## Issues and Related PRs

* Resolves [CRAYSAT-1780]()

## Testing

### Tested on:

  * mug

### Test description:

Tested on mug by downloading the new cray-sat image, opening a shell in the container with `sat bash`, and then opening a Python interpreter and using the `copy_image` function directly to confirm that the image architecture is retained when copying an aarch64 image. Also tested on an x86_64 image for good measure.

## Risks and Mitigations

Pretty low risk, just fixing a pretty simple bug.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
