### PR TITLE
CRAYSAT-1763: Stop supporting --release-files option in sat showrev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.27.11] - 2024-02-28
+
+### Fixed
+- Fixed for `sat showrev` to stop supporting `--release-files` option 
+  and log a warning message indicating that this option is no longer supported.
+
 ## [3.27.10] - 2024-02-26
 
 ### Added

--- a/docs/man/sat-showrev.8.rst
+++ b/docs/man/sat-showrev.8.rst
@@ -7,7 +7,7 @@ Print version information about the system
 ------------------------------------------
 
 :Author: Hewlett Packard Enterprise Development LP.
-:Copyright: Copyright 2019-2021,2023 Hewlett Packard Enterprise Development LP.
+:Copyright: Copyright 2019-2021,2023,2024 Hewlett Packard Enterprise Development LP.
 :Manual section: 8
 
 SYNOPSIS
@@ -114,9 +114,8 @@ These options must be specified after the subcommand.
         the other options are specified, this option is enabled by default.
 
 **--release-files**
-        Display version information installed in the ``/opt/cray/etc/release/``
-        directory. This option is not enabled by default and is included for
-        compatibility with previous releases.
+        The **--release-files** option is no longer supported. Use **--products** to
+        see installed product versions instead. This option is not enabled by default.
 
 **--all**
         Display everything. Equivalent to specifying **--system**,
@@ -144,10 +143,6 @@ site_info: /opt/cray/etc/site_info.yml
         is downloaded from the configured S3 bucket on every invocation of
         **sat showrev** if it is available, otherwise a local copy is used.
 
-release: /opt/cray/etc/release
-        Showrev parses the files in this directory to collect information for
-        the product releases. The fields shown in the output report are all
-        the fields found in these files, along with the product file name.
 
 EXAMPLES
 ========

