### PR TITLE
CRAYSAT-1100:Improve sat bootsys platform-services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `platform-services` stage of `sat bootsys boot`.
 - Added a function to mount s3fs and ceph post ceph health status check on ncn-m001 in 
   ncn power stage
+- If containers fail to stop, automate the procedure of trying to stop them again
+  in the `platform-services` stage.
 
 ### Fixed
 - Updated `sat bootsys` to increase the default management NCN shutdown timeout


### PR DESCRIPTION
IM:CRAYSAT-1100
Reviewer:Ryan

Implementation to improve `sat bootsys shutdown --stage platform-services` which is in progress.

## Summary and Scope

_Improve `sat bootsys shutdown --stage platform-services`_

- Change the -n 3 to -n 1 in the xargs command used to stop containers running under containerd.
- If containers fail to stop, automate the procedure of trying to stop them again.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

_Resolves [CRAYSAT-1100](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1100)_

## Testing

_List the environments in which these changes were tested._

### Tested on:

  _fanta_

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

Capture the output of `sat bootsys shutdown --stage platform-services`  during shutdown process

## Risks and Mitigations

_Minimal_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

