### PR TITLE
CRAYSAT-1138: Add new HSM types to `sat hwinv`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.28.5] - 2024-05-31
+
+### Added
+- Add new HSM types, namely `NodeBMC`, `RouterBMC`, `MgmtSwitch`, `CabinetPDU` and
+  `CabinetPDUPowerConnector` to `sat hwinv`. Also update the man page appropriately.
+
 ## [3.28.4] - 2024-05-08
 
 ### Fixed

--- a/docs/man/sat-hwinv.8.rst
+++ b/docs/man/sat-hwinv.8.rst
@@ -163,6 +163,21 @@ These options list components of certain types in the system.
 **--list-cmm-rectifiers**
         List all the CMM rectifiers in the system.
 
+**--list-node-bmcs**
+        List all the node BMCs in the system.
+
+**--list-router-bmcs**
+        List all the router BMCs in the system.
+
+**--list-mgmt-switches**
+        List all the mgmt switches in the system.
+
+**--list-cabinet-pdus**
+        List all the cabinet PDUs in the system.
+
+**--list-cabinet-pdu-power-connectors**
+        List all the cabinet PDU power connectors in the system.
+
 **--node-fields** *NODE_FIELDS*
         Display the given comma-separated list of fields for each node. Omit
         this option to display all fields. This option only has an effect if
@@ -214,6 +229,21 @@ These options list components of certain types in the system.
 
 **--cmm-rectifier-fields** *CMM_RECTIFIER_FIELDS*
         Same as **--node-fields** but for CMM rectifiers.
+
+**--node-bmc-fields** *NODE_BMC_FIELDS*
+        Same as **--node-fields** but for NodeBMCs.
+
+**--router-bmc-fields** *ROUTER_BMC_FIELDS*
+        Same as **--node-fields** but for RouterBMCs.
+
+**--mgmt-switch-fields** *MGMT_SWITCH_FIELDS*
+        Same as **--node-fields** but for Mgmt Switches.
+
+**--cabinet-pdu-fields** *CABINET_PDU_FIELDS*
+        Same as **--node-fields** but for Cabinet PDUs.
+
+**--cabinet-pdu-power-connector-fields** *CABINET_PDU_POWER_CONNECTOR_FIELDS*
+        Same as **--node-fields** but for Cabinet PDU Power Connectors.
 
 .. include:: _sat-format-opts.rst
 .. include:: _sat-filter-opts.rst

--- a/sat/cli/hwinv/parser.py
+++ b/sat/cli/hwinv/parser.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2020, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -178,6 +178,7 @@ def add_hwinv_subparser(subparsers):
     list_component_names = ['node', 'chassis', 'hsn-board', 'compute-module',
                             'router-module', 'node-enclosure', 'node-enclosure-power-supply',
                             'proc', 'node-accel', 'node-accel-riser', 'node-hsn-nic',
-                            'mem', 'drive', 'cmm-rectifier']
+                            'mem', 'drive', 'cmm-rectifier', 'node-bmc', 'router-bmc',
+                            'mgmt-switch', 'cabinet-pdu', 'cabinet-pdu-power-connector']
     for component in list_component_names:
         _add_list_option(list_group, component)

