### PR TITLE
CRAYSAT-1837: Improve python-csm-api-client build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.27.18] - 2024-04-05
+
+### Fixed
+- Improved the build of `python-csm-api-client` to take less time by
+  adding `poetry.lock` file that resolves the dependencies.
+
 ## [3.27.17] - 2024-04-01
 
 ### Fixed

--- a/requirements-dev.lock.txt
+++ b/requirements-dev.lock.txt
@@ -14,7 +14,7 @@ coverage==6.3.2
 cray-product-catalog==1.6.0
 croniter==0.3.37
 cryptography==42.0.4
-csm-api-client==1.2.2
+csm-api-client==1.2.3
 dataclasses-json==0.5.6
 docutils==0.17.1
 google-auth==2.6.0

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -11,7 +11,7 @@ click==8.0.4
 cray-product-catalog==1.6.0
 croniter==0.3.37
 cryptography==42.0.4
-csm-api-client==1.2.2
+csm-api-client==1.2.3
 dataclasses-json==0.5.6
 google-auth==2.6.0
 htmlmin==0.1.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ argcomplete
 boto3
 botocore
 cray-product-catalog >= 1.6.0
-csm-api-client >= 1.2.2, <2.0
+csm-api-client >= 1.2.3, <2.0
 croniter >= 0.3, < 1.0
 inflect >= 0.2.5, < 3.0
 Jinja2 >= 3.0, < 4.0


### PR DESCRIPTION
IM:CRAYSAT-1837
Reviewer:Ryan

python-csm-api-client builds were taking approximately 35 mins to complete the build.
Will improvise it to take less amount of time by adding poetry.lock file that resolves the dependencies

## Summary and Scope

_python-csm-api-client builds are taking 35 minutes_

To improvise the build to take less amount of time, we added the poetry.lock file which is an auto generated script from Poetry 1.5.1
poetry.lock file already has its transitive dependencies.
As we added poetry.lock file Jenkins does not need to resolve its dependencies, which takes a minimal amount of time.

## Issues and Related PRs

_Resolves [CRAYSAT-1837](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1837)._

## Testing

_List the environments in which these changes were tested._

### Test description:

_Will observe the Jenkins build pipeline of `python-csm-api-client`._
_It takes only around 1m 36s to complete the build pipeline after adding poetry.lock file_

## Risks and Mitigations

_Minimal_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

