### PR TITLE
CRAYSAT-1789: Allow `additional_inventory` in bootprep CFS configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.27.0] - 2023-12-05
+
+### Added
+- Added the ability to specify `additional_inventory` when creating CFS
+  configurations with `sat bootprep`.
+
 ## [3.26.2] - 2023-12-01
 
 ### Security

--- a/sat/cli/bootprep/main.py
+++ b/sat/cli/bootprep/main.py
@@ -45,7 +45,7 @@ from sat.cli.bootprep.errors import (
 )
 from sat.cli.bootprep.input.image import IMSInputImage
 from sat.cli.bootprep.input.instance import InputInstance
-from sat.cli.bootprep.input.configuration import InputConfigurationLayer
+from sat.cli.bootprep.input.configuration import InputConfigurationLayerBase
 from sat.cli.bootprep.constants import (
     ALL_KEYS,
     CONFIGURATIONS_KEY,
@@ -240,7 +240,7 @@ def do_bootprep_run(schema_validator, args):
                              jinja_env, product_catalog, args.dry_run, args.limit)
 
     # This is kind of an odd way to pass this through, but it works
-    InputConfigurationLayer.resolve_branches = args.resolve_branches
+    InputConfigurationLayerBase.resolve_branches = args.resolve_branches
     # Always validate CFS configurations. The names of CFS configurations from
     # the input instance are used when validating images and session templates,
     # and validation ensures the names render.

--- a/sat/data/schema/bootprep_schema.yaml
+++ b/sat/data/schema/bootprep_schema.yaml
@@ -41,7 +41,7 @@ $schema: "https://json-schema.org/draft/2020-12/schema"
 # ... patch component when all input files that were valid under the old schema
 #     are still valid under the new schema
 #
-version: '1.0.6'
+version: '1.0.7'
 title: Bootprep Input File
 description: >
   A description of the set of CFS configurations to create, the set of IMS
@@ -196,6 +196,31 @@ properties:
                       commit:
                         description: The commit hash in the product's git repository.
                         type: string
+        additional_inventory:
+          oneOf:
+          - description: Additional inventory to include in the CFS configuration
+            type: object
+            required: [url, branch]
+            properties:
+              name:
+                $ref: '#/$defs/CFSAdditionalInventoryName'
+              url:
+                $ref: '#/$defs/CFSAdditionalInventoryURL'
+              branch:
+                description: The branch of the given repository to use.
+                type: string
+          - description: Additional inventory to include in the CFS configuration
+            type: object
+            required: [url, commit]
+            properties:
+              name:
+                $ref: '#/$defs/CFSAdditionalInventoryName'
+              url:
+                $ref: '#/$defs/CFSAdditionalInventoryURL'
+              commit:
+                description: The commit of the given repository to use.
+                type: string
+
 
   images:
     description: The images to create and customize.
@@ -600,6 +625,15 @@ $defs:
           enable DKMS in IMS.
         type: boolean
         default: false
+  CFSAdditionalInventoryName:
+    type: string
+    description: >
+      The name of the additional inventory. Specifying a name for the
+      additional inventory is optional.
+  CFSAdditionalInventoryURL:
+    type: string
+    description: >
+      The URL to the git repository which contains the additional Ansible inventory.
   ImageName:
     description: >
       The name of the image that will be created in IMS. The image name

--- a/tests/cli/bootprep/test_validate.py
+++ b/tests/cli/bootprep/test_validate.py
@@ -235,9 +235,39 @@ VALID_UAN_CONFIGURATION = {
     ]
 }
 
