### PR TITLE
CRAYSAT-1839-sat-bootsys-waiter-subclass-addition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Modified the sat bootsys platform services stage to not perform unfreeze ceph
 - Updated the power on order of node groups in sat bootsys ncn-power stage to storage,
   unfreezing of ceph, managers and then the worker nodes.
+- Added a wait on the Kubernetes API being reachable between the step that starts 
+  kubelet and the step that re-creates Kubernetes cronjobs in the
+  `platform-services` stage of `sat bootsys boot`.
 
 ### Fixed
 - Updated `sat bootsys` to increase the default management NCN shutdown timeout


### PR DESCRIPTION
Updating the sat bootsys kubelet start function to address chronjob creation failure

IM:CRAYSAT-1839
Reviewer:Ryan

## Summary and Scope

modified the do_kubelet_start function to add the wait after kubelet gets started.
using the Waiter class that is already used in this module. Created a new Waiter subclass that implements the has_completed method to query the Kubernetes API to get the nodes in the Cluster.
Once the query returns successfully, would be proceeding with the next step.


## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CRAYSAT-1839](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1839)


## Testing

Yet to be tested .

### Tested on:

YTT

### Test description:

will power off the nodes and power on the node to validate the functionality inclusion during the power on.


## Risks and Mitigations

Minimal

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

