### PR TITLE
CRAYSAT-1839: Fixing the bug by importing time to handle sleep time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to 900 seconds.
 - Updated `sat bootsys` to include a prompt for input before proceeding with
   hard power off of management NCNs after timeout.
+- addressed the bug to import time to make the sleep time effective before retrying to create
+  cronjobs
 
 ## [3.28.1] - 2024-04-10
 

--- a/sat/cli/bootsys/platform.py
+++ b/sat/cli/bootsys/platform.py
@@ -27,6 +27,7 @@ Start and stop platform services to boot and shut down a Shasta system.
 
 import logging
 import socket
+import time
 import urllib3.exceptions
 from collections import namedtuple
 from multiprocessing import Process


### PR DESCRIPTION
Reviewer:Ryan

## Summary and Scope

- Addressing the bug were the retries are instantaneous instead of waiting for sleep time before next attempt.
- Adding the import to get the time.sleep effective before next attempt to recreate cron jobs.


_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CRAYSAT-1839](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1839)


## Testing

Tested.

### Tested on:

  * `<fanta>`


### Test description:

Tried to poweroff and power on the nodes and see if the issue gets fixed without the traceback error.
Able to get the traceback fixed in the o/p attached below


## Risks and Mitigations

minimal

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

