### PR TITLE
CRAYSAT-1798: Preserve all port policies in `sat swap`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.27.3] - 2024-01-31
+
+### Fixed
+- Fixed `sat swap switch` and `sat swap cable` so that they preserve all
+  existing port policies applied to the ports on a switch or a cable across the
+  disable and enable actions. The old behavior was that only the first policy
+  would be preserved, which was a problem for ports with multiple policies
+  configured.
+
 ## [3.27.2] - 2024-01-16
 
 ### Fixed

--- a/sat/cli/swap/cable.py
+++ b/sat/cli/swap/cable.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2021, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -39,7 +39,6 @@ def swap_cable(args):
 
     CableSwapper().swap_component(args.action,
                                   args.xnames,
-                                  args.disruptive,
                                   args.dry_run,
                                   args.save_ports,
                                   args.force)

--- a/sat/cli/swap/ports.py
+++ b/sat/cli/swap/ports.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2021, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -179,9 +179,9 @@ class PortManager:
             A list of dictionaries for ports or None if there is an error
                 Example: {"xname": "x3000c0r21j14p0",
                           "port_link": "/fabric/ports/x3000c0r21j14p0",
-                          "policy_link: "/fabric/port-policies/fabric-policy"}
+                          "policy_links: ["/fabric/port-policies/cassini-policy",
+                                          "/fabric/port-policies/qos-ll_be_bd_et-cassini-policy"]}
         """
-
         port_data_list = []
         for port_link in port_links:
             port = self.get_port(port_link)
@@ -194,7 +194,7 @@ class PortManager:
             try:
                 port_data['xname'] = port['conn_port']
                 port_data['port_link'] = port_link
-                port_data['policy_link'] = port['portPolicyLinks'][0]
+                port_data['policy_links'] = port['portPolicyLinks']
             except KeyError as err:
                 LOGGER.error('Key %s for port data missing from fabric manager switch information.', err)
                 return None
@@ -322,12 +322,12 @@ class PortManager:
 
         return port_data_list
 
-    def update_port_policy_link(self, port_link, policy_link):
+    def update_port_policy_links(self, port_link, policy_links):
         """Update a port to use a new policy
 
         Args:
             port_link (str): The full path of the port document link
-            policy_link (str): The full path of the new port policy
+            policy_links (list): The full paths of the new port policies
 
         Returns:
             True if update is successful
@@ -335,8 +335,7 @@ class PortManager:
         """
 
         # Example: {"portPolicyLinks":["/fabric/port-policies/edge-policy"]}
-        port_config = {}
-        port_config['portPolicyLinks'] = [policy_link]
+        port_config = {'portPolicyLinks': policy_links}
         config_json = json.dumps(port_config)
         LOGGER.debug(f'Updating port: {port_link}')
         LOGGER.debug(f'config_json: {config_json}')

--- a/sat/cli/swap/swap.py
+++ b/sat/cli/swap/swap.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2022, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -111,19 +111,18 @@ class Swapper(metaclass=abc.ABCMeta):
     def create_offline_port_policies(self, port_data_list):
         """Create port policies to be used to OFFLINE ports
 
+        For each policy applied to one of the ports in port_data_list, this will
+        create a new OFFLINE policy named with POL_PRE followed by the current
+        policy name, unless one already exists.
+
         Args:
             port_data_list (list): list of dictionaries with current port data
 
         Raises:
             SystemExit(4): if creating a new port policy fails
         """
-
-        # Create new policies to OFFLINE ports
-        # Name the new policies with POL_PRE followed by the current policy name
-        # unless the current policy name is already a POL_PRE policy
-        #
-        # Create a unique list of policies and create a new policy for each one
-        policy_list = list(set(p['policy_link'] for p in port_data_list))
+        # Create a list of unique policies referenced by the ports
+        policy_list = list(set(policy for port in port_data_list for policy in port['policy_links']))
         LOGGER.debug(f'policy_list: {policy_list}')
         for policy in policy_list:
             policy_name = policy.split('/')[-1]
@@ -151,21 +150,24 @@ class Swapper(metaclass=abc.ABCMeta):
         # Keeps updating the remaining ports if an error occurs for any single port
         success = True
         for port_data in port_data_list:
-            # Determine which policy to use depending on action and current policy
-            path_parts = port_data['policy_link'].split('/')
-            policy_name = path_parts[-1]
-            if action == "enable" and policy_name.startswith(POL_PRE):
-                # Remove prefix and use original policy
-                policy_name = policy_name[len(POL_PRE):]
-            elif action == "disable" and not policy_name.startswith(POL_PRE):
-                # Add prefix to policy
-                policy_name = POL_PRE + policy_name
+            new_policy_links = []
+            for policy_link in port_data['policy_links']:
+                # Determine which policy to use depending on action and current policy
+                path_parts = policy_link.split('/')
+                policy_name = path_parts[-1]
+                if action == "enable" and policy_name.startswith(POL_PRE):
+                    # Remove prefix and use original policy
+                    policy_name = policy_name[len(POL_PRE):]
+                elif action == "disable" and not policy_name.startswith(POL_PRE):
+                    # Add prefix to policy
+                    policy_name = POL_PRE + policy_name
+
+                new_policy_links.append('/'.join(path_parts[:-1]) + '/' + policy_name)
 
             port_link = port_data['port_link']
-            new_policy = '/'.join(path_parts[:-1]) + '/' + policy_name
-            LOGGER.debug(f'Updating {port_link} with policy: {new_policy}')
-            if not self.port_manager.update_port_policy_link(port_link, new_policy):
-                LOGGER.error(f'Error updating {port_link} with policy: {new_policy}')
+            LOGGER.debug(f'Updating {port_link} with policies: {new_policy_links}')
+            if not self.port_manager.update_port_policy_links(port_link, new_policy_links):
+                LOGGER.error(f'Error updating {port_link} with policies: {new_policy_links}')
                 success = False
 
         return success

--- a/sat/cli/swap/swap.py
+++ b/sat/cli/swap/swap.py
@@ -172,13 +172,12 @@ class Swapper(metaclass=abc.ABCMeta):
 
         return success
 
-    def swap_component(self, action, component_id, disruptive, dry_run, save_ports, force=False):
+    def swap_component(self, action, component_id, dry_run, save_ports, force=False):
         """Enable or disable ports specified by self.component_id
 
         Args:
             action (str): the action to perform, ('enable' or 'disable')
             component_id (str, list): The xname or list of xnames
