### PR TITLE
 CRAYSAT-1798: Preserve all port policies in sat swap (release/3.27)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.27.3] - 2024-01-31
+
+### Fixed
+- Fixed `sat swap switch` and `sat swap cable` so that they preserve all
+  existing port policies applied to the ports on a switch or a cable across the
+  disable and enable actions. The old behavior was that only the first policy
+  would be preserved, which was a problem for ports with multiple policies
+  configured.
+
 ## [3.27.2] - 2024-01-16
 
 ### Fixed

--- a/sat/cli/swap/cable.py
+++ b/sat/cli/swap/cable.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2021, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -39,7 +39,6 @@ def swap_cable(args):
 
     CableSwapper().swap_component(args.action,
                                   args.xnames,
-                                  args.disruptive,
                                   args.dry_run,
                                   args.save_ports,
                                   args.force)

--- a/sat/cli/swap/ports.py
+++ b/sat/cli/swap/ports.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2021, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -179,9 +179,9 @@ class PortManager:
             A list of dictionaries for ports or None if there is an error
                 Example: {"xname": "x3000c0r21j14p0",
                           "port_link": "/fabric/ports/x3000c0r21j14p0",
-                          "policy_link: "/fabric/port-policies/fabric-policy"}
+                          "policy_links: ["/fabric/port-policies/cassini-policy",
+                                          "/fabric/port-policies/qos-ll_be_bd_et-cassini-policy"]}
         """
-
         port_data_list = []
         for port_link in port_links:
             port = self.get_port(port_link)
@@ -194,7 +194,7 @@ class PortManager:
             try:
                 port_data['xname'] = port['conn_port']
                 port_data['port_link'] = port_link
-                port_data['policy_link'] = port['portPolicyLinks'][0]
+                port_data['policy_links'] = port['portPolicyLinks']
             except KeyError as err:
                 LOGGER.error('Key %s for port data missing from fabric manager switch information.', err)
                 return None
@@ -322,12 +322,12 @@ class PortManager:
 
         return port_data_list
 
-    def update_port_policy_link(self, port_link, policy_link):
+    def update_port_policy_links(self, port_link, policy_links):
         """Update a port to use a new policy
 
         Args:
             port_link (str): The full path of the port document link
-            policy_link (str): The full path of the new port policy
+            policy_links (list): The full paths of the new port policies
 
         Returns:
             True if update is successful
@@ -335,8 +335,7 @@ class PortManager:
         """
 
         # Example: {"portPolicyLinks":["/fabric/port-policies/edge-policy"]}
-        port_config = {}
-        port_config['portPolicyLinks'] = [policy_link]
+        port_config = {'portPolicyLinks': policy_links}
         config_json = json.dumps(port_config)
         LOGGER.debug(f'Updating port: {port_link}')
         LOGGER.debug(f'config_json: {config_json}')

--- a/sat/cli/swap/switch.py
+++ b/sat/cli/swap/switch.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2021, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -39,6 +39,5 @@ def swap_switch(args):
 
     SwitchSwapper().swap_component(args.action,
                                    args.xname,
-                                   args.disruptive,
                                    args.dry_run,
                                    args.save_ports)

--- a/tests/cli/swap/test_cable.py
+++ b/tests/cli/swap/test_cable.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2021, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -35,7 +35,6 @@ def set_options(namespace):
     """Set default options for Namespace."""
     namespace.xnames = ['x1000c6r7j101', 'x1000c6r8j102']
     namespace.action = None
-    namespace.disruptive = True
     namespace.dry_run = True
     namespace.force = False
     namespace.save_ports = False
@@ -62,7 +61,6 @@ class TestSwapCable(unittest.TestCase):
         swap_cable(self.fake_args)
         self.fake_swap_component.assert_called_once_with(self.fake_args.action,
                                                          self.fake_args.xnames,
-                                                         self.fake_args.disruptive,
                                                          self.fake_args.dry_run,
                                                          self.fake_args.save_ports,
                                                          self.fake_args.force)

--- a/tests/cli/swap/test_switch.py
+++ b/tests/cli/swap/test_switch.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2021, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -35,7 +35,6 @@ def set_options(namespace):
     """Set default options for Namespace."""
     namespace.xname = 'x1000c6r7'
     namespace.action = None
-    namespace.disruptive = True
     namespace.dry_run = True
     namespace.save_ports = False
 
@@ -56,7 +55,6 @@ class TestSwapSwitch(unittest.TestCase):
         swap_switch(self.fake_args)
         self.fake_swap_component.assert_called_once_with(self.fake_args.action,
                                                          self.fake_args.xname,
-                                                         self.fake_args.disruptive,
                                                          self.fake_args.dry_run,
                                                          self.fake_args.save_ports)
 


### PR DESCRIPTION
## Summary and Scope

* CRAYSAT-1798: Preserve all port policies in `sat swap`

  When enabling or disabling a switch or a cable in `sat swap switch` or
  `sat swap cable`, properly handle when a port has multiple port policies
  applied to it. This fixes the issue where only the first port policy
  associated with a port is kept through the disable/enable cycle.

  The strategy for keeping a record of the port policies applied to each
  port is unchanged. That is, for the disable action, for each port
  policy associated with the ports to be disabled, append the
  "sat-offline-" prefix to the policy name, create a new policy
  with the prefixed name which has `"state": "OFFLINE"`, and then apply
  the policy to the port being disabled.

  Note that for ports with more than one policy associated with them (e.g.
  fabric ports which have a fabric policy and a qos policy), this will
  result in multiple policies with the same `"state": "OFFLINE"` data
  being assigned to those ports. According to the Slingshot team, this is
  acceptable and should not cause issues.

  Fix and improve the unit tests for the `get_switch_port_data_list`
  method of the `PortManager`.  This now tests the method for a switch
  with just edge ports, a switch with just fabric ports, and a switch with
  both fabric and edge ports. It also does more consistent mocking by
  mocking the `get_port` method instead of directly mocking the
  `FabricControllerClient` class.

  Fix unit tests for `PortManager.get_jack_port_data_list`. Fix the
  `swap_component` unit tests for the `CableSwapper` and `SwitchSwapper`.

  Fix minor issues in tests including PyCharm code inspection type
  warnings and faulty `assertLogs` usages.

  Test Description:
  The following will be tested on baldar:

  * `sat swap switch --action disable` on an enabled switch
  * `sat swap switch --action disable` on an disabled switch
  * `sat swap switch --action enable` on an disabled switch
  * `sat swap switch --action enable` on an enabled switch

  The same will also be tested for `sat swap cable`.

* CRAYSAT-1798: Remove unused `disruptive` argument from `swap_component`

  The `disruptive` argument was not used in the `swap_component` method of
  the `Swapper` class. The value of the `disruptive` command-line option
  is checked in the function `check_arguments` in `sat.cli.swap.main`
  before calling the appropriate function for the cable, switch, or blade.

  Test Description:
  Unit tests pass. PyCharm is happier.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