--- a/sat/system/cabinet_pdu.py
+++ b/sat/system/cabinet_pdu.py
@@ -1,0 +1,54 @@
+#
+# MIT License
+#
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""
+Class to represent a CabinetPDU object obtained from Hardware State Manager (HSM).
+"""
+
+from sat.system.component import BaseComponent
+from sat.system.constants import CABINET_PDU_TYPE
+from sat.system.field import ComponentField
+from sat.cached_property import cached_property
+
+
+class CabinetPDU(BaseComponent):
+    """A Cabinet PDU in the system."""
+
+    hsm_type = CABINET_PDU_TYPE
+    arg_name = 'cabinet_pdu'
+    pretty_name = 'cabinet pdu'
+
+    fields = BaseComponent.fields + [
+        ComponentField('Equipment Type'),
+        ComponentField('Firmware Version')
+    ]
+
+    @cached_property
+    def equipment_type(self):
+        """str: the Equipment type of Cabinet PDU"""
+        return self.fru_info['EquipmentType']
+
+    @cached_property
+    def firmware_version(self):
+        """str: the firmware version"""
+        return self.fru_info['FirmwareVersion']

--- a/sat/system/cabinet_pdu_power_connector.py
+++ b/sat/system/cabinet_pdu_power_connector.py
@@ -1,0 +1,78 @@
+#
+# MIT License
+#
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""
+Class to represent a CabinetPDUPowerConnector object obtained from Hardware State Manager (HSM).
+"""
+
+from sat.system.component import BaseComponent
+from sat.system.constants import CABINET_PDU_POWER_CONNECTOR_TYPE
+from sat.system.field import ComponentField
+from sat.cached_property import cached_property
+
+
+class CabinetPDUPowerConnector(BaseComponent):
+    """A Cabinet PDU Power Connector in the system."""
+
+    hsm_type = CABINET_PDU_POWER_CONNECTOR_TYPE
+    arg_name = 'cabinet_pdu_power_connector'
+    pretty_name = 'cabinet pdu power connector'
+
+    fields = BaseComponent.fields + [
+        ComponentField('Nominal Voltage'),
+        ComponentField('Outlet Type'),
+        ComponentField('Phase Wiring Type'),
+        ComponentField('Power Enabled'),
+        ComponentField('Rated Current Amps'),
+        ComponentField('Voltage Type')
+    ]
+
+    @cached_property
+    def nominal_voltage(self):
+        """str: the Nominal Voltage of Cabinet PDU Power Connector"""
+        return self.fru_info['NominalVoltage']
+
+    @cached_property
+    def outlet_type(self):
+        """str: the Outlet type of Cabinet PDU Power Connector"""
+        return self.fru_info['OutletType']
+
+    @cached_property
+    def phase_wiring_type(self):
+        """str: the Phase Wiring type of Cabinet PDU Power Connector"""
+        return self.fru_info['PhaseWiringType']
+
+    @cached_property
+    def power_enabled(self):
+        """str: the Power Enabled or not in Cabinet PDU Power Connector"""
+        return self.fru_info['PowerEnabled']
+
+    @cached_property
+    def rated_current_amps(self):
+        """str: the Rated Current in Amps for Cabinet PDU Power Connector"""
+        return self.fru_info['RatedCurrentAmps']
+
+    @cached_property
+    def voltage_type(self):
+        """str: the Voltage type of Cabinet PDU Power Connector"""
+        return self.fru_info['VoltageType']

--- a/sat/system/component.py
+++ b/sat/system/component.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2021, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -199,7 +199,15 @@ class BaseComponent:
     def fru_info(self):
         """ComponentDataDict: The FRU info stored in the raw data.
         """
-        fru_info_key = '{}FRUInfo'.format(self.type)
+        hw_type = self.type
+
+        if hw_type == "CabinetPDU":
+            hw_type = "PDU"
+
+        if hw_type == "CabinetPDUPowerConnector":
+            hw_type = "Outlet"
+
+        fru_info_key = '{}FRUInfo'.format(hw_type)
         return ComponentDataDict(self.raw_data['PopulatedFRU'][fru_info_key])
 
     @cached_property

--- a/sat/system/constants.py
+++ b/sat/system/constants.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2020, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -49,6 +49,11 @@ NODE_HSN_NIC_TYPE = 'NodeHsnNic'
 NODE_TYPE = 'Node'
 PROCESSOR_TYPE = 'Processor'
 ROUTER_MODULE_TYPE = 'RouterModule'
+NODE_BMC_TYPE = 'NodeBMC'
+ROUTER_BMC_TYPE = 'RouterBMC'
+MGMT_SWITCH_TYPE = 'MgmtSwitch'
+CABINET_PDU_TYPE = 'CabinetPDU'
+CABINET_PDU_POWER_CONNECTOR_TYPE = 'CabinetPDUPowerConnector'
 
 # The types of cabinets are C-Series and S-Series.
 # C-Series is densely liquid cooled.

