### PR TITLE
CRAYSAT-1826: Allow for more complex passwords in `sat bmccreds`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,13 +25,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.27.14] - 2024-03-27
+
+### Changed
+- Remove the restrictions on the passwords that can be set with `sat bmccreds`
+  to allow for more complex passwords.
+- Improve the password generation logic in `sat bmccreds` to support generating
+  more complex passwords.
+
 ## [3.27.13] - 2024-03-25
 
 ### Updated
 - Updated the default grace period of the `HMSDiscoveryScheduledWaiter` to 3
   minutes to allow more time for a new job to be scheduled by the cronjob.
 
-## [3.27.12] - 2024-04-14
+## [3.27.12] - 2024-03-14
 
 ### Added
 - Added support for the Power Control Service (PCS). Functionality using CAPMC

--- a/sat/cli/bmccreds/constants.py
+++ b/sat/cli/bmccreds/constants.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -24,7 +24,6 @@
 """
 Constant values for the bmccreds subcommand.
 """
-
 import string
 
 # The username that bmccreds will always use
@@ -39,5 +38,10 @@ MAX_XNAMES_TO_DISPLAY = 20
 # The length of randomly-generated passwords
 RANDOM_PASSWORD_LENGTH = 8
 
-# The set of valid BMC password characters
-VALID_BMC_PASSWORD_CHARACTERS = string.ascii_letters + string.digits + '_'
+VALID_CHAR_SETS = {
+    'alpha': string.ascii_letters,
+    'numeric': string.digits,
+    'symbols': '!@#$%^&*'
+}
+
+VALID_CHAR_SETS_STRING = ''.join(VALID_CHAR_SETS.values())

--- a/tests/cli/bmccreds/test_creds_manager.py
+++ b/tests/cli/bmccreds/test_creds_manager.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -30,7 +30,7 @@ import unittest
 from unittest.mock import call, Mock, patch
 
 from sat.apiclient import APIError
-from sat.cli.bmccreds.constants import BMC_USERNAME
+from sat.cli.bmccreds.constants import BMC_USERNAME, RANDOM_PASSWORD_LENGTH, VALID_CHAR_SETS_STRING
 from sat.cli.bmccreds.creds_manager import BMCCredsException, BMCCredsManager
 from tests.common import ExtendedTestCase
 
@@ -51,9 +51,12 @@ class TestBMCCredsManager(unittest.TestCase):
         self.domain = None
         self.force = False
         self.report_format = 'pretty'
+        self.length = RANDOM_PASSWORD_LENGTH
+        self.allowed_chars = VALID_CHAR_SETS_STRING
 
         self.random_passwords = [
-            BMCCredsManager._generate_random_password_string() for _ in range(len(self.xnames))
+            BMCCredsManager._generate_random_password_string(self)
+            for _ in range(len(self.xnames))
         ]
         self.generate_random_password_string = patch.object(
             BMCCredsManager, '_generate_random_password_string', side_effect=self.random_passwords
@@ -70,7 +73,9 @@ class TestBMCCredsManager(unittest.TestCase):
             xnames=self.xnames,
             domain=self.domain,
             force=self.force,
-            report_format=self.report_format
+            report_format=self.report_format,
+            length=self.length,
+            allowed_chars=self.allowed_chars
         )
 
     def test_set_xnames_with_password(self):


### PR DESCRIPTION
IM:CRAYSAT-1826
Reviewer: Ryan

## Summary and Scope

_Improve "sat bmccreds" to accept and generate stronger passwords_

## Issues and Related PRs

_[CRAYSAT-1826](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1826)_

## Testing

_List the environments in which these changes were tested._

### Tested on:

_baldar and odin_

### Test description:

_Test went fine when executed `sat bmccreds` with `--ranom-password` with all the test cases_

## Risks and Mitigations

_Minimal_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