-            disruptive (bool): if True, do not confirm disable/enable
             dry_run (bool): if True, skip applying action to ports,
                 but still create the port set affected.
             save_ports (bool): if True, save port_data (xname, port_link, policy_link)

--- a/sat/cli/swap/switch.py
+++ b/sat/cli/swap/switch.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2021, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -39,6 +39,5 @@ def swap_switch(args):
 
     SwitchSwapper().swap_component(args.action,
                                    args.xname,
-                                   args.disruptive,
                                    args.dry_run,
                                    args.save_ports)

--- a/tests/cli/swap/test_cable.py
+++ b/tests/cli/swap/test_cable.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2021, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -35,7 +35,6 @@ def set_options(namespace):
     """Set default options for Namespace."""
     namespace.xnames = ['x1000c6r7j101', 'x1000c6r8j102']
     namespace.action = None
-    namespace.disruptive = True
     namespace.dry_run = True
     namespace.force = False
     namespace.save_ports = False
@@ -62,7 +61,6 @@ class TestSwapCable(unittest.TestCase):
         swap_cable(self.fake_args)
         self.fake_swap_component.assert_called_once_with(self.fake_args.action,
                                                          self.fake_args.xnames,
-                                                         self.fake_args.disruptive,
                                                          self.fake_args.dry_run,
                                                          self.fake_args.save_ports,
                                                          self.fake_args.force)

