### PR TITLE
CRAYSAT-1621: modifying sat bootsys shutdown approach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Removed the step that freezes Ceph from the `platform-services` stage of `sat bootsys shutdown`
+- Modified the `ncn-power` stage of `sat bootsys shutdown` to shut down the NCNs
+  one group at a time instead of all simultaneously. The new order of this stage
+  is to shut down workers, shut down masters (except ncn-m001), unmap and
+  unmount all rbd devices on `ncn-m001`, and then shut down storage nodes.
+
 ### Fixed
 - Updated `sat bootsys` to increase the default management NCN shutdown timeout
   to 900 seconds.

--- a/docs/man/sat-bootsys.8.rst
+++ b/docs/man/sat-bootsys.8.rst
@@ -57,13 +57,15 @@ to reach the power "Off" state.
 
 In the ``platform-services`` stage, it stops all management services on the
 non-compute nodes (NCNs). This includes backing up and stopping the etcd
-cluster, stopping the kubelet service on each node, freezing ceph, and stopping
-all containers running in containerd.
+cluster, stopping the kubelet service on each node, stopping all containers
+running in containerd, and stopping containerd.
 
-In the ``ncn-power`` stage, it shuts down Linux on all management NCNs
-simultaneously, powers them off, and creates screen sessions to monitor console
-logs using ``ipmitool``. Once this has completed, and it is safe to shutdown
-and power off ncn-m001 where this command was run.
+In the ``ncn-power`` stage, it shuts down worker NCNs, shuts down master NCNs
+except ncn-m001, unmaps and unmounts rbd devices on ncn-m001, freezes Ceph,
+and shuts down storage nodes. While each group of management NCNs is being shut
+down, it sets up screen sessions to monitor console logs using ``ipmitool``.
+Once this has completed, it is safe to shutdown and power off ncn-m001 where
+this command was run.
 
 BOOT ACTION
 -----------

--- a/sat/cli/bootsys/platform.py
+++ b/sat/cli/bootsys/platform.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021, 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021, 2023, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -503,7 +503,7 @@ def do_recreate_cronjobs(_):
         LOGGER.warning('Could not load Kubernetes configuration: %s', err)
 
 
-def do_ceph_freeze(ncn_groups):
+def do_ceph_freeze():
     """Check ceph health and freeze if healthy.
 
     Raises:
@@ -604,7 +604,6 @@ STEPS_BY_ACTION = {
         PlatformServicesStep('Stop containers running under containerd on all Kubernetes NCNs.',
                              do_stop_containers),
         PlatformServicesStep('Stop containerd on all Kubernetes NCNs.', do_containerd_stop),
-        PlatformServicesStep('Check health of Ceph cluster and freeze state.', do_ceph_freeze)
     ]
 }
 

--- a/tests/cli/bootsys/test_platform.py
+++ b/tests/cli/bootsys/test_platform.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021, 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021, 2023, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -787,7 +787,7 @@ class TestDoCephFreeze(unittest.TestCase):
 
     def test_do_ceph_freeze_success(self):
         """Test do_ceph_freeze in the successful case."""
-        do_ceph_freeze(self.ncn_groups)
+        do_ceph_freeze()
         self.check_ceph_health.assert_called_once_with()
         self.toggle_ceph_freeze_flags.assert_called_once_with(freeze=True)
 
@@ -795,7 +795,7 @@ class TestDoCephFreeze(unittest.TestCase):
         """When Ceph is not healthy, do not freeze Ceph."""
         self.check_ceph_health.side_effect = CephHealthCheckError
         with self.assertRaises(FatalPlatformError):
-            do_ceph_freeze(self.ncn_groups)
+            do_ceph_freeze()
         self.toggle_ceph_freeze_flags.assert_not_called()
 
 


### PR DESCRIPTION
IM:CRAYSAT-1621
Reviewer:Ryan

## Summary and Scope

The changes have be made on two stages of bootsys: 

**1. sat bootsys shutdown -- platform-services**

freeze ceph has been cleaned from the this stage.

**2. sat bootsys shutdown -- ncn-power:** 

Here we have modified the way shutdown of the ncn's are performed.
Earlier all the ncn's except m001 would be shutdown simultaneously together. Now it would be performed in grouping.
And the order would be workers, masters(except m001), unmap rbd on m001, freeze ceph and then shutdown the storage nodes.

The changes are in initial stage, may need add on's post review.



## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CRAYSAT-1621](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1621)
* Future work required by [CRAYSAT-1100](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1100) 


## Testing

Yet to be tested.

### Tested on:

Yet to be tested

### Test description:

Would need to try both the stages and validate.

## Risks and Mitigations

Low risk

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

