### PR TITLE
Adding func to mount ceph/s3fs in ncn-power stage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a wait on the Kubernetes API being reachable between the step that starts 
   kubelet and the step that re-creates Kubernetes cronjobs in the
   `platform-services` stage of `sat bootsys boot`.
+- Added a function to mount s3fs and ceph post ceph health status check on ncn-m001 in 
+  ncn power stage
 
 ### Fixed
 - Updated `sat bootsys` to increase the default management NCN shutdown timeout


### PR DESCRIPTION
IM:CRAYSAT-1582
Reviewer:Ryan

Adding a function to mount ceph and s3fs after checking the ceph health in ncn power stage

## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CRAYSAT-1582](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1582)

## Testing

### Tested on:

  * Tested on surtur and fanta system


### Test description:

Ncn's were powered off and then powered on to validate the changes.

In the step: sat bootsys boot --stage ncn-power --ncn-boot-timeout 900
The output was observed during the process of above command.Once the Ceph was unfreezed and status is available, could observe mount of ceph and s3fs happening with the msg **"INFO: Mounted Ceph and S3FS filesystems on ncn-m001 successfully."**

To validate if it successfully mounted or not, first verified on the ncn-m001, then once the other master and worker nodes booted. Logged into the ncn's and verified if the mount points are reflected. they were  available as mount points. below are the output samples:
```
ncn-m001:/mnt/shiva # awk '{ if ($3 == "fuse.s3fs") { print $2; }}' /etc/fstab
/var/opt/cray/sdu/collection-mount
/var/opt/cray/config-data

ncn-m002:~ # awk '{ if ($3 == "fuse.s3fs") { print $2; }}' /etc/fstab
/var/opt/cray/sdu/collection-mount
/var/opt/cray/config-data
ncn-m002:~ # awk '{ if ($3 == "ceph") { print $2; }}' /etc/fstab
/etc/cray/upgrade/csm
```
This successfully confirms the working of the function added to automate the mount availability.



## Risks and Mitigations
Low

_Are there known issues with these changes? Any other special considerations?_
no

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

