### PR TITLE
CRAYSAT-1820: Remove unnecessary queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.27.6] - 2024-02-16
+
+### Fixed
+- Remove unnecessary queries to BOS to get the name of the session template for 
+  every single node component in the output of `sat status`.
+
 ## [3.27.5] - 2024-02-07
 
 ### Security

--- a/sat/cli/status/status_module.py
+++ b/sat/cli/status/status_module.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -560,15 +560,10 @@ class BOSStatusModule(StatusModule):
                     continue
 
                 try:
-                    template_name = component_session['template_name']
-                    component['Most Recent Session Template'] = bos_client.get_session_template(template_name)['name']
-                except APIError as err:
-                    LOGGER.warning('Could not retrieve BOS session template for component %s with session %s: %s',
-                                   component_xname, session_id, err)
-
+                    component['Most Recent Session Template'] = component_session['template_name']
                 except KeyError as err:
-                    LOGGER.warning('"%s" key missing from BOS response for component %s',
-                                   err, component_xname)
+                    LOGGER.warning('Unable to determine session template %s due to missing %s key,',
+                                   session_id, err)
                     continue
             finally:
                 # This finally block always runs regardless of whether the

--- a/tests/cli/status/test_status_module.py
+++ b/tests/cli/status/test_status_module.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -27,6 +27,7 @@ Tests for the sat.cli.status.status_module module.
 from abc import ABC
 import inspect
 import unittest
+import logging
 from unittest.mock import MagicMock, patch
 
 from csm_api_client.service.gateway import APIError
@@ -333,9 +334,6 @@ class TestBOSStatusModule(BaseStatusModuleTestCase):
             },
             'template_name': self.bos_sessiontemplate,
         }
-        self.mock_bos_client.get_session_template.return_value = {
-            'name': self.bos_sessiontemplate
-        }
 
         self.mock_bos_client.get_components.return_value = [self.bos_component]
         patch('sat.cli.status.status_module.BOSClientCommon.get_bos_client',
@@ -430,22 +428,17 @@ class TestBOSStatusModule(BaseStatusModuleTestCase):
             'Most Recent Image': self.img_name,
         })
 
-    def test_get_sessiontemplate_apierror(self):
-        """Test retrieving component boot status when no sessiontemplate found"""
-        self.mock_bos_client.get_session_template.side_effect = APIError
-        rows = BOSStatusModule(session=self.session).rows
+    def test_get_session_missing_template_name(self):
+        """Test retrieving component status when the session template is missing from the session"""
+        del self.mock_bos_client.get_session.return_value['template_name']
+        with self.assertLogs(level=logging.WARNING) as logs_cm:
+            rows = BOSStatusModule(session=self.session).rows
 
-        self.assertEqual(rows[0], {
-            'xname': self.xname,
-            'Boot Status': 'stable',
-            'Most Recent BOS Session': self.bos_session,
-            'Most Recent Image': self.img_name,
-        })
+        self.assertEqual(len(logs_cm.records), 1)
+        self.assertRegex(logs_cm.records[0].message,
+                         "Unable to determine session template .* due to missing 'template_name' key")
 
-    def test_get_sessiontemplate_keyerror(self):
-        """Test retrieving component boot status when sessiontemplate missing "name" key"""
-        self.mock_bos_client.get_session_template.return_value = {}
-        rows = BOSStatusModule(session=self.session).rows
+        self.assertEqual(len(rows), 1)
         self.assertEqual(rows[0], {
             'xname': self.xname,
             'Boot Status': 'stable',


### PR DESCRIPTION
IM:CRAYSAT-1820
Reviewer: Ryan, Shiva

## Summary and Scope

_Remove unnecessary queries to BOS to get the name of the session template for every single node component in the output of sat status_

## Issues and Related PRs

_Resolves [CRAYSAT-1820](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1820)._

## Testing

_yet to be tested._

### Tested on:

  Testing on drax cluster

### Test description:

_After removal of additional query to BOS template, it not impacts the original output of `sat status`._

## Risks and Mitigations

_Low Risk_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

