### PR TITLE
Backport 3.25.6 to release branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.25.6] - 2023-10-18
+
+### Fixed
+- Fixed `sat bootprep` to ensure image architecture is retained when customizing
+  IMS images.
+
 ## [3.25.5] - 2023-10-12
 
 ### Security


### PR DESCRIPTION
## Summary and Scope

Backport 3.25.6 to release/3.25 branch to get a stable build for inclusion in CSM 1.5.0 and SAT 2.6.

## Issues and Related PRs

* Resolves [CRAYSAT-1780](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1780)

## Testing

See #171 

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

