### PR TITLE
CRAYSAT-1777: Correct file path for `sat bootprep generate-docs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.27.17] - 2024-04-01
+
+### Fixed
+- Updated `generate_docs_tarball` to pass the correct log message in
+  `sat bootprep generate-docs` to output the relative path as given by the user.
+
 ## [3.27.16] - 2024-03-28
 
 ### Fixed

--- a/sat/cli/bootprep/documentation.py
+++ b/sat/cli/bootprep/documentation.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -125,7 +125,7 @@ def generate_docs_tarball(schema_path, output_dir):
     except OSError as err:
         raise BootPrepDocsError(f'Could not create documentation tarball: {err}') from err
 
-    LOGGER.info('Wrote input schema documentation to %s', output_tar.name)
+    LOGGER.info('Wrote input schema documentation to %s', tarball_output_path)
 
 
 def display_schema(schema_contents):


### PR DESCRIPTION
IM:CRAYSAT-1777
Reviewer:Ryan

## Summary and Scope

_Update `generate_docs_tarball` to pass the correct log message in `sat bootprep generate-docs` to output the relative path as given by the user with the `-o OUTPUT_DIR` option._

## Issues and Related PRs

_Resolves CRAYSAT-1777 ._


## Testing

_List the environments in which these changes were tested._

### Tested on:

_Odin_

### Test description:

_Test went fine for all the possible cases with `sat bootprep generate-docs` command including `-o` option_


## Risks and Mitigations

_Minimal_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

