### PR TITLE
CRAYSAT-1747: Allow passing CFS session name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.27.15] - 2024-03-27
+
+### Changed
+- Updated `begin_image_configure` to pass session name generated to address the
+  sat bootprep incorrect logging of 2 session names
+
 ## [3.27.14] - 2024-03-27
 
 ### Changed

--- a/requirements-dev.lock.txt
+++ b/requirements-dev.lock.txt
@@ -14,7 +14,7 @@ coverage==6.3.2
 cray-product-catalog==1.6.0
 croniter==0.3.37
 cryptography==42.0.4
-csm-api-client==1.1.5
+csm-api-client==1.2.1
 dataclasses-json==0.5.6
 docutils==0.17.1
 google-auth==2.6.0

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -11,7 +11,7 @@ click==8.0.4
 cray-product-catalog==1.6.0
 croniter==0.3.37
 cryptography==42.0.4
-csm-api-client==1.1.5
+csm-api-client==1.2.1
 dataclasses-json==0.5.6
 google-auth==2.6.0
 htmlmin==0.1.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Top-level requirements for sat package to function.
-# (C) Copyright 2019-2023 Hewlett Packard Enterprise Development LP.
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -22,7 +22,7 @@ argcomplete
 boto3
 botocore
 cray-product-catalog >= 1.6.0
-csm-api-client >= 1.1.4, <2.0
+csm-api-client >= 1.2.1, <2.0
 croniter >= 0.3, < 1.0
 inflect >= 0.2.5, < 3.0
 Jinja2 >= 3.0, < 4.0

--- a/sat/cli/bootprep/input/image.py
+++ b/sat/cli/bootprep/input/image.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -403,7 +403,7 @@ class BaseInputImage(DependencyGroupMember, ABC):
 
         try:
             self.image_configure_session = self.cfs_client.create_image_customization_session(
-                self.configuration, self.image_id_to_configure, self.configuration_group_names, self.name)
+                session_name, self.configuration, self.image_id_to_configure, self.configuration_group_names, self.name)
         except APIError as err:
             raise ImageCreateError(f'Failed to launch image customization CFS session: {err}')
 


### PR DESCRIPTION
## Summary and Scope

Incorrect logging is observed in sat bootprep logs SAT is also generating a session name, 
which is conflicting with session name generated in create_image_customization_session

Hence updating the `begin_image_configure` to pass session name to address sat bootprep incorrect logging

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CRAYSAT-1747](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1747)


## Testing

Tested

### Tested on:

 baldar

### Test description:

sat bootprep run test was verified to check the session name being logged.

**Before changes:**
ncn-m001:/etc/cray/upgrade/csm/media/230912-2 # sat bootprep run  --limit images --limit configurations --vars-file session_vars.yaml --format json --bos-version v2 .bootprep-230912/management-bootprep-shiva.yaml
INFO: Validating given input file .bootprep-230912/management-bootprep-shiva.yaml
INFO: Input file successfully validated against schema
INFO: Creating 1 CFS configuration
INFO: Creating CFS configuration at index 0 with name=b55-management-23.11-shiva
INFO: Successfully created CFS configuration at index 0 with name=b55-management-23.11-shiva
INFO: Found IMS base for image at index 0: image provided by version 1.5.0-beta.55 of product csm with name matching prefix "secure-kubernetes"
INFO: Of the 1 that will be created, 1 have no dependencies and will be created first.
INFO: Creating 1 images.
WARNING: Found 3 public keys in IMS whose contents match the contents of public key file /root/.ssh/id_rsa.pub. Using the first one, but you may wish to clean up the duplicates.
INFO: Using IMS public key with id 1719755a-575a-48de-a44f-dccaa1cbbd1b
INFO: Creating images
INFO: Base for image with name b55-worker-secure-kubernetes-5.2.26-x86_64.squashfs-shiva is a pre-built image.
**INFO: Creating CFS session sat-ae2e9ced-706a-45f1-8331-88c81e2507e1 to configure image b55-worker-secure-kubernetes-5.2.26-x86_64.squashfs-shiva
INFO: Created CFS session sat-ae2e9ced-706a-45f1-8331-88c81e2507e1 to configure image b55-worker-secure-kubernetes-5.2.26-x86_64.squashfs-shiva
INFO: Waiting for CFS to create Kubernetes job associated with session sat-315a07ce-5067-423e-87b5-4f4eba0c7d**60.
INFO: CFS session: sat-315a07ce-5067-423e-87b5-4f4eba0c7d60      Image: b55-worker-secure-kubernetes-5.2.26-x86_64.squashfs-shiva:
INFO:     Container git-clone   transitioned to waiting

**After changes:**
ncn-m001:/etc/cray/upgrade/csm/media/230912-2 # sat bootprep run  --limit images --limit configurations --vars-file session_vars.yaml --format json --bos-version v2 .bootprep-230912/management-bootprep-shiva.yaml
INFO: Validating given input file .bootprep-230912/management-bootprep-shiva.yaml
INFO: Input file successfully validated against schema
1 CFS configuration already exists with the name b55-management-23.11-shiva. Would you like to skip, overwrite, or abort? [skip,overwrite,abort] overwrite
INFO: 1 CFS configuration already exists with the name b55-management-23.11-shiva and will be overwritten.
INFO: Creating 1 CFS configuration
INFO: Creating CFS configuration at index 0 with name=b55-management-23.11-shiva
INFO: Successfully created CFS configuration at index 0 with name=b55-management-23.11-shiva
INFO: Found IMS base for image at index 0: image provided by version 1.5.0-beta.55 of product csm with name matching prefix "secure-kubernetes"
INFO: Of the 1 that will be created, 1 have no dependencies and will be created first.
INFO: Creating 1 images.
WARNING: Found 3 public keys in IMS whose contents match the contents of public key file /root/.ssh/id_rsa.pub. Using the first one, but you may wish to clean up the duplicates.
INFO: Using IMS public key with id 1719755a-575a-48de-a44f-dccaa1cbbd1b
INFO: Creating images
INFO: Base for image with name b55-worker-secure-kubernetes-5.2.26-x86_64.squashfs-shiva is a pre-built image.
**INFO: Creating CFS session sat-6147c976-9087-4a7f-b938-580ba7e7a5ff to configure image b55-worker-secure-kubernetes-5.2.26-x86_64.squashfs-shiva
INFO: Created CFS session sat-6147c976-9087-4a7f-b938-580ba7e7a5ff to configure image b55-worker-secure-kubernetes-5.2.26-x86_64.squashfs-shiva
INFO: Waiting for CFS to create Kubernetes job associated with session sat-6147c976-9087-4a7f-b938-580ba7e7a5ff.
INFO: CFS session: sat-6147c976-9087-4a7f-b938-580ba7e7a5ff      Image: b55-worker-secure-kubernetes-5.2.26-x86_64.squashfs-shiva:**
INFO:     Container git-clone   transitioned to running


## Risks and Mitigations

Minimal

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