+
+VALID_CONFIG_ADDITIONAL_INV_COMMIT = {
+    'name': 'config-with-additional-inventory-commit',
+    'layers': [],
+    'additional_inventory': {
+        'url': 'https://api-gw-service-nmn.local/vcs/cray/additional_inventory.git',
+        'commit': '257cc5642cb1a054f08cc83f2d943e56fd3ebe99'
+    }
+}
+
+VALID_CONFIG_ADDITIONAL_INV_BRANCH = {
+    'name': 'config-with-additional-inventory-branch',
+    'layers': [],
+    'additional_inventory': {
+        'url': 'https://api-gw-service-nmn.local/vcs/cray/additional_inventory.git',
+        'branch': 'main'
+    }
+}
+
 NOT_VALID_ANY_OF_MESSAGE = "Not valid under any of the given schemas"
 NOT_OF_TYPE_ARRAY_MESSAGE = "is not of type 'array'"
 NOT_OF_TYPE_STRING_MESSAGE = "is not of type 'string'"
+
+
+class TestBootprepSchema(unittest.TestCase):
+    """Test whether the bootprep_schema.yaml is valid in JSON Schema."""
+
+    def test_bootprep_schema_is_valid_json_schema(self):
+        """Test that the bootprep_schema.yaml is still valid against the JSON Schema metaschema"""
+        try:
+            load_bootprep_schema()
+        except BootPrepInternalError as e:
+            self.fail(f'Bootprep Schema file invalid against JSON Schema metaschema: {e}')
 
 
 class TestValidateInstanceSchemaVersion(unittest.TestCase):
@@ -460,6 +490,20 @@ class TestValidateInstance(ExtendedTestCase):
                 'name': 'valid-config-product-layer-playbook',
                 'layers': [layer]
             }]
+        }
+        self.assert_valid_instance(instance)
+
+    def test_valid_config_additional_inventory_commit(self):
+        """Valid configuration with additional inventory that uses a commit"""
+        instance = {
+            'configurations': [VALID_CONFIG_ADDITIONAL_INV_COMMIT]
+        }
+        self.assert_valid_instance(instance)
+
+    def test_valid_config_additional_inventory_branch(self):
+        """Valid configuration with additional inventory that uses a branch"""
+        instance = {
+            'configurations': [VALID_CONFIG_ADDITIONAL_INV_BRANCH]
         }
         self.assert_valid_instance(instance)
 


### PR DESCRIPTION
## Summary and Scope

Add support to the bootprep input file schema to support specifying `additional_inventory` when creating CFS configurations using `sat bootprep`.

This includes a schema change for the bootprep input file that allows the user to specify a new `additional_inventory` property in their CFS configuration definitions which corresponds with the field of the same name in the CFS API.

Add a unit test that just verifies that the `bootprep_schema.yaml` data file is valid against the JSON Schema metaschema. This is helpful to test only the validity of edits to the bootprep input file schema.

Add unit tests to validate against the schema new bootprep input that includes the new `additional_inventory` property.

When `additional_inventory` is specified, treat branches in the same way as for layers. That is, by default, resolve them to commit hashes before passing them to CFS. If `--no-resolve-branches` is specified, pass the branches as-is to CFS and let it do the resolution.

Utilize the same code for branch resolution that is already used for the layers of a CFS configuration. To do so, split the common functionality between the layers and the additional_inventory into a new common abstract base class called `InputConfigurationLayerBase`. Then implement the remaining abstract methods in `InputConfigurationLayer` and `AdditionalInventory` subclasses.

Add and update unit tests to test the `AdditionalInventory` subclass.

## Issues and Related PRs

* Resolves [CRAYSAT-1789](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1789)

## Testing

### Tested on:

  * Local development system
  * Jenkins
  * mug

### Test description:

Unit tests pass.

Tested on mug by creating a bootprep input file that defines CFS configurations. Defined several CFS configurations including:

* One with no additional_inventory and a layer without a branch
* One with no additional_inventory and a layer with a branch
* One with additional_inventory and layer, both with branches
* One with additional_inventory and layer, both with commits
* One with additional_inventory with an invalid branch name
* One with additional_inventory and layer with invalid branch names

Executed `sat bootprep run` against this input file and confirmed that CFS configurations were created as expected both with and without the `--no-resolve-branches` option.

## Risks and Mitigations

This introduces some risk because of a minor refactor to re-use some code. However, it has good unit test coverage, and manual testing was pretty extensive as well.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