--- a/sat/cli/showrev/main.py
+++ b/sat/cli/showrev/main.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2021, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -46,15 +46,10 @@ def assign_default_args(args):
     Returns:
         None. Modifies args in place.
     """
-    if args.all:
+    if args.all or not any((args.system, args.products, args.local, args.release_files)):
         args.system = True
         args.products = True
         args.local = True
-        args.release_files = True
-    elif not any((args.system, args.products, args.local, args.release_files)):
-        args.local = True
-        args.system = True
-        args.products = True
 
 
 def do_showrev(args):
@@ -107,12 +102,8 @@ def do_showrev(args):
         )
 
     if args.release_files:
-        release_headings, release_data = products.get_release_file_versions()
-        append_report(
-            'Local Release Files',
-            release_headings,
-            release_data
-        )
+        LOGGER.warning('The --release-files option is no longer supported. Use '
+                       '--products to see installed product versions instead.')
 
     if args.products:
         product_headings, product_data = products.get_product_versions()

--- a/sat/cli/showrev/products.py
+++ b/sat/cli/showrev/products.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2023, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -24,42 +24,12 @@
 """
 Module for obtaining product version information.
 """
-from collections import OrderedDict
 import logging
-import os
 
 from cray_product_catalog.query import ProductCatalog, ProductCatalogError
 
-from sat.constants import MISSING_VALUE
 
 LOGGER = logging.getLogger(__name__)
-
-# This is the only required key in a file to consider it a file that contains
-# version information about an installed product.
-REQUIRED_KEY = 'PRODUCT'
-
-# The name of the column that contains the name of the product release file
-RELEASE_FILE_COLUMN = 'RELEASE_FILE'
-
-
-def _get_unique_keys(ordered_dicts):
-    """Gets a list of unique keys from the list of OrderedDicts.
-
-    Args:
-        ordered_dicts (list): A list of OrderedDicts
-
-    Returns:
-        A list of the unique keys maintaining the order of the keys as seen
-        when iterating over the list of OrderedDicts.
-    """
-    seen_keys = set()
-    unique_keys = []
-    for ordered_dict in ordered_dicts:
-        for key in ordered_dict:
-            if key not in seen_keys:
-                seen_keys.add(key)
-                unique_keys.append(key)
-    return unique_keys
 
 
 def get_product_versions():
@@ -99,70 +69,3 @@ def get_product_versions():
         products.append([product.name, product.version, images, recipes])
 
     return headers, products
-
-
-def get_release_file_versions(release_dir_path='/opt/cray/etc/release'):
-    """Gets the product versions from files in `release_dir_path`.
-
-    Args:
-        The path to the release directory containing product version files.
-
-    Returns:
-        A tuple of (headings, data_rows) where headings is a list of strings
-        representing the headings for the data, and data_rows is a list of
-        lists where each element is a list representing one row of data.
-
-        The headings will be the union of headings seen across every product
-        file, and they will be returned in the same order as seen when iterating
-        over the product files in alphabetical order by file name.
-
-        Every element of data_rows will have a value for each heading, but the
-        value may be `MISSING_VALUE` for headings which are not present in that
-        particular product file.
-    """
-    product_dicts = []
-
-    try:
-        listed_dir = sorted(os.listdir(release_dir_path))
-    except OSError as err:
-        LOGGER.error("Unable to read product versions from '%s': %s",
-                     release_dir_path, err)
-        return [], []
-
-    for path in listed_dir:
-        full_path = os.path.join(release_dir_path, path)
-        if not os.path.isfile(full_path):
-            LOGGER.info("Skipping '%s' because it is not a file.", full_path)
-            continue
-
-        try:
-            with open(full_path, 'r') as f:
-                # read().splitlines() removes trailing '\n' unlike readlines()
-                product_lines = f.read().splitlines()
-        except OSError as err:
-            LOGGER.warning("Skipping unreadable file '%s': %s",
-                           release_dir_path, err)
-            continue
-
-        product_dict = OrderedDict()
-        product_dict[RELEASE_FILE_COLUMN] = path
-
-        for line in product_lines:
-            try:
-                key, value = line.split('=', maxsplit=1)
-            except ValueError:
-                LOGGER.info("Skipping line without '=' in '%s': %s",
-                            full_path, line)
-                continue
-
-            # Remove any double quotes used in the values
-            product_dict[key] = value.strip('"')
-
-        if REQUIRED_KEY in product_dict:
-            product_dicts.append(product_dict)
-
-    headings = _get_unique_keys(product_dicts)
-    data_rows = [[product_dict.get(key, MISSING_VALUE) for key in headings]
-                 for product_dict in product_dicts]
-
-    return headings, data_rows

--- a/tests/cli/showrev/test_products.py
+++ b/tests/cli/showrev/test_products.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2021,2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2021,2023,2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -32,8 +32,7 @@ from unittest.mock import patch, Mock
 
 from cray_product_catalog.query import InstalledProductVersion, ProductCatalogError
 
-from sat.cli.showrev.products import get_product_versions, get_release_file_versions, RELEASE_FILE_COLUMN
-from sat.constants import MISSING_VALUE
+from sat.cli.showrev.products import get_product_versions
 from tests.test_util import ExtendedTestCase
 
 SAMPLES_DIR = os.path.join(os.path.dirname(__file__), 'samples')
@@ -159,127 +158,6 @@ class TestGetProducts(ExtendedTestCase):
         self.mock_product_catalog_cls.assert_called_once_with()
         self.assertEqual(self.expected_headers, actual_headers)
         self.assertEqual(expected_fields, actual_fields)
-
-
-class TestReleaseFiles(unittest.TestCase):
-    """Tests for getting local release files."""
-
-    def test_get_release_file_versions_good(self):
-        """Test get_release_file_versions with a good release directory."""
-        release_dir = os.path.join(SAMPLES_DIR, 'good_release')
-        headers, versions = get_release_file_versions(release_dir)
-
-        expected_headers = [
-            RELEASE_FILE_COLUMN,
-            'PRODUCT',
-            'OS',
-            'ARCH',
-            'VERSION',
-            'DATE',
-        ]
-        expected_versions = [
-            ['analytics',
-             "Cray's Analytics Programming Environment Packages",
-             'SLES15SP1',
-             'x86_64',
-             'base',
-             '20200309155039'],
-            ['cle',
-             "Cray's Linux Environment",
-             'SLES15SP1',
-             'x86_64',
-             '1.2.0',
-             '20200306143455'],
-            ['pe-base',
-             "Cray's Programming Environment BASE Packages",
-             'SLES15SP1',
-             'x86_64',
-             'master',
-             '20200309154143'],
-        ]
-
-        self.assertEqual(expected_headers, headers)
-        self.assertEqual(expected_versions, versions)
-
-    def test_get_release_file_versions_messy(self):
-        """Test get_release_file_versions with a messy release directory.
-
-        This release directory will contain an empty file, a normal product
-        version file, a product version file without all its typical keys and
-        a blank line, a product version file with an extra key, a file that
-        contains a bunch of garbage in it, and a nested directory that should
-        be ignored.
-
-        The get_release_file_versions function should handle all of this gracefully.
-        """
-        release_dir = os.path.join(SAMPLES_DIR, 'messy_release')
-        headers, versions = get_release_file_versions(release_dir)
-
-        expected_headers = [
-            RELEASE_FILE_COLUMN,
-            'PRODUCT',
-            'OS',
-            'ARCH',
-            'VERSION',
-            'DATE',
-            'EXTRA_STUFF'
-        ]
-        expected_versions = [
-            ['analytics',
-             "Cray's Analytics Programming Environment Packages",
-             'SLES15SP1',
-             MISSING_VALUE,
-             MISSING_VALUE,
-             MISSING_VALUE,
-             MISSING_VALUE],
-            ['cle',
-             "Cray's Linux Environment",
-             'SLES15SP1',
-             'x86_64',
-             '1.2.0',
-             '20200306143455',
-             'hello=goodbye'],
-            ['pe-base',
-             "Cray's Programming Environment BASE Packages",
-             'SLES15SP1',
-             'x86_64',
-             'master',
-             '20200309154143',
-             MISSING_VALUE],
-        ]
-
-        self.assertEqual(expected_headers, headers)
-        self.assertEqual(expected_versions, versions)
-
-    @patch('os.listdir', return_value=[])
-    def test_get_release_file_versions_empty_dir(self, _):
-        """Test get_release_file_versions with an empty release directory."""
-        headers, versions = get_release_file_versions('empty_dir')
-        self.assertEqual([], headers)
-        self.assertEqual([], versions)
-
-    @patch('os.listdir', side_effect=FileNotFoundError)
-    def test_get_release_file_versions_non_existent_dir(self, _):
-        """Test get_release_file_versions with a non-existent release dir"""
-        headers, versions = get_release_file_versions('does_not_exist')
-        self.assertEqual([], headers)
-        self.assertEqual([], versions)
-
-    @patch('os.listdir', side_effect=NotADirectoryError)
-    def test_get_release_file_versions_release_non_directory(self, _):
-        """Test get_release_file_versions with release dir not being a dir."""
-        headers, versions = get_release_file_versions('not_a_directory')
-        self.assertEqual([], headers)
-        self.assertEqual([], versions)
-
-    @patch('os.listdir', return_value=['bad_perms', 'other_unreadable'])
-    @patch('builtins.open', side_effect=[PermissionError, OSError])
-    @patch('os.path.isfile', return_value=True)
-    def test_get_release_file_versions_unreadable_files(self, *_):
-        """Test get_release_file_versions with a unreadable files."""
-        headers, versions = get_release_file_versions()
-        self.assertEqual([], headers)
-        self.assertEqual([], versions)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
IM: CRAYSAT-1763
Reviewer: Ryan

## Summary and Scope

_From this PR, will stop supporting `--release-files` option in `sat showrev`_

## Issues and Related PRs

_[CRAYSAT-1763](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1763)_

## Testing

_List the environments in which these changes were tested._

### Tested on:

  _baldar_

### Test description:

_Tested with `sat showrev` commands. Test went fine without any issues_

## Risks and Mitigations

_Low Risk_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

