### PR TITLE
CRAYSAT-1824:Backport cray-sat 3.27.4 through 3.27.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 - Update the version of jinja2 from 3.0.3 to 3.1.3 to address
   CVE-2024-22195
-- Update the version of cryptography from 41.0.6 to 42.0.0 to resolve
-  CVE-2023-50782
+- Update the version of cryptography from 41.0.6 to 42.0.4 to resolve
+  CVE-2023-50782, CVE-2024-0727, and CVE-2024-26130
 
 ### Fixed
 - Remove unnecessary queries to BOS to get the name of the session template for 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.25.11] - 2024-02-23
+
+### Security
+- Update the version of jinja2 from 3.0.3 to 3.1.3 to address
+  CVE-2024-22195
+- Update the version of cryptography from 41.0.6 to 42.0.0 to resolve
+  CVE-2023-50782
+
+### Fixed
+- Remove unnecessary queries to BOS to get the name of the session template for 
+  every single node component in the output of `sat status`.
+
+### Changed
+- Changed the WARNING messages about the deleted BOS sessions to DEBUG messages
+  for `sat status`
+- Changed the "Most Recent Image" column to show the IMS image ID instead of
+  image name for `sat status`
+
 ## [3.25.10] - 2024-02-01
 
 ### Fixed

--- a/requirements-dev.lock.txt
+++ b/requirements-dev.lock.txt
@@ -13,7 +13,7 @@ click==8.0.4
 coverage==6.3.2
 cray-product-catalog==1.6.0
 croniter==0.3.37
-cryptography==42.0.0
+cryptography==42.0.4
 csm-api-client==1.1.5
 dataclasses-json==0.5.6
 docutils==0.17.1

--- a/requirements-dev.lock.txt
+++ b/requirements-dev.lock.txt
@@ -13,7 +13,7 @@ click==8.0.4
 coverage==6.3.2
 cray-product-catalog==1.6.0
 croniter==0.3.37
-cryptography==41.0.6
+cryptography==42.0.0
 csm-api-client==1.1.5
 dataclasses-json==0.5.6
 docutils==0.17.1
@@ -22,7 +22,7 @@ htmlmin==0.1.12
 idna==3.3
 imagesize==1.3.0
 inflect==2.1.0
-Jinja2==3.0.3
+Jinja2==3.1.3
 jmespath==0.10.0
 json-schema-for-humans==0.40
 jsonschema==4.4.0

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -10,14 +10,14 @@ charset-normalizer==2.0.12
 click==8.0.4
 cray-product-catalog==1.6.0
 croniter==0.3.37
-cryptography==41.0.6
+cryptography==42.0.0
 csm-api-client==1.1.5
 dataclasses-json==0.5.6
 google-auth==2.6.0
 htmlmin==0.1.12
 idna==3.3
 inflect==2.1.0
-Jinja2==3.0.3
+Jinja2==3.1.3
 jmespath==0.10.0
 json-schema-for-humans==0.40
 jsonschema==4.4.0

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -10,7 +10,7 @@ charset-normalizer==2.0.12
 click==8.0.4
 cray-product-catalog==1.6.0
 croniter==0.3.37
-cryptography==42.0.0
+cryptography==42.0.4
 csm-api-client==1.1.5
 dataclasses-json==0.5.6
 google-auth==2.6.0

--- a/sat/cli/status/status_module.py
+++ b/sat/cli/status/status_module.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -35,7 +35,6 @@ from csm_api_client.service.gateway import APIError
 from csm_api_client.service.hsm import HSMClient
 
 from sat.apiclient.bos import BOSClientCommon
-from sat.apiclient.ims import IMSClient
 from sat.apiclient.sls import SLSClient
 from sat.config import get_config_value
 from sat.constants import MISSING_VALUE
@@ -459,9 +458,9 @@ class BOSStatusModule(StatusModule):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        # Cache mappings of images IDs to names and BOS IDs to BOS sessions to reduce calls to IMS and BOS.
-        self._cached_image_ids_to_names = {}
+        # Cache mappings of BOS IDs to BOS sessions to reduce calls to BOS.
         self._cached_bos_sessions = {}
+        self.missing_sessions = {}
 
     @staticmethod
     def can_use():
@@ -470,44 +469,25 @@ class BOSStatusModule(StatusModule):
         return (True, None)
 
     def get_image_for_component(self, raw_component):
