### PR TITLE
CRAYSAT-1799: Deprecate `sat swap switch/cable`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.28.0] - 2024-04-09
+
+### Deprecated
+- Deprecate the `sat swap switch`, `sat swap cable`, and `sat switch` commands
+  and log a message referring the user to the Slingshot Orchestrated Maintenance
+  procedure instead. Prompt the user if they would still like to continue with
+  the given `sat` command.
+
 ## [3.27.18] - 2024-04-05
 
 ### Fixed

--- a/docs/man/sat-swap.8.rst
+++ b/docs/man/sat-swap.8.rst
@@ -22,9 +22,17 @@ SYNOPSIS
 DESCRIPTION
 ===========
 
-The sat swap subcommand streamlines hardware component replacement by
-disabling components before removal and enabling the new components
-after installation.
+The sat swap subcommand streamlines hardware component replacement by disabling
+components before removal and enabling the new components after installation.
+
+The 'swap blade' subcommand disables or enables a compute or UAN blade. This can
+be used to replace a given blade with a different blade from the same system or
+another system.
+
+Note: The 'sat swap switch' and 'sat swap cable' commands are deprecated and
+will be removed in a future release. Please use Slingshot Orchestrated
+Maintenance to perform switch and cable removal. See the HPE Slingshot
+Operations Guide for details.
 
 The 'swap switch' subcommand disables or enables the ports on a switch
 This can be used during switch replacement, or for other purposes where
@@ -34,9 +42,6 @@ The 'swap cable' subcommand disables or enables the ports to which a cable
 is connected.  Given one or more jacks that a cable connects, the command
 will disable all ports connected by that cable.
 
-The 'swap blade' subcommand disables or enables a compute or UAN blade. This can
-be used to replace a given blade with a different blade from the same system or
-another system.
 
 ARGUMENTS
 =========
@@ -126,14 +131,23 @@ Disable a switch in preparation to replace it:
 ::
 
     # sat swap switch --action disable x1000c6r7
+    WARNING: The "sat swap switch" command has been deprecated and will be removed in a future release. Please use Slingshot Orchestrated Maintenance to perform switch and cable removal. See the HPE Slingshot Operations Guide for details.
+    You may still continue with "sat swap switch", but please begin migrating to Slingshot Orchestrated Maintenance.
+    Proceed with "sat swap switch"? [yes,no] yes
+    Proceeding with "sat swap switch".
     Enable/disable of switch can impact system. Continue? (yes/[no]) yes
     Switch has been disabled and is ready for replacement.
 
-Enable a switch after replacing it and skip the prompt:
+Enable a switch after replacing it and skip the prompt about the operation being
+disruptive. Note that the prompt about the deprecation cannot be skipped.
 
 ::
 
     # sat swap switch --action enable --disruptive x1000c6r7
+    WARNING: The "sat swap switch" command has been deprecated and will be removed in a future release. Please use Slingshot Orchestrated Maintenance to perform switch and cable removal. See the HPE Slingshot Operations Guide for details.
+    You may still continue with "sat swap switch", but please begin migrating to Slingshot Orchestrated Maintenance.
+    Proceed with "sat swap switch"? [yes,no] yes
+    Proceeding with "sat swap switch".
     Switch has been enabled.
 
 Disable a cable in preparation to replace it:
@@ -141,6 +155,10 @@ Disable a cable in preparation to replace it:
 ::
 
     # sat swap cable --action disable --disruptive x5000c1r3j16
+    WARNING: The "sat swap cable" command has been deprecated and will be removed in a future release. Please use Slingshot Orchestrated Maintenance to perform switch and cable removal. See the HPE Slingshot Operations Guide for details.
+    You may still continue with "sat swap cable", but please begin migrating to Slingshot Orchestrated Maintenance.
+    Proceed with "sat swap cable"? [yes,no] yes
+    Proceeding with "sat swap cable".
     Ports: x5000c1r3j16p0 x5000c3r7j18p0 x5000c1r3j16p1 x5000c3r7j18p1
     Cable has been disabled and is ready for replacement.
 
@@ -150,6 +168,10 @@ by the cable:
 ::
 
     # sat swap cable --action disable --disruptive x5000c1r3j16 x5000c3r7j18
+    WARNING: The "sat swap cable" command has been deprecated and will be removed in a future release. Please use Slingshot Orchestrated Maintenance to perform switch and cable removal. See the HPE Slingshot Operations Guide for details.
+    You may still continue with "sat swap cable", but please begin migrating to Slingshot Orchestrated Maintenance.
+    Proceed with "sat swap cable"? [yes,no] yes
+    Proceeding with "sat swap cable".
     Ports: x5000c3r7j18p0 x5000c1r3j16p0 x5000c3r7j18p1 x5000c1r3j16p1
     Cable has been disabled and is ready for replacement.
 
@@ -159,6 +181,10 @@ are not connected by a single cable:
 ::
 
     # sat swap cable --action disable --disruptive --force x5000c1r3j16 x5000c1r4j19