--- a/tests/cli/swap/test_swap.py
+++ b/tests/cli/swap/test_swap.py
@@ -78,7 +78,6 @@ class TestCableSwapper(ExtendedTestCase):
         self.swap_args: dict[str, typing.Any] = {
             'action': None,
             'component_id': ['x1000c6r7j101'],
-            'disruptive': True,
             'dry_run': True,
             'force': False,
             'save_ports': False
@@ -248,24 +247,6 @@ class TestCableSwapper(ExtendedTestCase):
         for msg in expected_logs:
             self.assert_in_element(msg, logs_cm.output)
 
-    def test_not_disruptive_not_dry(self):
-        """Test swap_component not disruptive and not dry run"""
-        self.swap_args['disruptive'] = False
-        self.swap_args['dry_run'] = False
-        self.swap_args['action'] = 'enable'
-        with self.assertLogs(level=logging.INFO) as logs_cm:
-            self.run_swap_component()
-        self.mock_port_manager.get_jack_port_data_list.assert_called_once()
-        self.mock_output_json.assert_not_called()
-        self.mock_port_manager.create_offline_port_policy.assert_not_called()
-        self.mock_port_manager.update_port_policy_links.assert_called()
-        xnames = self.mock_port_manager.get_jack_port_data_list.return_value
-        expected_logs = [f"Ports: {' '.join([p['xname'] for p in xnames])}",
-                         f"Enabling ports on cable {self.swap_args['component_id'][0]}",
-                         "Cable has been enabled."]
-        for msg in expected_logs:
-            self.assert_in_element(msg, logs_cm.output)
-
     def test_get_ports_data_error(self):
         """Test swap_component error getting ports data"""
         self.mock_port_manager.get_jack_port_data_list.return_value = None
@@ -376,7 +357,6 @@ class TestSwitchSwapper(ExtendedTestCase):
         self.swap_args: dict[str, typing.Any] = {
             'action': None,
             'component_id': 'x1000c6r7',
-            'disruptive': True,
             'dry_run': True,
             'force': False,
             'save_ports': False
@@ -451,24 +431,6 @@ class TestSwitchSwapper(ExtendedTestCase):
         expected_logs = [f"Ports: {' '.join([p['xname'] for p in xnames])}",
                          f"Disabling ports on switch {self.swap_args['component_id']}",
                          "Switch has been disabled and is ready for replacement."]
-        for msg in expected_logs:
-            self.assert_in_element(msg, logs_cm.output)
-
-    def test_not_disruptive_not_dry(self):
-        """Test swap_component not disruptive and not dry run"""
-        self.swap_args['disruptive'] = False
-        self.swap_args['dry_run'] = False
-        self.swap_args['action'] = 'enable'
-        with self.assertLogs(level=logging.INFO) as logs_cm:
-            self.run_swap_component()
-        self.mock_port_manager.get_switch_port_data_list.assert_called_once()
-        self.mock_output_json.assert_not_called()
-        self.mock_port_manager.create_offline_port_policy.assert_not_called()
-        self.mock_port_manager.update_port_policy_links.assert_called()
-        xnames = self.mock_port_manager.get_jack_port_data_list.return_value
-        expected_logs = [f"Ports: {' '.join([p['xname'] for p in xnames])}",
-                         f"Enabling ports on switch {self.swap_args['component_id']}",
-                         'Switch has been enabled.']
         for msg in expected_logs:
             self.assert_in_element(msg, logs_cm.output)
 

--- a/tests/cli/swap/test_swap.py
+++ b/tests/cli/swap/test_swap.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2022, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -26,41 +26,56 @@ Unit tests for sat.cli.swap.swap
 """
 
 import logging
+from os.path import basename, dirname
+import typing
 import unittest
 from unittest import mock
+
+from sat.cli.swap.swap import SwitchSwapper, CableSwapper, output_json, POL_PRE
+from sat.cli.swap import swap
 from tests.test_util import ExtendedTestCase
 
-from sat.cli.swap.swap import SwitchSwapper, CableSwapper, output_json
-from sat.cli.swap import swap
+# Constants used in the tests
+EDGE_POLICY_LINK = '/fabric/port-policies/edge-policy'
+FABRIC_POLICY_LINK = '/fabric/port-policies/fabric-policy'
+QOS_POLICY_LINK = '/fabric/port-policies/qos-ll_be_bd_et-fabric-policy'
+ONLINE_FABRIC_POLICY_LINKS = [FABRIC_POLICY_LINK, QOS_POLICY_LINK]
+ONLINE_EDGE_POLICY_LINKS = [EDGE_POLICY_LINK]
+OFFLINE_FABRIC_POLICY_LINKS = [f'{dirname(link)}/{POL_PRE}{basename(link)}'
+                               for link in ONLINE_FABRIC_POLICY_LINKS]
+OFFLINE_EDGE_POLICY_LINKS = [f'{dirname(link)}/{POL_PRE}{basename(link)}'
+                             for link in ONLINE_EDGE_POLICY_LINKS]
 
 
 class TestCableSwapper(ExtendedTestCase):
 
     def setUp(self):
         """Mock functions called."""
-        self.mock_port_manager = mock.patch('sat.cli.swap.swap.PortManager',
-                                            autospec=True).start().return_value
-        self.mock_port_manager.get_jack_port_data_list.return_value = [
+        self.mock_port_data_list = [
             {'xname': 'x1000c6r7j101p0',
              'port_link': '/fabric/ports/x1000c6r7j101p0',
-             'policy_link': '/fabric/port-policies/fabric-policy'},
+             'policy_links': ONLINE_FABRIC_POLICY_LINKS},
             {'xname': 'x1000c6r7j101p1',
              'port_link': '/fabric/ports/x1000c6r7j101p1',
-             'policy_link': '/fabric/port-policies/fabric-policy'},
+             'policy_links': ONLINE_FABRIC_POLICY_LINKS},
             {'xname': 'x1000c6r7j2p0',
              'port_link': '/fabric/ports/x1000c6r7j2p0',
-             'policy_link': '/fabric/port-policies/edge-policy'},
+             'policy_links': ONLINE_EDGE_POLICY_LINKS},
             {'xname': 'x1000c6r7j2p1',
              'port_link': '/fabric/ports/x1000c6r7j2p1',
-             'policy_link': '/fabric/port-policies/edge-policy'}
+             'policy_links': ONLINE_EDGE_POLICY_LINKS}
         ]
+        self.mock_port_manager = mock.patch('sat.cli.swap.swap.PortManager',
+                                            autospec=True).start().return_value
+        self.mock_port_manager.get_jack_port_data_list.return_value = self.mock_port_data_list
 
         self.mock_pester = mock.patch('sat.cli.swap.swap.pester', autospec=True).start()
         self.mock_pester.return_value = True
         self.mock_print = mock.patch('builtins.print', autospec=True).start()
         self.mock_output_json = mock.patch('sat.cli.swap.swap.output_json', autospec=True).start()
 
-        self.swap_args = {
+        # Type hint quiets PyCharm when 'action' value is set to a str in tests
+        self.swap_args: dict[str, typing.Any] = {
             'action': None,
             'component_id': ['x1000c6r7j101'],
             'disruptive': True,
@@ -76,23 +91,22 @@ class TestCableSwapper(ExtendedTestCase):
         """Run swap_component()"""
         CableSwapper().swap_component(**self.swap_args)
 
-    def test_basic(self):
-        """Test basic swap cable"""
+    def test_dry_run(self):
+        """Test swap cable in dry-run mode"""
         with self.assertLogs(level=logging.INFO) as logs_cm:
             self.run_swap_component()
         self.mock_port_manager.get_jack_port_data_list.assert_called_once()
         self.mock_output_json.assert_not_called()
         self.mock_port_manager.create_offline_port_policy.assert_not_called()
-        self.mock_port_manager.update_port_policy_link.assert_not_called()
-        xnames = self.mock_port_manager.get_jack_port_data_list.return_value
+        self.mock_port_manager.update_port_policy_links.assert_not_called()
         expected_logs = [
-            f"Ports: {' '.join([p['xname'] for p in xnames])}",
+            f"Ports: {' '.join([p['xname'] for p in self.mock_port_data_list])}",
             f"Dry run, so not enabling/disabling cable {self.swap_args['component_id'][0]}"]
         for msg in expected_logs:
             self.assert_in_element(msg, logs_cm.output)
 
-    def test_swap_force(self):
-        """Test swap cable with force"""
+    def test_swap_force_dry_run(self):
+        """Test swap cable with force in dry-run mode"""
         self.swap_args['force'] = True
         with self.assertLogs(level=logging.INFO) as logs_cm:
             self.run_swap_component()
@@ -101,10 +115,9 @@ class TestCableSwapper(ExtendedTestCase):
         )
         self.mock_output_json.assert_not_called()
         self.mock_port_manager.create_offline_port_policy.assert_not_called()
-        self.mock_port_manager.update_port_policy_link.assert_not_called()
-        xnames = self.mock_port_manager.get_jack_port_data_list.return_value
+        self.mock_port_manager.update_port_policy_links.assert_not_called()
         expected_logs = [
-            f"Ports: {' '.join([p['xname'] for p in xnames])}",
+            f"Ports: {' '.join([p['xname'] for p in self.mock_port_data_list])}",
             f"Dry run, so not enabling/disabling cable {self.swap_args['component_id'][0]}"]
         for msg in expected_logs:
             self.assert_in_element(msg, logs_cm.output)
@@ -117,16 +130,22 @@ class TestCableSwapper(ExtendedTestCase):
         self.mock_port_manager.get_jack_port_data_list.assert_called_once()
         self.mock_output_json.assert_called_once()
         self.mock_port_manager.create_offline_port_policy.assert_not_called()
-        self.mock_port_manager.update_port_policy_link.assert_not_called()
-        xnames = self.mock_port_manager.get_jack_port_data_list.return_value
+        self.mock_port_manager.update_port_policy_links.assert_not_called()
         expected_logs = [
-            f"Ports: {' '.join([p['xname'] for p in xnames])}",
+            f"Ports: {' '.join([p['xname'] for p in self.mock_port_data_list])}",
             f"Dry run, so not enabling/disabling cable {self.swap_args['component_id'][0]}"]
         for msg in expected_logs:
             self.assert_in_element(msg, logs_cm.output)
 
-    def test_enable(self):
-        """Test swap_component enables components"""
+    def test_enable_disabled_cable(self):
+        """Test enable action enables a cable which is disabled"""
+        # Update port data to use offline policies
+        for port in self.mock_port_data_list:
+            if len(port['policy_links']) > 1:
+                port['policy_links'] = OFFLINE_FABRIC_POLICY_LINKS
+            else:
+                port['policy_links'] = OFFLINE_EDGE_POLICY_LINKS
+
         self.swap_args['dry_run'] = False
         self.swap_args['action'] = 'enable'
         with self.assertLogs(level=logging.INFO) as logs_cm:
@@ -134,24 +153,94 @@ class TestCableSwapper(ExtendedTestCase):
         self.mock_port_manager.get_jack_port_data_list.assert_called_once()
         self.mock_output_json.assert_not_called()
         self.mock_port_manager.create_offline_port_policy.assert_not_called()
-        self.mock_port_manager.update_port_policy_link.assert_called()
-        xnames = self.mock_port_manager.get_jack_port_data_list.return_value
-        expected_logs = [f"Ports: {' '.join([p['xname'] for p in xnames])}",
+
+        expected_calls = []
+        for port in self.mock_port_data_list:
+            if len(port['policy_links']) > 1:
+                policy_links = ONLINE_FABRIC_POLICY_LINKS
+            else:
+                policy_links = ONLINE_EDGE_POLICY_LINKS
+            expected_calls.append(mock.call(port['port_link'], policy_links))
+        self.mock_port_manager.update_port_policy_links.assert_has_calls(expected_calls, any_order=True)
+
+        expected_logs = [f"Ports: {' '.join([p['xname'] for p in self.mock_port_data_list])}",
                          f"Enabling ports on cable {self.swap_args['component_id'][0]}",
                          "Cable has been enabled."]
         for msg in expected_logs:
             self.assert_in_element(msg, logs_cm.output)
 
-    def test_disable(self):
-        """Test swap_component disables components"""
+    def test_enable_already_enabled_cable(self):
+        """Test enable action keeps the same port policies on an already enabled cable"""
+        self.swap_args['dry_run'] = False
+        self.swap_args['action'] = 'enable'
+        with self.assertLogs(level=logging.INFO) as logs_cm:
+            self.run_swap_component()
+        self.mock_port_manager.get_jack_port_data_list.assert_called_once()
+        self.mock_output_json.assert_not_called()
+        self.mock_port_manager.create_offline_port_policy.assert_not_called()
+
+        expected_calls = [mock.call(port['port_link'], port['policy_links'])
+                          for port in self.mock_port_data_list]
+        self.mock_port_manager.update_port_policy_links.assert_has_calls(expected_calls, any_order=True)
+
+        expected_logs = [f"Ports: {' '.join([p['xname'] for p in self.mock_port_data_list])}",
+                         f"Enabling ports on cable {self.swap_args['component_id'][0]}",
+                         "Cable has been enabled."]
+        for msg in expected_logs:
+            self.assert_in_element(msg, logs_cm.output)
+
+    def test_disable_enabled_cable(self):
+        """Test disable action disables an enabled cable"""
         self.swap_args['dry_run'] = False
         self.swap_args['action'] = 'disable'
         with self.assertLogs(level=logging.INFO) as logs_cm:
             self.run_swap_component()
         self.mock_port_manager.get_jack_port_data_list.assert_called_once()
         self.mock_output_json.assert_not_called()
-        self.mock_port_manager.create_offline_port_policy.assert_called()
-        self.mock_port_manager.update_port_policy_link.assert_called()
+        self.mock_port_manager.create_offline_port_policy.assert_has_calls(
+            [mock.call(policy, POL_PRE)
+             for policy in ONLINE_FABRIC_POLICY_LINKS + ONLINE_EDGE_POLICY_LINKS],
+            any_order=True
+        )
+
+        expected_calls = []
+        for port in self.mock_port_data_list:
+            if len(port['policy_links']) > 1:
+                policy_links = OFFLINE_FABRIC_POLICY_LINKS
+            else:
+                policy_links = OFFLINE_EDGE_POLICY_LINKS
+            expected_calls.append(mock.call(port['port_link'], policy_links))
+        self.mock_port_manager.update_port_policy_links.assert_has_calls(expected_calls, any_order=True)
+
+        xnames = self.mock_port_manager.get_jack_port_data_list.return_value
+        expected_logs = [f"Ports: {' '.join([p['xname'] for p in xnames])}",
+                         f"Disabling ports on cable {self.swap_args['component_id'][0]}",
+                         "Cable has been disabled and is ready for replacement."]
+        for msg in expected_logs:
+            self.assert_in_element(msg, logs_cm.output)
+
+    def test_disable_already_disabled_cable(self):
+        """Test disable cation keeps the same policies on an already disabled cable"""
+        # Update port data to use offline policies
+        for port in self.mock_port_data_list:
+            if len(port['policy_links']) > 1:
+                port['policy_links'] = OFFLINE_FABRIC_POLICY_LINKS
+            else:
+                port['policy_links'] = OFFLINE_EDGE_POLICY_LINKS
+
+        self.swap_args['dry_run'] = False
+        self.swap_args['action'] = 'disable'
+        with self.assertLogs(level=logging.INFO) as logs_cm:
+            self.run_swap_component()
+        self.mock_port_manager.get_jack_port_data_list.assert_called_once()
+        self.mock_output_json.assert_not_called()
+        # Offline policy creation is skipped when they already start with the offline prefix
+        self.mock_port_manager.create_offline_port_policy.assert_not_called()
+
+        expected_calls = [mock.call(port['port_link'], port['policy_links'])
+                          for port in self.mock_port_data_list]
+        self.mock_port_manager.update_port_policy_links.assert_has_calls(expected_calls, any_order=True)
+
         xnames = self.mock_port_manager.get_jack_port_data_list.return_value
         expected_logs = [f"Ports: {' '.join([p['xname'] for p in xnames])}",
                          f"Disabling ports on cable {self.swap_args['component_id'][0]}",
@@ -169,7 +258,7 @@ class TestCableSwapper(ExtendedTestCase):
         self.mock_port_manager.get_jack_port_data_list.assert_called_once()
         self.mock_output_json.assert_not_called()
         self.mock_port_manager.create_offline_port_policy.assert_not_called()
-        self.mock_port_manager.update_port_policy_link.assert_called()
+        self.mock_port_manager.update_port_policy_links.assert_called()
         xnames = self.mock_port_manager.get_jack_port_data_list.return_value
         expected_logs = [f"Ports: {' '.join([p['xname'] for p in xnames])}",
                          f"Enabling ports on cable {self.swap_args['component_id'][0]}",
@@ -180,46 +269,42 @@ class TestCableSwapper(ExtendedTestCase):
     def test_get_ports_data_error(self):
         """Test swap_component error getting ports data"""
         self.mock_port_manager.get_jack_port_data_list.return_value = None
-        with self.assertRaises(SystemExit) as cm, \
-             self.assertLogs(level=logging.INFO) as logs_cm:
+        with self.assertRaises(SystemExit) as cm:
             self.run_swap_component()
         self.assertEqual(cm.exception.code, swap.ERR_GET_PORTS_FAIL)
         self.mock_port_manager.get_jack_port_data_list.assert_called_once()
         self.mock_output_json.assert_not_called()
         self.mock_port_manager.create_offline_port_policy.assert_not_called()
-        self.mock_port_manager.update_port_policy_link.assert_not_called()
+        self.mock_port_manager.update_port_policy_links.assert_not_called()
 
     def test_no_jack_ports(self):
         """Test swap_component when no jack ports are returned"""
         self.mock_port_manager.get_jack_port_data_list.return_value = []
-        with self.assertRaises(SystemExit) as cm, \
-             self.assertLogs(level=logging.INFO) as logs_cm:
-            self.run_swap_component()
+        with self.assertLogs(level=logging.ERROR) as logs_cm:
+            with self.assertRaises(SystemExit) as cm:
+                self.run_swap_component()
         self.assertEqual(cm.exception.code, swap.ERR_NO_PORTS_FOUND)
         self.mock_port_manager.get_jack_port_data_list.assert_called_once()
         self.mock_output_json.assert_not_called()
         self.mock_port_manager.create_offline_port_policy.assert_not_called()
-        self.mock_port_manager.update_port_policy_link.assert_not_called()
-        self.assert_in_element(
-            f"No ports found for cable {self.swap_args['component_id']}",
-            logs_cm.output)
+        self.mock_port_manager.update_port_policy_links.assert_not_called()
+        self.assert_in_element(f"No ports found for cable {self.swap_args['component_id']}",
+                               logs_cm.output)
 
     def test_create_port_policy_error(self):
         """Test swap_component disable with an error creating port policy"""
         self.swap_args['dry_run'] = False
         self.swap_args['action'] = 'disable'
         self.mock_port_manager.create_offline_port_policy.return_value = None
-        with self.assertRaises(SystemExit) as cm, \
-             self.assertLogs(level=logging.INFO) as logs_cm:
-            self.run_swap_component()
+        with self.assertLogs(level=logging.INFO) as logs_cm:
+            with self.assertRaises(SystemExit) as cm:
+                self.run_swap_component()
         self.assertEqual(cm.exception.code, swap.ERR_PORT_POLICY_CREATE_FAIL)
         self.mock_port_manager.get_jack_port_data_list.assert_called_once()
         self.mock_output_json.assert_not_called()
         self.mock_port_manager.create_offline_port_policy.assert_called()
-        self.mock_port_manager.update_port_policy_link.assert_not_called()
-        self.mock_port_manager.get_jack_port_data_list.return_value
-        xnames = self.mock_port_manager.get_jack_port_data_list.return_value
-        expected_logs = [f"Ports: {' '.join([p['xname'] for p in xnames])}",
+        self.mock_port_manager.update_port_policy_links.assert_not_called()
+        expected_logs = [f"Ports: {' '.join([p['xname'] for p in self.mock_port_data_list])}",
                          f"Disabling ports on cable {self.swap_args['component_id'][0]}"]
         for msg in expected_logs:
             self.assert_in_element(msg, logs_cm.output)
@@ -228,17 +313,16 @@ class TestCableSwapper(ExtendedTestCase):
         """Test swap_component enable with an error updating port policy link"""
         self.swap_args['dry_run'] = False
         self.swap_args['action'] = 'enable'
-        self.mock_port_manager.update_port_policy_link.return_value = None
-        with self.assertRaises(SystemExit) as cm, \
-             self.assertLogs(level=logging.INFO) as logs_cm:
-            self.run_swap_component()
+        self.mock_port_manager.update_port_policy_links.return_value = None
+        with self.assertLogs(level=logging.INFO) as logs_cm:
+            with self.assertRaises(SystemExit) as cm:
+                self.run_swap_component()
         self.assertEqual(cm.exception.code, swap.ERR_PORT_POLICY_TOGGLE_FAIL)
         self.mock_port_manager.get_jack_port_data_list.assert_called_once()
         self.mock_output_json.assert_not_called()
         self.mock_port_manager.create_offline_port_policy.assert_not_called()
-        self.assertEqual(self.mock_port_manager.update_port_policy_link.call_count, 4)
-        xnames = self.mock_port_manager.get_jack_port_data_list.return_value
-        expected_logs = [f"Ports: {' '.join([p['xname'] for p in xnames])}",
+        self.assertEqual(self.mock_port_manager.update_port_policy_links.call_count, 4)
+        expected_logs = [f"Ports: {' '.join([p['xname'] for p in self.mock_port_data_list])}",
                          f"Enabling ports on cable {self.swap_args['component_id'][0]}"]
         for msg in expected_logs:
             self.assert_in_element(msg, logs_cm.output)
@@ -247,17 +331,16 @@ class TestCableSwapper(ExtendedTestCase):
         """Test swap_component disable with an error updating port policy link"""
         self.swap_args['dry_run'] = False
         self.swap_args['action'] = 'disable'
-        self.mock_port_manager.update_port_policy_link.return_value = None
-        with self.assertRaises(SystemExit) as cm, \
-             self.assertLogs(level=logging.INFO) as logs_cm:
-            self.run_swap_component()
+        self.mock_port_manager.update_port_policy_links.return_value = None
+        with self.assertLogs(level=logging.INFO) as logs_cm:
+            with self.assertRaises(SystemExit) as cm:
+                self.run_swap_component()
         self.assertEqual(cm.exception.code, swap.ERR_PORT_POLICY_TOGGLE_FAIL)
         self.mock_port_manager.get_jack_port_data_list.assert_called_once()
         self.mock_output_json.assert_not_called()
         self.mock_port_manager.create_offline_port_policy.assert_called()
-        self.assertEqual(self.mock_port_manager.update_port_policy_link.call_count, 4)
-        xnames = self.mock_port_manager.get_jack_port_data_list.return_value
-        expected_logs = [f"Ports: {' '.join([p['xname'] for p in xnames])}",
+        self.assertEqual(self.mock_port_manager.update_port_policy_links.call_count, 4)
+        expected_logs = [f"Ports: {' '.join([p['xname'] for p in self.mock_port_data_list])}",
                          f"Disabling ports on cable {self.swap_args['component_id'][0]}",
                          f"Failed to disable cable {self.swap_args['component_id'][0]}"]
         for msg in expected_logs:
@@ -273,23 +356,24 @@ class TestSwitchSwapper(ExtendedTestCase):
         self.mock_port_manager.get_switch_port_data_list.return_value = [
             {'xname': 'x1000c6r7j101p0',
              'port_link': '/fabric/ports/x1000c6r7j101p0',
-             'policy_link': '/fabric/port-policies/fabric-policy'},
+             'policy_links': [FABRIC_POLICY_LINK]},
             {'xname': 'x1000c6r7j101p1',
              'port_link': '/fabric/ports/x1000c6r7j101p1',
-             'policy_link': '/fabric/port-policies/fabric-policy'},
+             'policy_links': [FABRIC_POLICY_LINK]},
             {'xname': 'x1000c6r7j2p0',
              'port_link': '/fabric/ports/x1000c6r7j2p0',
-             'policy_link': '/fabric/port-policies/edge-policy'},
+             'policy_links': [EDGE_POLICY_LINK]},
             {'xname': 'x1000c6r7j2p1',
              'port_link': '/fabric/ports/x1000c6r7j2p1',
-             'policy_link': '/fabric/port-policies/edge-policy'}
+             'policy_links': [EDGE_POLICY_LINK]}
         ]
         self.mock_pester = mock.patch('sat.cli.swap.swap.pester', autospec=True).start()
         self.mock_pester.return_value = True
         self.mock_print = mock.patch('builtins.print', autospec=True).start()
         self.mock_output_json = mock.patch('sat.cli.swap.swap.output_json', autospec=True).start()
 
-        self.swap_args = {
+        # Type hint quiets PyCharm when 'action' value is set to a str in tests
+        self.swap_args: dict[str, typing.Any] = {
             'action': None,
             'component_id': 'x1000c6r7',
             'disruptive': True,
@@ -312,7 +396,7 @@ class TestSwitchSwapper(ExtendedTestCase):
         self.mock_port_manager.get_switch_port_data_list.assert_called_once()
         self.mock_output_json.assert_not_called()
         self.mock_port_manager.create_offline_port_policy.assert_not_called()
-        self.mock_port_manager.update_port_policy_link.assert_not_called()
+        self.mock_port_manager.update_port_policy_links.assert_not_called()
         xnames = self.mock_port_manager.get_jack_port_data_list.return_value
         expected_logs = [
             f"Ports: {' '.join([p['xname'] for p in xnames])}",
@@ -328,7 +412,7 @@ class TestSwitchSwapper(ExtendedTestCase):
         self.mock_port_manager.get_switch_port_data_list.assert_called_once_with(switch_xname='x1000c6r7')
         self.mock_output_json.assert_called_once()
         self.mock_port_manager.create_offline_port_policy.assert_not_called()
-        self.mock_port_manager.update_port_policy_link.assert_not_called()
+        self.mock_port_manager.update_port_policy_links.assert_not_called()
         xnames = self.mock_port_manager.get_jack_port_data_list.return_value
         expected_logs = [
             f"Ports: {' '.join([p['xname'] for p in xnames])}",
@@ -345,7 +429,7 @@ class TestSwitchSwapper(ExtendedTestCase):
         self.mock_port_manager.get_switch_port_data_list.assert_called_once()
         self.mock_output_json.assert_not_called()
         self.mock_port_manager.create_offline_port_policy.assert_not_called()
-        self.mock_port_manager.update_port_policy_link.assert_called()
+        self.mock_port_manager.update_port_policy_links.assert_called()
         xnames = self.mock_port_manager.get_jack_port_data_list.return_value
         expected_logs = [f"Ports: {' '.join([p['xname'] for p in xnames])}",
                          f"Enabling ports on switch {self.swap_args['component_id']}",
@@ -362,7 +446,7 @@ class TestSwitchSwapper(ExtendedTestCase):
         self.mock_port_manager.get_switch_port_data_list.assert_called_once()
         self.mock_output_json.assert_not_called()
         self.mock_port_manager.create_offline_port_policy.assert_called()
-        self.mock_port_manager.update_port_policy_link.assert_called()
+        self.mock_port_manager.update_port_policy_links.assert_called()
         xnames = self.mock_port_manager.get_jack_port_data_list.return_value
         expected_logs = [f"Ports: {' '.join([p['xname'] for p in xnames])}",
                          f"Disabling ports on switch {self.swap_args['component_id']}",
@@ -380,7 +464,7 @@ class TestSwitchSwapper(ExtendedTestCase):
         self.mock_port_manager.get_switch_port_data_list.assert_called_once()
         self.mock_output_json.assert_not_called()
         self.mock_port_manager.create_offline_port_policy.assert_not_called()
-        self.mock_port_manager.update_port_policy_link.assert_called()
+        self.mock_port_manager.update_port_policy_links.assert_called()
         xnames = self.mock_port_manager.get_jack_port_data_list.return_value
         expected_logs = [f"Ports: {' '.join([p['xname'] for p in xnames])}",
                          f"Enabling ports on switch {self.swap_args['component_id']}",
@@ -391,26 +475,25 @@ class TestSwitchSwapper(ExtendedTestCase):
     def test_get_ports_data_error(self):
         """Test swap_component error getting ports data"""
         self.mock_port_manager.get_switch_port_data_list.return_value = None
-        with self.assertRaises(SystemExit) as cm, \
-             self.assertLogs(level=logging.INFO) as logs_cm:
+        with self.assertRaises(SystemExit) as cm:
             self.run_swap_component()
         self.assertEqual(cm.exception.code, swap.ERR_GET_PORTS_FAIL)
         self.mock_port_manager.get_switch_port_data_list.assert_called_once()
         self.mock_output_json.assert_not_called()
         self.mock_port_manager.create_offline_port_policy.assert_not_called()
-        self.mock_port_manager.update_port_policy_link.assert_not_called()
+        self.mock_port_manager.update_port_policy_links.assert_not_called()
 
     def test_no_jack_ports(self):
         """Test swap_component when no jack ports are returned"""
         self.mock_port_manager.get_switch_port_data_list.return_value = []
-        with self.assertRaises(SystemExit) as cm, \
-                self.assertLogs(level=logging.INFO) as logs_cm:
-            self.run_swap_component()
+        with self.assertLogs(level=logging.INFO) as logs_cm:
+            with self.assertRaises(SystemExit) as cm:
+                self.run_swap_component()
         self.assertEqual(cm.exception.code, swap.ERR_NO_PORTS_FOUND)
         self.mock_port_manager.get_switch_port_data_list.assert_called_once()
         self.mock_output_json.assert_not_called()
         self.mock_port_manager.create_offline_port_policy.assert_not_called()
-        self.mock_port_manager.update_port_policy_link.assert_not_called()
+        self.mock_port_manager.update_port_policy_links.assert_not_called()
         self.assert_in_element(f"No ports found for switch {self.swap_args['component_id']}",
                                logs_cm.output)
 
@@ -419,14 +502,14 @@ class TestSwitchSwapper(ExtendedTestCase):
         self.swap_args['dry_run'] = False
         self.swap_args['action'] = 'disable'
         self.mock_port_manager.create_offline_port_policy.return_value = None
-        with self.assertRaises(SystemExit) as cm, \
-                self.assertLogs(level=logging.INFO) as logs_cm:
-            self.run_swap_component()
+        with self.assertLogs(level=logging.INFO) as logs_cm:
+            with self.assertRaises(SystemExit) as cm:
+                self.run_swap_component()
         self.assertEqual(cm.exception.code, swap.ERR_PORT_POLICY_CREATE_FAIL)
         self.mock_port_manager.get_switch_port_data_list.assert_called_once()
         self.mock_output_json.assert_not_called()
         self.mock_port_manager.create_offline_port_policy.assert_called()
-        self.mock_port_manager.update_port_policy_link.assert_not_called()
+        self.mock_port_manager.update_port_policy_links.assert_not_called()
         xnames = self.mock_port_manager.get_jack_port_data_list.return_value
         expected_logs = [f"Ports: {' '.join([p['xname'] for p in xnames])}",
                          f"Disabling ports on switch {self.swap_args['component_id']}"]
@@ -437,27 +520,27 @@ class TestSwitchSwapper(ExtendedTestCase):
         """Test swap_component enable with an error updating port policy link"""
         self.swap_args['dry_run'] = False
         self.swap_args['action'] = 'enable'
-        self.mock_port_manager.update_port_policy_link.return_value = None
+        self.mock_port_manager.update_port_policy_links.return_value = None
         with self.assertRaises(SystemExit) as cm:
             self.run_swap_component()
         self.assertEqual(cm.exception.code, swap.ERR_PORT_POLICY_TOGGLE_FAIL)
         self.mock_port_manager.get_switch_port_data_list.assert_called_once()
         self.mock_output_json.assert_not_called()
         self.mock_port_manager.create_offline_port_policy.assert_not_called()
-        self.assertEqual(self.mock_port_manager.update_port_policy_link.call_count, 4)
+        self.assertEqual(self.mock_port_manager.update_port_policy_links.call_count, 4)
 
     def test_disable_update_port_policy_link_error(self):
         """Test swap_component disable with an error updating port policy link"""
         self.swap_args['dry_run'] = False
         self.swap_args['action'] = 'disable'
-        self.mock_port_manager.update_port_policy_link.return_value = None
+        self.mock_port_manager.update_port_policy_links.return_value = None
         with self.assertRaises(SystemExit) as cm:
             self.run_swap_component()
         self.assertEqual(cm.exception.code, swap.ERR_PORT_POLICY_TOGGLE_FAIL)
         self.mock_port_manager.get_switch_port_data_list.assert_called_once()
         self.mock_output_json.assert_not_called()
         self.mock_port_manager.create_offline_port_policy.assert_called()
-        self.assertEqual(self.mock_port_manager.update_port_policy_link.call_count, 4)
+        self.assertEqual(self.mock_port_manager.update_port_policy_links.call_count, 4)
 
 
 class TestOutputJson(unittest.TestCase):

--- a/tests/cli/swap/test_switch.py
+++ b/tests/cli/swap/test_switch.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2021, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -35,7 +35,6 @@ def set_options(namespace):
     """Set default options for Namespace."""
     namespace.xname = 'x1000c6r7'
     namespace.action = None
-    namespace.disruptive = True
     namespace.dry_run = True
     namespace.save_ports = False
 
@@ -56,7 +55,6 @@ class TestSwapSwitch(unittest.TestCase):
         swap_switch(self.fake_args)
         self.fake_swap_component.assert_called_once_with(self.fake_args.action,
                                                          self.fake_args.xname,
-                                                         self.fake_args.disruptive,
                                                          self.fake_args.dry_run,
                                                          self.fake_args.save_ports)
 


### PR DESCRIPTION
## Summary and Scope

* CRAYSAT-1798: Preserve all port policies in `sat swap`

  When enabling or disabling a switch or a cable in `sat swap switch` or
  `sat swap cable`, properly handle when a port has multiple port policies
  applied to it. This fixes the issue where only the first port policy
  associated with a port is kept through the disable/enable cycle.

  The strategy for keeping a record of the port policies applied to each
  port is unchanged. That is, for the disable action, for each port
  policy associated with the ports to be disabled, append the
  "sat-offline-" prefix to the policy name, create a new policy
  with the prefixed name which has `"state": "OFFLINE"`, and then apply
  the policy to the port being disabled.

  Note that for ports with more than one policy associated with them (e.g.
  fabric ports which have a fabric policy and a qos policy), this will
  result in multiple policies with the same `"state": "OFFLINE"` data
  being assigned to those ports. According to the Slingshot team, this is
  acceptable and should not cause issues.

  Fix and improve the unit tests for the `get_switch_port_data_list`
  method of the `PortManager`.  This now tests the method for a switch
  with just edge ports, a switch with just fabric ports, and a switch with
  both fabric and edge ports. It also does more consistent mocking by
  mocking the `get_port` method instead of directly mocking the
  `FabricControllerClient` class.

  Fix unit tests for `PortManager.get_jack_port_data_list`. Fix the
  `swap_component` unit tests for the `CableSwapper` and `SwitchSwapper`.

  Fix minor issues in tests including PyCharm code inspection type
  warnings and faulty `assertLogs` usages.

  Test Description:
  The following will be tested on baldar:

  * `sat swap switch --action disable` on an enabled switch
  * `sat swap switch --action disable` on an disabled switch
  * `sat swap switch --action enable` on an disabled switch
  * `sat swap switch --action enable` on an enabled switch

  The same will also be tested for `sat swap cable`.

* CRAYSAT-1798: Remove unused `disruptive` argument from `swap_component`

  The `disruptive` argument was not used in the `swap_component` method of
  the `Swapper` class. The value of the `disruptive` command-line option
  is checked in the function `check_arguments` in `sat.cli.swap.main`
  before calling the appropriate function for the cable, switch, or blade.

  Test Description:
  Unit tests pass. PyCharm is happier.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