-        """Helper function to query the image name given a component dict from BOS.
+        """Helper function to query the image ID given a component dict from BOS.
 
         Args:
             raw_component (dict): a component dictionary returned from BOS v2
 
         Returns:
-            str: the name of the IMS image currently booted on the given
+            str: the IMS image ID currently booted on the given
                 component, or MISSING_VALUE if it cannot be identified
         """
-
-        # To get a human readable name for each booted image, IMS is
-        # queried for images based on the path to the actual booted kernel.
-        # This depends on the fact that the IMS image ID is part of the
-        # path to the booted kernel in S3.
-        #
-        # TODO: This seems a bit fragile but BOS doesn't appear to provide
-        # this information anywhere else.
-
-        ims_client = IMSClient(self.session)
-        booted_image = None
+        # Get the IMS image ID from the path to the booted kernel in S3.
+        booted_image_id = None
 
         kernel_path = get_val_by_path(raw_component, 'actual_state.boot_artifacts.kernel')
         if kernel_path:
             img_id = urlparse(kernel_path).path.split('/')[1]
-            if img_id in self._cached_image_ids_to_names:
-                booted_image = self._cached_image_ids_to_names[img_id]
-            else:
-                try:
-                    booted_image = ims_client.get_image(img_id)['name']
-                except APIError as err:
-                    LOGGER.warning('Could not retrieve image name for component %s: %s',
-                                   raw_component['id'], err)
-                except KeyError as err:
-                    LOGGER.warning('Image %s missing "%s" field in IMS response',
-                                   img_id, err)
-                self._cached_image_ids_to_names[img_id] = booted_image
+            if img_id:
+                booted_image_id = img_id
 
-        return booted_image or MISSING_VALUE
+        return booted_image_id or MISSING_VALUE
 
     @property
     def rows(self):
@@ -553,26 +533,30 @@ class BOSStatusModule(StatusModule):
                     try:
                         component_session = bos_client.get_session(session_id)
                     except APIError as err:
-                        LOGGER.warning('Could not retrieve BOS session for component %s: %s',
-                                       component_xname, err)
+                        LOGGER.debug('Could not retrieve BOS session %s: %s',
+                                     session_id, err)
                     self._cached_bos_sessions[session_id] = component_session
                 if component_session is None:
+                    # Track missing sessions
+                    if session_id in self.missing_sessions:
+                        self.missing_sessions[session_id] += 1
+                    else:
+                        self.missing_sessions[session_id] = 1
                     continue
 
                 try:
-                    template_name = component_session['template_name']
-                    component['Most Recent Session Template'] = bos_client.get_session_template(template_name)['name']
-                except APIError as err:
-                    LOGGER.warning('Could not retrieve BOS session template for component %s with session %s: %s',
-                                   component_xname, session_id, err)
-
+                    component['Most Recent Session Template'] = component_session['template_name']
                 except KeyError as err:
-                    LOGGER.warning('"%s" key missing from BOS response for component %s',
-                                   err, component_xname)
+                    LOGGER.warning('Unable to determine session template %s due to missing %s key,',
+                                   session_id, err)
                     continue
             finally:
                 # This finally block always runs regardless of whether the
                 # loop was prematurely `continue`d or not.
                 components.append(component)
+        # Logging missing sessions
+        for session_id, count in self.missing_sessions.items():
+            LOGGER.debug('Session id %s which applies to %d nodes is missing',
+                         session_id, count)
 
         return components


### PR DESCRIPTION
IM:CRAYSAT-1824
Reviewer:Ryan

## Summary and Scope

This will Backport cray-sat 3.27.4 through 3.27.9
- Update the version of jinja2 from 3.0.3 to 3.1.3
- Update the version of cryptography from 41.0.6 to 42.0.0
- Remove unnecessary queries to BOS to get the name of the session template for every single node component in the output of sat status
- Changed the WARNING messages about the deleted BOS sessions to DEBUG messages for sat status
- Changed the "Most Recent Image" column to show the IMS image ID instead of image name for sat status
- Update the version of cryptography from 42.0.0 to 42.0.2
- Update the version of cryptography from 42.0.2 to 42.0.4


## Issues and Related PRs

[CRAYSAT-1816](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1816)
[CRAYSAT-1819](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1819)
[CRAYSAT-1820](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1820)
[CRAYSAT-1764](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1764)
[CRAYSAT-1821](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1821)
[CRAYSAT-1823](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1823)


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