+    WARNING: The "sat swap cable" command has been deprecated and will be removed in a future release. Please use Slingshot Orchestrated Maintenance to perform switch and cable removal. See the HPE Slingshot Operations Guide for details.
+    You may still continue with "sat swap cable", but please begin migrating to Slingshot Orchestrated Maintenance.
+    Proceed with "sat swap cable"? [yes,no] yes
+    Proceeding with "sat swap cable".
     WARNING: Jacks x5000c1r3j16,x5000c1r4j19 are not connected by a single cable
     Ports: x5000c1r3j16p0 x5000c3r7j18p0 x5000c1r3j16p1 x5000c3r7j18p1 x5000c1r4j19p0 x5000c1r1j15p0 x5000c1r4j19p1 x5000c1r1j15p1
     Cable has been disabled and is ready for replacement.
@@ -168,6 +194,10 @@ Use **--dry-run** to determine all linked ports from a single jack:
 ::
 
     # sat swap cable --dry-run x5000c1r3j16
+    WARNING: The "sat swap cable" command has been deprecated and will be removed in a future release. Please use Slingshot Orchestrated Maintenance to perform switch and cable removal. See the HPE Slingshot Operations Guide for details.
+    You may still continue with "sat swap cable", but please begin migrating to Slingshot Orchestrated Maintenance.
+    Proceed with "sat swap cable"? [yes,no] yes
+    Proceeding with "sat swap cable".
     Ports: x5000c1r3j16p0 x5000c3r7j18p0 x5000c1r3j16p1 x5000c3r7j18p1
     Dry run completed with no action to enable/disable cable.
 

--- a/docs/man/sat-switch.8.rst
+++ b/docs/man/sat-switch.8.rst
@@ -18,9 +18,9 @@ SYNOPSIS
 DESCRIPTION
 ===========
 
-Note: The 'sat switch' subcommand is deprecated and will be removed in
-a future release.  Please use the equivalent 'sat swap switch' command.
-For more information, please see sat-swap(8).
+Note: The 'sat switch' subcommand is deprecated and will be removed in a future
+release. Please use Slingshot Orchestrated Maintenance to perform switch and
+cable removal. See the HPE Slingshot Operations Guide for details.
 
 The switch subcommand disables the ports on a switch, or enables the
 ports on a switch. This can be used during switch replacement, or for
@@ -86,14 +86,22 @@ Disable the switch in preparation to replace it:
 :: 
 
     # sat switch --action disable x1000c6r7
-    Enable/disable of switch can impact system. Continue? (yes/[no]) yes
+    WARNING: The "sat switch" command has been deprecated and will be removed in a future release. Please use Slingshot Orchestrated Maintenance to perform switch and cable removal. See the HPE Slingshot Operations Guide for details.
+    You may still continue with "sat switch", but please begin migrating to Slingshot Orchestrated Maintenance.
+    Proceed with "sat switch"? [yes,no] yes
+    Proceeding with "sat switch".
     Switch has been disabled and is ready for replacement.
 
-Enable the switch after replacing it and skip the prompt:
+Enable the switch after replacing it and skip the prompt. Note that the prompt
+about the deprecation cannot be skipped.
 
 :: 
 
     # sat switch --action enable --disruptive x1000c6r7
+    WARNING: The "sat switch" command has been deprecated and will be removed in a future release. Please use Slingshot Orchestrated Maintenance to perform switch and cable removal. See the HPE Slingshot Operations Guide for details.
+    You may still continue with "sat switch", but please begin migrating to Slingshot Orchestrated Maintenance.
+    Proceed with "sat switch"? [yes,no] yes
+    Proceeding with "sat switch".
     Switch has been enabled.
 
 SEE ALSO

--- a/sat/cli/swap/main.py
+++ b/sat/cli/swap/main.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2022, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -31,7 +31,7 @@ from sat.cli.swap.blade import swap_blade
 from sat.cli.swap.cable import swap_cable
 from sat.cli.swap.errors import ERR_INVALID_OPTIONS
 from sat.cli.swap.switch import swap_switch
-from sat.util import pester
+from sat.util import pester, prompt_continue
 
 
 LOGGER = logging.getLogger(__name__)
@@ -62,6 +62,24 @@ def check_arguments(component_type, action, dry_run, disruptive):
         raise SystemExit(ERR_INVALID_OPTIONS)
 
 
+def log_deprecation_and_prompt(subcommand):
+    """Log a deprecation warning and prompt user to continue
+
+    Args:
+        subcommand (str): the deprecated command which was used
+    """
+    command = f'sat {subcommand}'
+
+    LOGGER.warning(f'The "{command}" command has been deprecated and will be removed '
+                   f'in a future release. Please use Slingshot Orchestrated '
+                   f'Maintenance to perform switch and cable removal. See the '
+                   f'HPE Slingshot Operations Guide for details.')
+
+    prompt_continue(f'"{command}"',
+                    f'You may still continue with "{command}", but please '
+                    f'begin migrating to Slingshot Orchestrated Maintenance.')
+
+
 def do_swap(args):
     """Perform the specified swap action
 
@@ -72,6 +90,10 @@ def do_swap(args):
         None
     """
     action = getattr(args, 'action', None)