--- a/sat/system/mgmt_switch.py
+++ b/sat/system/mgmt_switch.py
@@ -1,0 +1,48 @@
+#
+# MIT License
+#
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""
+Class to represent a MgmtSwitch object obtained from Hardware State Manager (HSM).
+"""
+
+from sat.system.component import BaseComponent
+from sat.system.constants import MGMT_SWITCH_TYPE
+from sat.system.field import ComponentField
+from sat.cached_property import cached_property
+
+
+class MgmtSwitch(BaseComponent):
+    """A mgmt switch in the system."""
+
+    hsm_type = MGMT_SWITCH_TYPE
+    arg_name = 'mgmt_switch'
+    pretty_name = 'mgmt switch'
+
+    fields = BaseComponent.fields + [
+        ComponentField('Chassis Type')
+    ]
+
+    @cached_property
+    def chassis_type(self):
+        """str: the type of Chassis"""
+        return self.fru_info['ChassisType']

--- a/sat/system/node_bmc.py
+++ b/sat/system/node_bmc.py
@@ -1,0 +1,54 @@
+#
+# MIT License
+#
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""
+Class to represent a NodeBMC object obtained from Hardware State Manager (HSM).
+"""
+
+from sat.system.component import BaseComponent
+from sat.system.constants import NODE_BMC_TYPE
+from sat.system.field import ComponentField
+from sat.cached_property import cached_property
+
+
+class NodeBMC(BaseComponent):
+    """A node bmc in the system."""
+
+    hsm_type = NODE_BMC_TYPE
+    arg_name = 'node_bmc'
+    pretty_name = 'node bmc'
+
+    fields = BaseComponent.fields + [
+        ComponentField('Manager Type'),
+        ComponentField('Firmware Version')
+    ]
+
+    @cached_property
+    def manager_type(self):
+        """str: the manager type of node BMC"""
+        return self.fru_info['ManagerType']
+
+    @cached_property
+    def firmware_version(self):
+        """str: the firmware version"""
+        return self.location_info['FirmwareVersion']

