### PR TITLE
CRAYSAT-1707: sat bootsys boot stages modification.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   one group at a time instead of all simultaneously. The new order of this stage
   is to shut down workers, shut down masters (except ncn-m001), unmap and
   unmount all rbd devices on `ncn-m001`, and then shut down storage nodes.
+- Modified the sat bootsys platform services stage to not perform unfreeze ceph
+- Updated the power on order of node groups in sat bootsys ncn-power stage to storage,
+  unfreezing of ceph, managers and then the worker nodes.
 
 ### Fixed
 - Updated `sat bootsys` to increase the default management NCN shutdown timeout

--- a/sat/cli/bootsys/platform.py
+++ b/sat/cli/bootsys/platform.py
@@ -591,8 +591,6 @@ STEPS_BY_ACTION = {
                              do_containerd_start),
         PlatformServicesStep('Ensure etcd is running and enabled on all Kubernetes manager NCNs.',
                              do_etcd_start),
-        PlatformServicesStep('Start inactive Ceph services, unfreeze Ceph cluster and wait for Ceph health.',
-                             do_ceph_unfreeze),
         PlatformServicesStep('Start and enable kubelet on all Kubernetes NCNs.', do_kubelet_start),
         PlatformServicesStep('Recreate cron jobs that have become stuck', do_recreate_cronjobs),
     ],


### PR DESCRIPTION
Reviewer: Ryan


## Summary and Scope

- sat bootsys boot platform-services: removed the unfreeze ceph from this stage.
- sat bootsys boot ncn-power: modifying the boot order of groups from manager,storage and worker to storage, unfreezing ceph , manager and then the worker nodes

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CRAYSAT-1707](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1707)
`

## Testing

Yet to be tested 

### Tested on:

yet to be tested 

### Test description:

need to power off and then power on the cluster to check the changes

## Risks and Mitigations

minimal

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