+
+    if args.target in ('cable', 'switch'):
+        log_deprecation_and_prompt(f'swap {args.target}')
+
     check_arguments(args.target, action, args.dry_run, args.disruptive)
 
     if args.target == 'cable':

--- a/sat/cli/switch/main.py
+++ b/sat/cli/switch/main.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -25,16 +25,11 @@
 The main entry point for the switch subcommand.
 """
 
-import warnings
-
 from sat.cli.swap.switch import swap_switch
+from sat.cli.swap.main import log_deprecation_and_prompt
 
 
 def do_switch(args):
 
-    # DeprecationWarnings are ignored by default, so force this to be displayed
-    warnings.simplefilter('once', category=DeprecationWarning)
-    warnings.warn('The "sat switch" command is deprecated and will be removed in a future release. '
-                  'Please use "sat swap switch" instead.', DeprecationWarning)
-
+    log_deprecation_and_prompt('switch')
     swap_switch(args)

--- a/tests/cli/switch/test_switch.py
+++ b/tests/cli/switch/test_switch.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -25,8 +25,8 @@
 Unit tests for sat.cli.switch
 """
 
+import logging
 import unittest
-import warnings
 from unittest import mock
 
 from sat.cli.switch.main import do_switch
@@ -38,15 +38,32 @@ class TestDoSwitch(unittest.TestCase):
     def setUp(self):
         self.mock_args = mock.Mock()
         self.mock_swap_switch = mock.patch('sat.cli.switch.main.swap_switch').start()
+        self.mock_pester_choices = mock.patch('sat.util.pester_choices').start()
+        self.mock_pester_choices.return_value = 'yes'
 
     def test_do_switch(self):
-        """do_switch should call swap_switch with a warning"""
-        with warnings.catch_warnings(record=True) as w:
+        """do_switch should call swap_switch with a deprecation warning and prompt"""
+        with self.assertLogs(level=logging.WARNING) as logs_cm:
             do_switch(self.mock_args)
 
-        self.assertEqual(len(w), 1)
-        self.assertEqual(w[0].category, DeprecationWarning)
-        self.mock_swap_switch.assert_called_once_with(self.mock_args)
+        self.mock_swap_switch.assert_called_with(self.mock_args)
+        self.assertEqual(1, len(logs_cm.records))
+        self.assertRegex(logs_cm.records[0].message,
+                         'The "sat switch" command has been deprecated')
+
+    def test_do_switch_abort(self):
+        """do_switch should abort when user answers 'no' to prompt"""
+        self.mock_pester_choices.return_value = 'no'
+
+        with self.assertRaises(SystemExit) as raises_cm:
+            with self.assertLogs(level=logging.WARNING) as logs_cm:
+                do_switch(self.mock_args)
+
+        self.mock_swap_switch.assert_not_called()
+        self.assertEqual(1, len(logs_cm.records))
+        self.assertRegex(logs_cm.records[0].message,
+                         'The "sat switch" command has been deprecated')
+        self.assertEqual(1, raises_cm.exception.code)
 
 
 if __name__ == '__main__':

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -32,7 +32,7 @@ import os
 from textwrap import dedent
 from unittest import mock
 import unittest
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 from sat import util
 from tests.common import ExtendedTestCase
@@ -614,6 +614,18 @@ class TestPromptContinue(unittest.TestCase):
             util.prompt_continue(action_msg)
         self.mock_print.assert_called_once_with('Will not proceed with {}. '
                                                 'Exiting.'.format(action_msg))
+
+    def test_with_description(self):
+        """Test prompt_continue with an optional description."""
+        self.mock_pester_choices.return_value = 'yes'
+        action_msg = 'action'
+        description = 'description preceding the prompt'
+        util.prompt_continue(action_msg, description)
+
+        self.mock_print.assert_has_calls([
+            call(description),
+            call('Proceeding with {}.'.format(action_msg))
+        ])
 
 
 class TestGetS3Resource(ExtendedTestCase):


### PR DESCRIPTION

## Summary and Scope
Deprecate the `sat swap switch` and `sat swap cable` commands and refer the user to the Slingshot Operations Guide for information on the Orchestrated Maintenance feature instead.

For now, this is only a deprecation and a prompt, but the user can still continue with `sat swap switch/cable` if they want. In the future, we will remove the ability to continue with the logic in `sat swap` and just log the deprecation message as an error or remove the command entirely.

Also log the same warning for the `sat switch` command which was just an alias for `sat swap switch`.

## Issues and Related PRs

* Resolves CRAYSAT-1799

## Testing

### Tested on:

  * Local development environment

### Test description:

Tested running `sat swap switch`, `sat swap cable`, and `sat switch` in a local virtual environment and confirmed that the appropriate messages were logged and the prompt worked as expected.

## Risks and Mitigations

Low risk. This adds a warning log message and a prompt. There is already a prompt in `sat swap` by default, so it seems unlikely to disrupt users. The only issue would occur if somebody had scripted `sat swap switch/cable` commands with the `--disruptive` option. That would not skip the deprecation prompt, but we really do want to bring this to the users' attention so they switch over to Slingshot Orchestrated Maintenance.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

