### PR TITLE
CRAYSAT-1839: Fix kubernetes version to match version in CSM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.28.2] - 2024-04-25
+
+### Fixed
+- Fix the `kubernetes` Python client library version to match the Kubernetes
+  cluster version in CSM 1.5 and currently in CSM 1.6.
+
 ## [3.28.1] - 2024-04-10
 
 ### Added

--- a/requirements-dev.lock.txt
+++ b/requirements-dev.lock.txt
@@ -14,7 +14,7 @@ coverage==6.3.2
 cray-product-catalog==1.6.0
 croniter==0.3.37
 cryptography==42.0.4
-csm-api-client==1.2.3
+csm-api-client==1.2.4
 dataclasses-json==0.5.6
 docutils==0.17.1
 google-auth==2.6.0
@@ -26,7 +26,7 @@ Jinja2==3.1.3
 jmespath==0.10.0
 json-schema-for-humans==0.40
 jsonschema==4.4.0
-kubernetes==23.3.0
+kubernetes==22.6.0
 markdown2==2.4.2
 MarkupSafe==2.1.0
 marshmallow==3.14.1

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -11,7 +11,7 @@ click==8.0.4
 cray-product-catalog==1.6.0
 croniter==0.3.37
 cryptography==42.0.4
-csm-api-client==1.2.3
+csm-api-client==1.2.4
 dataclasses-json==0.5.6
 google-auth==2.6.0
 htmlmin==0.1.12
@@ -21,7 +21,7 @@ Jinja2==3.1.3
 jmespath==0.10.0
 json-schema-for-humans==0.40
 jsonschema==4.4.0
-kubernetes==23.3.0
+kubernetes==22.6.0
 markdown2==2.4.2
 MarkupSafe==2.1.0
 marshmallow==3.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,13 +22,13 @@ argcomplete
 boto3
 botocore
 cray-product-catalog >= 1.6.0
-csm-api-client >= 1.2.3, <2.0
+csm-api-client >= 1.2.4, <2.0
 croniter >= 0.3, < 1.0
 inflect >= 0.2.5, < 3.0
 Jinja2 >= 3.0, < 4.0
 json-schema-for-humans
 jsonschema >= 4.0, < 5.0
-kubernetes
+kubernetes >= 22.0, < 23.0
 paramiko >= 2.11.0
 parsec == 3.5.0
 prettytable >= 0.7.2, < 1.0


### PR DESCRIPTION
## Summary and Scope

The version of the Python kubernetes client package was ahead of the
version of Kubernetes running in CSM 1.5, which resulted in some
compatibility issues. For example, `CoreV1Api.list_node` did not work if
a condition with a type of "ReadonlyFilesystem" was present on any of
the Kubernetes nodes in the cluster.

See https://github.com/kubernetes-client/python?tab=readme-ov-file#compatibility
for details on the compatibility of the Python `kubernetes` package with
the Kubernetes cluster version.

Also update the version of csm-api-client, which has been updated to
relax the kubernetes version constraint and allow versions >= 22.0
rather than only >= 23.0.

## Issues and Related PRs

* Resolves CRAYSAT-1848
* Merge after https://github.com/Cray-HPE/python-csm-api-client/pull/28

## Testing

### Tested on:

  * odin

### Test description:

Built the container image, downloaded to odin, and ran the
`CoreV1Api.list_node` method in a Python interpreter in the `sat bash`
shell.

Also ran `sat bootprep run` against a simple input file that defined a
single CFS configuration, built an image from a recipe, and then
configured that image with CFS. This was just to ensure that nothing
using the K8s API in that code path was impacted.

## Risks and Mitigations

This should be low risk. It is aligning the version of the `kubernetes` Python package with the version of the Kubernetes cluster in CSM 1.5. We will want to remember to update it for CSM 1.6 (See CRAYSAT-1849).


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
- [ ] Remove commit that adds unstable repo to PIP_EXTRA_INDEX_URL

