### PR TITLE
CRAYSAT-1764: sat status bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.27.7] - 2024-02-20
+
+### Changed
+- Changed the WARNING messages about the deleted BOS sessions to DEBUG messages
+  for `sat status`
+- Changed the "Most Recent Image" column to show the IMS image ID instead of
+  image name for `sat status`
+
 ## [3.27.6] - 2024-02-16
 
 ### Fixed

--- a/tests/cli/status/test_status_module.py
+++ b/tests/cli/status/test_status_module.py
@@ -339,19 +339,6 @@ class TestBOSStatusModule(BaseStatusModuleTestCase):
         patch('sat.cli.status.status_module.BOSClientCommon.get_bos_client',
               return_value=self.mock_bos_client).start()
 
-        self.mock_ims_client = MagicMock()
-        self.mock_ims_client.get_image.return_value = {
-            'created': '2022-01-01T00:00:00',
-            'id': self.img_id,
-            'link': {
-                'etag': 'abcdef123456789abcdef12345678909',
-                'path': f's3://boot-images/{self.img_id}/manifest.json',
-                'type': 's3',
-            },
-            'name': self.img_name,
-        }
-        patch('sat.cli.status.status_module.IMSClient', return_value=self.mock_ims_client).start()
-
         self.session = MagicMock()
 
     def test_can_use_in_bos_v1(self):
@@ -377,7 +364,7 @@ class TestBOSStatusModule(BaseStatusModuleTestCase):
             'xname': self.xname,
             'Boot Status': 'stable',
             'Most Recent BOS Session': self.bos_session,
-            'Most Recent Image': self.img_name,
+            'Most Recent Image': self.img_id,
             'Most Recent Session Template': self.bos_sessiontemplate,
         })
 
@@ -390,7 +377,7 @@ class TestBOSStatusModule(BaseStatusModuleTestCase):
             'xname': self.xname,
             'Boot Status': 'stable',
             'Most Recent BOS Session': MISSING_VALUE,
-            'Most Recent Image': self.img_name,
+            'Most Recent Image': self.img_id,
         })
 
     def test_no_session_key_for_component(self):
@@ -402,7 +389,7 @@ class TestBOSStatusModule(BaseStatusModuleTestCase):
             'xname': self.xname,
             'Boot Status': 'stable',
             'Most Recent BOS Session': MISSING_VALUE,
-            'Most Recent Image': self.img_name,
+            'Most Recent Image': self.img_id,
         })
 
     def test_session_key_empty_string(self):
@@ -413,7 +400,7 @@ class TestBOSStatusModule(BaseStatusModuleTestCase):
             'xname': self.xname,
             'Boot Status': 'stable',
             'Most Recent BOS Session': MISSING_VALUE,
-            'Most Recent Image': self.img_name,
+            'Most Recent Image': self.img_id,
         })
 
     def test_get_session_apierror(self):
@@ -425,7 +412,7 @@ class TestBOSStatusModule(BaseStatusModuleTestCase):
             'xname': self.xname,
             'Boot Status': 'stable',
             'Most Recent BOS Session': self.bos_session,
-            'Most Recent Image': self.img_name,
+            'Most Recent Image': self.img_id,
         })
 
     def test_get_session_missing_template_name(self):
@@ -443,5 +430,5 @@ class TestBOSStatusModule(BaseStatusModuleTestCase):
             'xname': self.xname,
             'Boot Status': 'stable',
             'Most Recent BOS Session': self.bos_session,
-            'Most Recent Image': self.img_name,
+            'Most Recent Image': self.img_id,
         })


### PR DESCRIPTION
IM: CRAYSAT-1764
Reviewer: Ryan, Shiva

## Summary and Scope

- Change the WARNING messages about the deleted BOS sessions to DEBUG messages
- Keep the "Most Recent Session Template" column in the output of sat status
- changing the Most Recent Image column to show the IMS image ID instead of the name

## Issues and Related PRs

Resolves [CRAYSAT-1764](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1764)

## Testing

Testing on baldar (csm system)

### Test description:

TO DO

## Risks and Mitigations

Low Risk


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

