### PR TITLE
CRAYSAT-1800: Fix logging traceback due to deepcopy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-(C) Copyright 2020-2023 Hewlett Packard Enterprise Development LP
+(C) Copyright 2020-2024 Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -24,6 +24,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [3.25.9] - 2024-01-17
+
+### Fixed
+- Fixed a lengthy traceback that occurs when logging parsing errors that occur
+  during parsing of `--filter` options.
 
 ## [3.25.8] - 2024-01-16
 

--- a/sat/logging.py
+++ b/sat/logging.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2020,2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2020, 2023-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -26,7 +26,7 @@ Sets up logging for SAT.
 """
 import logging
 import os
-from copy import deepcopy
+from copy import copy
 from logging import Formatter, LogRecord
 
 from sat.config import get_config_value
@@ -43,7 +43,7 @@ class LineSplittingFormatter(Formatter):
     def formatMessage(self, record: LogRecord) -> str:
         formatted_records = []
         for line in record.message.splitlines():
-            line_record = deepcopy(record)
+            line_record = copy(record)
             line_record.message = line
             formatted_records.append(super().formatMessage(line_record))
         return '\n'.join(formatted_records)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2020,2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2020, 2023-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -67,6 +67,9 @@ class TestLineSplittingFormatter(unittest.TestCase):
         self.logger.info(msg)
         self.assertEqual(len(self.handler.messages), 1)
         self.assertEqual(self.handler.messages[0], f"INFO: {line1}\nINFO: {line2}")
+        # Assert that the original log record is not changed by the formatter
+        self.assertEqual(len(self.handler.records), 1)
+        self.assertEqual(self.handler.records[0].message, msg)
 
     @mock.patch('logging.time.time', side_effect=itertools.count())
     def test_logging_multiple_lines_with_dates(self, _):


### PR DESCRIPTION
## Summary and Scope

The use of `deepcopy` in the `LineSplittingLogFormatter` causes problems when a logging method is called, and a format string is passed in along with an argument to be used in that format string, and the object does not support copying with `deepcopy`.

Switching to `copy` instead. This is all that is needed because the `LineSplittingLogFormatter` was just creating a copy of the log record to modify its message without modifying the original record. Using `copy` is sufficient for this purpose.

This fixes an issue seen when a filter query string could not be parsed and a logging call is made that passes along the `ParseError` object from `parsec`.

Add a unit test that ensures that the original log record's message is not indavertently changed, which is what the `deepcopy` was originally trying to ensure.

(cherry picked from commit ec094315227947cc9a9261c31818116c72060c54)

## Issues and Related PRs

* Resolves the traceback in CRAYSAT-1800

## Testing

### Tested on:

  * Local development system
  * mug

### Test description:

Test Description:
Unit tests for logging multiple lines with the logging format applied to each line still work.

Tested `sat bootprep` against an input file that had multiple errors, and verified that every line of the error message was prefixed with the "ERROR: " log level.

Tested `sat status --filter 'bad'` and confirmed that it just logs a simple error message containing the string representation of the `ParseError` instead of a long traceback.

## Risks and Mitigations

Pretty low risk. This is just the part of the fix for CRAYSAT-1800 pertaining to the logging fix, so that a long traceback will no longer occur when logging a parsing error on an invalid filter.

The other part which changes the grammar for the filter queries is not being backported since it's slightly higher risk.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable