### PR TITLE
Update release/3.26 branch with 3.26.2 version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.26.1] - 2023-11-27
+
+### Security
+- Update the version of urllib3 from 1.26.17 to 1.26.18 to address
+  CVE-2023-45803
+
 ## [3.26.0] - 2023-10-24
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.26.2] - 2023-12-01
+
+### Security
+- Update the version of cryptography from 41.0.4 to 41.0.6 to address
+  CVE-2023-49083
+
 ## [3.26.1] - 2023-11-27
 
 ### Security

--- a/requirements-dev.lock.txt
+++ b/requirements-dev.lock.txt
@@ -13,7 +13,7 @@ click==8.0.4
 coverage==6.3.2
 cray-product-catalog==1.6.0
 croniter==0.3.37
-cryptography==41.0.4
+cryptography==41.0.6
 csm-api-client==1.1.5
 dataclasses-json==0.5.6
 docutils==0.17.1

--- a/requirements-dev.lock.txt
+++ b/requirements-dev.lock.txt
@@ -68,5 +68,5 @@ sseclient-py==1.7.2
 toml==0.10.0
 typing-inspect==0.7.1
 typing_extensions==4.1.1
-urllib3==1.26.17
+urllib3==1.26.18
 websocket-client==1.3.1

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -10,7 +10,7 @@ charset-normalizer==2.0.12
 click==8.0.4
 cray-product-catalog==1.6.0
 croniter==0.3.37
-cryptography==41.0.4
+cryptography==41.0.6
 csm-api-client==1.1.5
 dataclasses-json==0.5.6
 google-auth==2.6.0

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -51,5 +51,5 @@ sseclient-py==1.7.2
 toml==0.10.0
 typing-inspect==0.7.1
 typing_extensions==4.1.1
-urllib3==1.26.17
+urllib3==1.26.18
 websocket-client==1.3.1


### PR DESCRIPTION
## Summary and Scope

Update the release/3.26 branch with the latest 3.26.2 from main.

## Issues and Related PRs

* Resolves [CRAYSAT-1785](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1785)
* Resolves [CRAYSAT-1792](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1792)

## Testing

### Tested on:

  * mug

### Test description:

Performed a smoke test of latest main branch build on mug. Ran `sat status` and `sat showrev` to check general functionality after upgrades to urllib3 and cryptography package versions.

## Risks and Mitigations

Low risk, fixing security vulnerabilities.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