--- a/sat/system/router_bmc.py
+++ b/sat/system/router_bmc.py
@@ -1,0 +1,54 @@
+#
+# MIT License
+#
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""
+Class to represent a RouterBMC object obtained from Hardware State Manager (HSM).
+"""
+
+from sat.system.component import BaseComponent
+from sat.system.constants import ROUTER_BMC_TYPE
+from sat.system.field import ComponentField
+from sat.cached_property import cached_property
+
+
+class RouterBMC(BaseComponent):
+    """A router bmc in the system."""
+
+    hsm_type = ROUTER_BMC_TYPE
+    arg_name = 'router_bmc'
+    pretty_name = 'router bmc'
+
+    fields = BaseComponent.fields + [
+        ComponentField('Manager Type'),
+        ComponentField('Firmware Version')
+    ]
+
+    @cached_property
+    def manager_type(self):
+        """str: the manager type of Router BMC"""
+        return self.fru_info['ManagerType']
+
+    @cached_property
+    def firmware_version(self):
+        """str: the firmware version"""
+        return self.location_info['FirmwareVersion']

--- a/sat/system/system.py
+++ b/sat/system/system.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2020, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -43,6 +43,11 @@ from sat.system.node_accel import NodeAccel
 from sat.system.node_accel_riser import NodeAccelRiser
 from sat.system.node_hsn_nic import NodeHsnNic
 from sat.system.router_module import RouterModule
+from sat.system.node_bmc import NodeBMC
+from sat.system.router_bmc import RouterBMC
+from sat.system.mgmt_switch import MgmtSwitch
+from sat.system.cabinet_pdu import CabinetPDU
+from sat.system.cabinet_pdu_power_connector import CabinetPDUPowerConnector
 from sat.xname import XName
 
 LOGGER = logging.getLogger(__name__)
@@ -75,7 +80,12 @@ class System:
             NodeAccel: {},
             NodeAccelRiser: {},
             NodeHsnNic: {},
-            RouterModule: {}
+            RouterModule: {},
+            NodeBMC: {},
+            RouterBMC: {},
+            MgmtSwitch: {},
+            CabinetPDU: {},
+            CabinetPDUPowerConnector: {}
         }
 
         for component in self.complete_raw_data:

--- a/tests/system/component_data.py
+++ b/tests/system/component_data.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2020, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -40,6 +40,11 @@ NODE_HSN_NIC_XNAME = 'x1000c0s0b0n0h0'
 MEMORY_MODULE_XNAME = 'x1000c0s0b0n0d0'
 DRIVE_XNAME = 'x1000c0s0b0n0g1k1'
 CMM_RECTIFIER_XNAME = 'x1000c0t0'
+NODE_BMC_XNAME = 'x8000c0s0b0'
+ROUTER_BMC_XNAME = 'x8000c0r1b0'
+MGMT_SWITCH_XNAME = 'x8000c0w0'
+CABINET_PDU_XNAME = 'x3000m0p0'
+CABINET_PDU_POWER_CONNECTOR_XNAME = 'x3000m0p0v1'
 
 # Default values for component raw data.
 DEFAULT_HSM_TYPE = 'Sample'

--- a/tests/system/test_cabinet_pdu.py
+++ b/tests/system/test_cabinet_pdu.py
@@ -1,0 +1,69 @@
+#
+# MIT License
+#
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""
+Unit tests for sat.system.cabinet_pdu.
+"""
+import unittest
+
+from sat.constants import EMPTY_VALUE
+from sat.system.cabinet_pdu import CabinetPDU
+from tests.system.component_data import CABINET_PDU_XNAME, get_component_raw_data
+
+EQUIPMENT_TYPE = ''
+FIRMWARE_VERSION = '1.2.3'
+
+
+def get_cabinet_pdu_raw_data(xname=CABINET_PDU_XNAME, **kwargs):
+    component_data = get_component_raw_data(hsm_type='PDU', xname=xname, **kwargs)
+    extra_fru_info = {
+        'EquipmentType': EQUIPMENT_TYPE,
+        'FirmwareVersion': FIRMWARE_VERSION,
+    }
+    component_data['PopulatedFRU']['PDUFRUInfo'].update(extra_fru_info)
+    return component_data
+
+
+class TestCabinetPDU(unittest.TestCase):
+    """Test the CabinetPDU class."""
+
+    def setUp(self):
+        """Create a CabinetPDU object to use in the tests."""
+        self.raw_data = get_cabinet_pdu_raw_data()
+        self.cabinet_pdu = CabinetPDU(self.raw_data)
+
+    def test_init(self):
+        """Test initialization of a CabinetPDU object."""
+        self.assertEqual(self.raw_data, self.cabinet_pdu.raw_data)
+
+    def test_equipment_type(self):
+        """Test the equipment_type property."""
+        self.assertEqual(self.cabinet_pdu.equipment_type, EMPTY_VALUE)
+
+    def test_firmware_version(self):
+        """Test the firmware_version property."""
+        self.assertEqual(self.cabinet_pdu.firmware_version, FIRMWARE_VERSION)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/system/test_cabinet_pdu_power_connector.py
+++ b/tests/system/test_cabinet_pdu_power_connector.py
@@ -1,0 +1,93 @@
+#
+# MIT License
+#
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""
+Unit tests for sat.system.cabinet_pdu_power_connector.
+"""
+import unittest
+
+from sat.constants import EMPTY_VALUE
+from sat.system.cabinet_pdu_power_connector import CabinetPDUPowerConnector
+from tests.system.component_data import CABINET_PDU_POWER_CONNECTOR_XNAME, get_component_raw_data
+
+NOMINAL_VOLTAGE = 'AC200V'
+OUTLET_TYPE = ''
+PHASE_WIRING_TYPE = 'ThreePhase4Wire'
+POWER_ENABLED = 'true'
+RATED_CURRENT_AMPS = 10
+VOLTAGE_TYPE = 'AC'
+
+
+def get_cabinet_pdu_power_connector_raw_data(xname=CABINET_PDU_POWER_CONNECTOR_XNAME, **kwargs):
+    component_data = get_component_raw_data(hsm_type='Outlet', xname=xname, **kwargs)
+    extra_fru_info = {
+        'NominalVoltage': NOMINAL_VOLTAGE,
+        'OutletType': OUTLET_TYPE,
+        'PhaseWiringType': PHASE_WIRING_TYPE,
+        'PowerEnabled': POWER_ENABLED,
+        'RatedCurrentAmps': RATED_CURRENT_AMPS,
+        'VoltageType': VOLTAGE_TYPE,
+    }
+    component_data['PopulatedFRU']['OutletFRUInfo'].update(extra_fru_info)
+    return component_data
+
+
+class TestCabinetPDUPowerConnector(unittest.TestCase):
+    """Test the CabinetPDUPowerConnector class."""
+
+    def setUp(self):
+        """Create a CabinetPDUPowerConnector object to use in the tests."""
+        self.raw_data = get_cabinet_pdu_power_connector_raw_data()
+        self.cabinet_pdu_power_connector = CabinetPDUPowerConnector(self.raw_data)
+
+    def test_init(self):
+        """Test initialization of a CabinetPDUPowerConnector object."""
+        self.assertEqual(self.raw_data, self.cabinet_pdu_power_connector.raw_data)
+
+    def test_nominal_voltage(self):
+        """Test the nominal_voltage property."""
+        self.assertEqual(self.cabinet_pdu_power_connector.nominal_voltage, NOMINAL_VOLTAGE)
+
+    def test_outlet_type(self):
+        """Test the outlet_type property."""
+        self.assertEqual(self.cabinet_pdu_power_connector.outlet_type, EMPTY_VALUE)
+
+    def test_phase_wiring_type(self):
+        """Test the phase_wiring_type property."""
+        self.assertEqual(self.cabinet_pdu_power_connector.phase_wiring_type, PHASE_WIRING_TYPE)
+
+    def test_power_enabled(self):
+        """Test the power enabled or not in CabinetPDUPowerConnector."""
+        self.assertEqual(self.cabinet_pdu_power_connector.power_enabled, POWER_ENABLED)
+
+    def test_rated_current_amps(self):
+        """Test rated current amps in CabinetPDUPowerConnector."""
+        self.assertEqual(self.cabinet_pdu_power_connector.rated_current_amps, RATED_CURRENT_AMPS)
+
+    def voltage_type(self):
+        """Test the voltage_type property."""
+        self.assertEqual(self.cabinet_pdu_power_connector.voltage_type, VOLTAGE_TYPE)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/system/test_mgmt_switch.py
+++ b/tests/system/test_mgmt_switch.py
@@ -1,0 +1,63 @@
+#
+# MIT License
+#
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""
+Unit tests for sat.system.mgmt_switch.
+"""
+import unittest
+
+from sat.constants import EMPTY_VALUE
+from sat.system.mgmt_switch import MgmtSwitch
+from tests.system.component_data import MGMT_SWITCH_XNAME, get_component_raw_data
+
+CHASSIS_TYPE = ''
+
+
+def get_mgmt_switch_raw_data(xname=MGMT_SWITCH_XNAME, **kwargs):
+    component_data = get_component_raw_data(hsm_type='MgmtSwitch', xname=xname, **kwargs)
+    extra_fru_info = {
+        'ChassisType': CHASSIS_TYPE,
+    }
+    component_data['PopulatedFRU']['MgmtSwitchFRUInfo'].update(extra_fru_info)
+    return component_data
+
+
+class TestMgmtSwitch(unittest.TestCase):
+    """Test the MgmtSwitch class."""
+
+    def setUp(self):
+        """Create a MgmtSwitch object to use in the tests."""
+        self.raw_data = get_mgmt_switch_raw_data()
+        self.mgmt_switch = MgmtSwitch(self.raw_data)
+
+    def test_init(self):
+        """Test initialization of a MgmtSwitch object."""
+        self.assertEqual(self.raw_data, self.mgmt_switch.raw_data)
+
+    def test_chassis_type(self):
+        """Test the chassis_type property."""
+        self.assertEqual(self.mgmt_switch.chassis_type, EMPTY_VALUE)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/system/test_node_bmc.py
+++ b/tests/system/test_node_bmc.py
@@ -1,0 +1,72 @@
+#
+# MIT License
+#
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""
+Unit tests for sat.system.node_bmc.
+"""
+import unittest
+
+from sat.constants import EMPTY_VALUE
+from sat.system.node_bmc import NodeBMC
+from tests.system.component_data import NODE_BMC_XNAME, get_component_raw_data
+
+MANAGER_TYPE = ''
+FIRMWARE_VERSION = '1.2.3'
+
+
+def get_node_bmc_raw_data(xname=NODE_BMC_XNAME, **kwargs):
+    component_data = get_component_raw_data(hsm_type='NodeBMC', xname=xname, **kwargs)
+    extra_fru_info = {
+        'ManagerType': MANAGER_TYPE,
+    }
+    extra_location_info = {
+        'FirmwareVersion': FIRMWARE_VERSION
+    }
+    component_data['PopulatedFRU']['NodeBMCFRUInfo'].update(extra_fru_info)
+    component_data['NodeBMCLocationInfo'].update(extra_location_info)
+    return component_data
+
+
+class TestNodeBMC(unittest.TestCase):
+    """Test the NodeBMC class."""
+
+    def setUp(self):
+        """Create a NodeBMC object to use in the tests."""
+        self.raw_data = get_node_bmc_raw_data()
+        self.node_bmc = NodeBMC(self.raw_data)
+
+    def test_init(self):
+        """Test initialization of a NodeBMC object."""
+        self.assertEqual(self.raw_data, self.node_bmc.raw_data)
+
+    def test_manager_type(self):
+        """Test the manager_type property."""
+        self.assertEqual(self.node_bmc.manager_type, EMPTY_VALUE)
+
+    def test_firmware_version(self):
+        """Test the firmware_version property."""
+        self.assertEqual(self.node_bmc.firmware_version, FIRMWARE_VERSION)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/system/test_router_bmc.py
+++ b/tests/system/test_router_bmc.py
@@ -1,0 +1,72 @@
+#
+# MIT License
+#
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""
+Unit tests for sat.system.router_bmc.
+"""
+import unittest
+
+from sat.constants import EMPTY_VALUE
+from sat.system.router_bmc import RouterBMC
+from tests.system.component_data import ROUTER_BMC_XNAME, get_component_raw_data
+
+MANAGER_TYPE = ''
+FIRMWARE_VERSION = '1.2.3'
+
+
+def get_router_bmc_raw_data(xname=ROUTER_BMC_XNAME, **kwargs):
+    component_data = get_component_raw_data(hsm_type='RouterBMC', xname=xname, **kwargs)
+    extra_fru_info = {
+        'ManagerType': MANAGER_TYPE,
+    }
+    extra_location_info = {
+        'FirmwareVersion': FIRMWARE_VERSION
+    }
+    component_data['PopulatedFRU']['RouterBMCFRUInfo'].update(extra_fru_info)
+    component_data['RouterBMCLocationInfo'].update(extra_location_info)
+    return component_data
+
+
+class TestRouterBMC(unittest.TestCase):
+    """Test the RouterBMC class."""
+
+    def setUp(self):
+        """Create a RouterBMC object to use in the tests."""
+        self.raw_data = get_router_bmc_raw_data()
+        self.router_bmc = RouterBMC(self.raw_data)
+
+    def test_init(self):
+        """Test initialization of a RouterBMC object."""
+        self.assertEqual(self.raw_data, self.router_bmc.raw_data)
+
+    def test_manager_type(self):
+        """Test the manager_type property."""
+        self.assertEqual(self.router_bmc.manager_type, EMPTY_VALUE)
+
+    def test_firmware_version(self):
+        """Test the firmware_version property."""
+        self.assertEqual(self.router_bmc.firmware_version, FIRMWARE_VERSION)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
IM: CRAYSAT-1138
Reviewer: Ryan

Add new HSM types, namely `NodeBMC`, `RouterBMC`, `MgmtSwitch`, `CabinetPDU` and `CabinetPDUPowerConnector` to `sat hwinv`

## Summary and Scope

_This PR is to add new HSM types, namely `NodeBMC`, `RouterBMC`, `MgmtSwitch`, `CabinetPDU` and `CabinetPDUPowerConnector` to `sat hwinv`_

## Issues and Related PRs

_Resolves [CRAYSAT-1138](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1138)._

## Testing

_List the environments in which these changes were tested._

### Tested on:

_Odin_

### Test description:

_Test the `sat hwinv` command with newly added parameters for all the new components_

## Risks and Mitigations

_N/A_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

