### PR TITLE
CRAYSAT-1868:Backport of `sat firmware`

### DIFF
--- a/.github/workflows/license-check.yaml
+++ b/.github/workflows/license-check.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/.github/workflows/license-check.yaml
+++ b/.github/workflows/license-check.yaml
@@ -41,7 +41,7 @@ jobs:
 
     - name: Get changed files
       id: changed-files
-      uses: tj-actions/changed-files@v35
+      uses: tj-actions/changed-files@v41
 
     - name: License Check
       if: ${{ steps.changed-files.outputs.all_changed_files }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.25.12] - 2024-06-11
+
+### Fixed
+- Polling the snapshot in `sat firmware` resulted in HTTP errors in large clusters.
+  Hence, adding the retry option when it consecutively fails for up to 5 times.
+- Remove expiration time and add `--delete-snapshot` option to delete the snapshot
+  if it is no longer needed. By default, log a message referring the user how to
+  delete the snapshot.
+
 ## [3.25.11] - 2024-02-23
 
 ### Security

--- a/docs/man/sat-firmware.8.rst
+++ b/docs/man/sat-firmware.8.rst
@@ -7,7 +7,7 @@ Show firmware version
 ---------------------
 
 :Author: Hewlett Packard Enterprise Development LP.
-:Copyright: Copyright 2020-2021 Hewlett Packard Enterprise Development LP.
+:Copyright: Copyright 2020-2021, 2024 Hewlett Packard Enterprise Development LP.
 :Manual section: 8
 
 SYNOPSIS
@@ -45,6 +45,10 @@ These options must be specified after the subcommand.
         names. Provide this option with no arguments to print a list of
         available snapshots.
 
+**--delete-snapshot** *SNAPSHOT-NAME*
+        Delete a snapshot by providing the snapshot name, if it is no
+        longer needed.
+
 .. include:: _sat-xname-opts.rst
 .. include:: _sat-format-opts.rst
 .. include:: _sat-filter-opts.rst
@@ -70,6 +74,7 @@ Get a report of all the firmware versions on the system (note: output truncated)
   | x3000c0s2b0  | 10         | Power Management Controller FW Bootloader       | 1.1                     |
   | x3000c0s2b0  | 7          | Power Supply Firmware                           | 1.00                    |
   ...
+  INFO: Use `sat firmware --delete-snapshot` to delete the snapshot if it is no longer needed
 
 Get a report of all the firmware versions associated with a particular xname:
 
@@ -86,6 +91,7 @@ Get a report of all the firmware versions associated with a particular xname:
   | x3000c0r39b0 | FPGA0      | sFPGA-ROS                                       | 1.08                    |
   | x3000c0r39b0 | BMC        | BMC                                             | sc.1.4.409              |
   +--------------+------------+-------------------------------------------------+-------------------------+
+  INFO: Use `sat firmware --delete-snapshot` to delete the snapshot if it is no longer needed
 
 Get a report of all the firmware versions associated with a particular snapshot
 (note: output truncated):
@@ -137,6 +143,13 @@ List all firmware snapshot names:
   # sat firmware --snapshots
   firmware-2021-3-2-23-45-52
   firmware-2021-3-2-20-41-55
+
+Delete the firmware snapshot if it is no longer needed:
+
+::
+
+  # sat firmware --delete-snapshot SAT-2024-4-25-6-44-6
+  INFO: Snapshot SAT-2024-4-25-6-44-6 deleted successfully.
 
 SEE ALSO
 ========

--- a/sat/cli/firmware/parser.py
+++ b/sat/cli/firmware/parser.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -49,7 +49,14 @@ def add_firmware_subparser(subparsers):
                     'are specified, then all xnames will be targeted.',
         parents=[xname_options, format_options, filter_options])
 
-    firmware_parser.add_argument(
+    firmware_snapshot = firmware_parser.add_mutually_exclusive_group()
+
+    firmware_snapshot.add_argument(
         '--snapshots', dest='snapshots', metavar='SNAPSHOT', nargs='*',
         help='Describe firmware snapshots. Provide no arguments to this '
              'option to list available snapshots.')
+
+    firmware_snapshot.add_argument(
+        '--delete-snapshot', dest='delete_snapshot', metavar='SNAPSHOT_NAME', nargs='+',
+        help='Delete a snapshot by providing the snapshot name.'
+    )

--- a/tests/cli/firmware/test_firmware.py
+++ b/tests/cli/firmware/test_firmware.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2021, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -125,6 +125,18 @@ class TestFirmware(ExtendedTestCase):
         """An APIError getting snapshot names logs an error and exits"""
         args = self.parser.parse_args(['firmware', '--snapshots'])
         self.firmware_client.get_all_snapshot_names.side_effect = APIError
+        self.assertExitsWithError(do_firmware, args)
+
+    def test_delete_snapshot(self):
+        """Deleting a snapshot using --delete-snapshot with correct snapshot name"""
+        args = self.parser.parse_args(['firmware', '--delete-snapshot', 'snap1'])
+        do_firmware(args)
+        self.firmware_client.delete_snapshot.assert_called_once_with('snap1')
+
+    def test_delete_snapshot_error(self):
+        """An APIError deleting incorrect snapshot name logs an error and exits"""
+        args = self.parser.parse_args(['firmware', '--delete-snapshot', 'foo'])
+        self.firmware_client.delete_snapshot.side_effect = APIError
         self.assertExitsWithError(do_firmware, args)
 
     def test_xname_and_snapshots_without_arguments(self):


### PR DESCRIPTION
IM: CRAYSAT-1868
Reviewer: Ryan

Backporting to include:
Improved snapshot creation by removing expiration time Add delete option to prompt user to delete the snapshot if it is no longer needed.

## Summary and Scope

- Polling the snapshot in `sat firmware` resulted in HTTP errors in large clusters.
  Hence, adding the retry option when it consecutively fails for up to 5 times.
- Remove expiration time and add `--delete-snapshot` option to prompt the user to delete the snapshot
  if it is no longer needed. By default, log a message referring the user how to delete the snapshot.


## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

Resolves [CRAYSAT-1868](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1868)

## Testing

_List the environments in which these changes were tested._

### Tested on:

 Odin

### Test description:

_Test by creating a new snapshot using `sat firmware` command_
_Test by deleting the snapshot using `sat firmware --delete-snapshot <snapshote-name>`_

## Risks and Mitigations

_Minimal_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

