### PR TITLE
CRAYSAT-1775:Update container status in csm_api_client.service.cfs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.27.16] - 2024-03-28
+
+### Fixed
+- Update the `_update_container_status` method of the
+  CFSImageConfigurationSession class in csm_api_client.service.cfs to handle
+  the case when either `init_container_statuses` or `container_statuses` or
+  both are None.
+
 ## [3.27.15] - 2024-03-27
 
 ### Changed

--- a/requirements-dev.lock.txt
+++ b/requirements-dev.lock.txt
@@ -14,7 +14,7 @@ coverage==6.3.2
 cray-product-catalog==1.6.0
 croniter==0.3.37
 cryptography==42.0.4
-csm-api-client==1.2.1
+csm-api-client==1.2.2
 dataclasses-json==0.5.6
 docutils==0.17.1
 google-auth==2.6.0

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -11,7 +11,7 @@ click==8.0.4
 cray-product-catalog==1.6.0
 croniter==0.3.37
 cryptography==42.0.4
-csm-api-client==1.2.1
+csm-api-client==1.2.2
 dataclasses-json==0.5.6
 google-auth==2.6.0
 htmlmin==0.1.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ argcomplete
 boto3
 botocore
 cray-product-catalog >= 1.6.0
-csm-api-client >= 1.2.1, <2.0
+csm-api-client >= 1.2.2, <2.0
 croniter >= 0.3, < 1.0
 inflect >= 0.2.5, < 3.0
 Jinja2 >= 3.0, < 4.0


### PR DESCRIPTION
IM:CRAYSAT-1775
Reviewer:Ryan

Update the _update_container_status method of the CFSImageConfigurationSession class in csm_api_client.service.cfs to handle the case when either init_container_statuses or container_statuses or both are None.

## Summary and Scope

_Update the update_container_status method of the CFSImageConfigurationSession class in csm_api_client.service.cfs when either init_container_statuses or container_statuses or both are None.
If they are None we can log an info message and will skip processing the container statuses until they are populated._

## Issues and Related PRs

_Resolves [CRAYSAT-1775](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1775)._


## Testing

_List the environments in which these changes were tested._

### Tested on:

  Odin

### Test description:

_Test went fine with bootprep command without hitting any issues_

## Risks and Mitigations

_Minimal_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

