### PR TITLE
CRAYSAT-1835:increasing default grace period for hsm discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.27.13] - 2024-03-25
+
+### Updated
+- Updated the default grace period of the `HMSDiscoveryScheduledWaiter` to 3
+  minutes to allow more time for a new job to be scheduled by the cronjob.
+
 ## [3.27.12] - 2024-04-14
 
 ### Added

--- a/sat/hms_discovery.py
+++ b/sat/hms_discovery.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -201,7 +201,7 @@ class HMSDiscoveryCronJob:
 class HMSDiscoveryScheduledWaiter(Waiter):
     """Waiter for HMS discovery cronjob to be scheduled by k8s."""
 
-    def __init__(self, poll_interval=5, grace_period=60, retries=1):
+    def __init__(self, poll_interval=5, grace_period=180, retries=1):
         """Create a new HMSDiscoveryScheduledWaiter.
 
         Timeout is computed automatically based on the latest possible time


### PR DESCRIPTION
Reviewer:Ryan

## Summary and Scope

need to increase the grace period to allow more time for a new job to be scheduled by the cronjob. 
It might be good to wait a 3 extra minutes, which is the interval on which the job is created by the cronjob.
Hence increasing the grace period.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CRAYSAT-1835](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1835)


## Testing

yet to be tested
### Tested on:

Baldar



## Risks and Mitigations

minimal

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

