### PR TITLE
CRAYSAT-1771: Change builds to also publish to csm-docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.26.0] - 2023-10-24
+
+### Changed
+- Added publishing of `cray-sat` container image to `csm-docker` in Artifactory
+  as well as `sat-docker`. This is more consistent with other CSM builds.
+
 ## [3.25.6] - 2023-10-18
 
 ### Fixed

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -68,6 +68,11 @@ pipeline {
                 script {
                     publishCsmDockerImage(
                         artifactoryRepo: 'sat-docker',
+                        image: env.NAME,
+                        tag: env.VERSION,
+                        isStable: env.IS_STABLE
+                    )
+                    publishCsmDockerImage(
                         image: env.NAME,
                         tag: env.VERSION,
                         isStable: env.IS_STABLE


### PR DESCRIPTION
## Summary and Scope

Change container image builds to also publish to csm-docker instead of
just sat-docker in Artifactory. Using csm-docker is more consistent with
how other CSM images are published. Publish to both locations for now to
ease the transition and to make it easier to pull in new builds of
cray-sat into CSM 1.5 patches without pulling in the related changes to
the sat-podman wrapper script.

Publishing to csm-docker has the added benefit of getting us DST image
mirroring without having to set up another mirror for sat-docker.

## Issues and Related PRs

* Resolves [CRAYSAT-1771](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1767)

## Testing

### Tested on:

  * Jenkins

### Test description:

Checked that Jenkins published to the correct locations in sat-docker and csm-docker.

## Risks and Mitigations
Low risk since it just adds another publishing location.

In CSM 1.6, we will pull the cray-sat image from the new location in the csm repo, and we will update the cray-sat-podman wrapper scripts to look in the new location in Nexus when it's uploaded there under the new path.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
