### PR TITLE
CRAYSAT-1861: Unmount Ceph and s3fs filesystems on ncn-m001 during shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,8 +31,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed the step that freezes Ceph from the `platform-services` stage of `sat bootsys shutdown`
 - Modified the `ncn-power` stage of `sat bootsys shutdown` to shut down the NCNs
   one group at a time instead of all simultaneously. The new order of this stage
-  is to shut down workers, shut down masters (except ncn-m001), unmap and
-  unmount all rbd devices on `ncn-m001`, and then shut down storage nodes.
+  is to shut down workers, shut down masters (except ncn-m001), unmount all Ceph
+  and s3fs filesystems on `ncn-m001`, unmount and unmap all RBD devices on
+  `ncn-m001`, and then shut down storage nodes.
+- Added a step that disables the `ensure-ceph-mounts` systemd cron job on
+  `ncn-m001` during the `ncn-power` stage of `sat bootsys shutdown`.
+- Added a step that re-enables the `ensure-ceph-mounts` systemd cron job on
+  `ncn-m001` during the `ncn-power` stage of `sat bootsys boot`.
 - Modified the sat bootsys platform services stage to not perform unfreeze ceph
 - Updated the power on order of node groups in sat bootsys ncn-power stage to storage,
   unfreezing of ceph, managers and then the worker nodes.

--- a/sat/cli/bootsys/cron.py
+++ b/sat/cli/bootsys/cron.py
@@ -1,0 +1,89 @@
+#
+# MIT License
+#
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""
+Manage cron job definitions on the system (i.e. those run by the cron systemd service).
+"""
+import logging
+
+LOGGER = logging.getLogger(__name__)
+
+
+class CronJobError(Exception):
+    """Error modifying a system cron job."""
+    pass
+
+
+def modify_cron_job(ssh_client, hostname, job_file_path, enabled=False):
+    """Disable or enable a systemd cron job.
+
+    Disable or enable a cron job defined in the given file path by commenting
+    out or uncommenting its crontab entry.
+
+    This function can only enable or disable all crontab entries in a single
+    file, e.g. a file inside the `/etc/cron.d` directory.
+
+    Args:
+        ssh_client (paramiko.SSHClient): the SSH client connected to the host
+            where commands should be executed
+        hostname (str): the hostname associated with the ssh_client (for logging)
+        job_file_path (str): the path to the file defining the cronjob
+        enabled (bool): if True, then ensure the cron job is enabled. If False,
+            then ensure the cron job is disabled.
+
+    Raises:
+        paramiko.SSHException: if there is an error executing the command via SSH
+        CronJobError: if there is an error while executing the command to enable
+            or disable the cron job, or if the cron job should be enabled but the
+            given file path does not exist
+    """
+    action = ('disable', 'enable')[enabled]
+
+    _, stdout, stderr = ssh_client.exec_command(f'test -e {job_file_path}')
+    exit_code = stdout.channel.recv_exit_status()
+    if exit_code:
+        if not enabled:
+            LOGGER.info(f'Cron job {job_file_path} does not exist on {hostname}, '
+                        f'so it does not need to be disabled')
+            return
+        else:
+            raise CronJobError(
+                f'Cron job {job_file_path} does not exist on {hostname}, '
+                f'so it cannot be enabled'
+            )
+
+    magic_string = 'COMMENTED_BY_SAT'
+    if enabled:
+        # Only uncomment lines containing magic_string, which indicates SAT commented them out
+        sed_cmd = fr"sed -i 's/^# {magic_string} //' {job_file_path}"
+    else:
+        # Add magic_string to allow us to see which lines were commented out by SAT
+        sed_cmd = fr"sed -i 's/^\([^#]\)/# {magic_string} \1/' {job_file_path}"
+
+    _, stdout, stderr = ssh_client.exec_command(sed_cmd)
+    exit_code = stdout.channel.recv_exit_status()
+    if exit_code:
+        raise CronJobError(
+            f'Command "{sed_cmd}" failed to {action} cron job {job_file_path}'
+            f'on {hostname}: {stderr.read()}'
+        )

--- a/sat/cli/bootsys/filesystems.py
+++ b/sat/cli/bootsys/filesystems.py
@@ -1,0 +1,327 @@
+#
+# MIT License
+#
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""
+Manage the mounting and unmounting of filesystems during shutdown and boot.
+"""
+import functools
+import json
+import logging
+
+from inflect import engine
+from paramiko.ssh_exception import SSHException
+
+from sat.util import prompt_continue
+from sat.cli.bootsys.cron import CronJobError, modify_cron_job
+
+LOGGER = logging.getLogger(__name__)
+
+
+class FilesystemError(OSError):
+    """Error detecting, mounting, or unmounting a filesystem."""
+    pass
+
+
+def convert_ssh_exception(func):
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except SSHException as err:
+            raise FilesystemError(
+                f'Error executing command via SSH during {func.__name__}: {err}'
+            ) from err
+
+    return wrapper
+
+
+@convert_ssh_exception
+def modify_ensure_ceph_mounts_cron_job(ssh_client, hostname, enabled=False):
+    """Enable or disable the cron job that ensures ceph and s3fs filesystems are mounted.
+
+    There is a cronjob defined at `/etc/cron.d/ensure-ceph-mounts` that runs
+    every minute and ensures all filesystems of type fuse.s3fs (and one specific
+    ceph filesystem) are mounted. This function either enables or disables that
+    cronjob by commenting or uncommenting the crontab entry in this file.
+
+    Args:
+        ssh_client (paramiko.SSHClient): the SSH client connected to the host
+            where commands should be executed
+        hostname (str): the hostname associated with the ssh_client (for logging)
+        enabled (bool): if True, then ensure the cron job is enabled. If False,
+            then ensure the cron job is disabled.
+
+    Raises:
+        FilesystemError: if there is an error executing the command to disable
+            the automatic filesystem mounting job
+    """
+    try:
+        modify_cron_job(ssh_client, hostname, '/etc/cron.d/ensure-ceph-mounts', enabled=enabled)
+    except CronJobError as err:
+        err_msg = (
+            f'Failed to {"enable" if enabled else "disable"} cron job that ensures '
+            f'Ceph and s3fs filesystems are mounted on {hostname}: {err}'
+        )
+        raise FilesystemError(err_msg) from err
+
+
+@convert_ssh_exception
+def find_rbd_device_mounts(ssh_client, hostname):
+    """Find mount points for RBD devices on the system.
+
+    Args:
+        ssh_client (paramiko.SSHClient): the SSH client connected to the host
+            where commands should be executed
+        hostname (str): the hostname associated with the ssh_client (for logging)
+
+    Raises:
+        FilesystemError: if there is a problem listing RBD devices or mount points
+
+    Returns:
+        list of str: the list of mount points where RBD devices are mounted
+    """
+    rbd_list_cmd = 'rbd device list --format json'
+    _, stdout, stderr = ssh_client.exec_command(rbd_list_cmd)
+    exit_code = stdout.channel.recv_exit_status()
+    if exit_code:
+        raise FilesystemError(
+            f'Command "{rbd_list_cmd}" failed to list mapped RBD devices on '
+            f'{hostname}: {stderr.read().decode()}'
+        )
+
+    mounted_rbd_devices = []
+
+    rbd_device_list = json.loads(stdout.read().decode())
+    for rbd_device in rbd_device_list:
+        device_path = rbd_device.get('device')
+        if not device_path:
+            LOGGER.warning(f'Unable to determine device path for RBD device {rbd_device}, skipping')
+            continue
+
+        LOGGER.info(f'Checking for mounts of RBD device {device_path} on {hostname}')
+
+        findmnt_cmd = f'findmnt --source {device_path} --output TARGET -n'
+        _, stdout, stderr = ssh_client.exec_command(findmnt_cmd)
+        exit_code = stdout.channel.recv_exit_status()
+
+        rbd_mount_point = stdout.read().decode().strip()
+        if exit_code or not rbd_mount_point:
+            LOGGER.info(f'No mount of RBD device {device_path} found on {hostname}')
+            continue
+
+        LOGGER.info(f'Found mount of RBD device {device_path} at {rbd_mount_point} on {hostname}')
+        mounted_rbd_devices.append(rbd_mount_point)
+
+    return mounted_rbd_devices
+
+
+@convert_ssh_exception
+def find_ceph_and_s3fs_mounts(ssh_client, hostname):
+    """Find Ceph and s3fs mounts.
+
+    Args:
+        ssh_client (paramiko.SSHClient): the SSH client connected to the host
+            where commands should be executed
+        hostname (str): the hostname associated with the ssh_client (for logging)
+
+    Raises:
+        FilesystemError: if there is a problem finding ceph or s3fs mount points
+
+    Returns:
+        list of str: the list of mount points of ceph and s3fs filesystems
+    """
+    # Finds filesystems of type ceph or fuse.s3fs and only outputs the TARGET with no headers
+    findmnt_cmd = 'findmnt --types ceph,fuse.s3fs --output TARGET -n'
+    _, stdout, stderr = ssh_client.exec_command(findmnt_cmd)
+    exit_code = stdout.channel.recv_exit_status()
+    if exit_code:
+        raise FilesystemError(
+            f'Command "{findmnt_cmd}" failed to list mounted Ceph or s3fs '
+            f'filesystems on {hostname}: {stderr.read()}'
+        )
+
+    return stdout.read().decode().splitlines()
+
+
+@convert_ssh_exception
+def check_mount_activity(ssh_client, hostname, mount_points):
+    """Check whether mounts are active or not.
+
+    For each given mount point on the given hostname, check whether the mount
+    point is currently in use, and if so, give the user an opportunity to stop
+    any processes using the mount point. Keep looping until all given mount
+    points are no longer in use.
+
+    Args:
+        ssh_client (paramiko.SSHClient): the SSH client connected to the host
+            where commands should be executed
+        hostname (str): the hostname associated with the ssh_client (for logging)
+        mount_points (list of str): the list of mount points to check for activity
+
+    Raises:
+        FilesystemError: if there is a problem listing RBD devices or mount points
+        SystemExit: if the admin decides not to continue with unmounts
+    """
+    while True:
+        mount_points_in_use = False
+        for mount_point in mount_points:
+            lsof_cmd = f'lsof {mount_point}'
+
+            LOGGER.info(f'Checking whether mount point {mount_point} is in use on {hostname}')
+
+            _, stdout, _ = ssh_client.exec_command(lsof_cmd)
+            exit_code = stdout.channel.recv_exit_status()
+
+            # lsof exits with non-zero exit status when mount point is not in use
+            if exit_code:
+                LOGGER.info(f'Mount point {mount_point} is not in use on {hostname}')
+                continue
+
+            # lsof exits with zero exit status when mount point is in use
+            mount_points_in_use = True
+            LOGGER.info(f'Mount point {mount_point} is in use by the following processes on {hostname}:')
+            LOGGER.info(f'{stdout.read().decode()}')
+
+        if mount_points_in_use:
+            prompt_continue(
+                'unmount of filesystems',
+                'Some filesystems to be unmounted remain in use. '
+                'Please address this before continuing.'
+            )
+        elif mount_points:
+            LOGGER.info('All mount points are not in use and ready to be unmounted')
+            break
+        else:
+            LOGGER.debug('No mount points to be checked')
+            break
+
+
+@convert_ssh_exception
+def unmount_filesystems(ssh_client, hostname, mount_points):
+    """Unmount filesystems mounted at given mount points.
+
+    All given mount points are assumed not to be currently in use by running
+    processes. Unmounting will fail if filesystems are currently in use.
+
+    Args:
+        ssh_client (paramiko.SSHClient): the SSH client connected to the host
+            where commands should be executed
+        hostname (str): the hostname associated with the ssh_client (for logging)
+        mount_points (list of str): the list of mount points to be unmounted
+
+    Raises:
+        FilesystemError: if there is an error unmounting any filesystems
+    """
+    failed_unmounts = []
+
+    for mount_point in mount_points:
+        LOGGER.info(f'Unmounting {mount_point} on {hostname}')
+        umount_cmd = f'umount {mount_point}'
+        _, stdout, stderr = ssh_client.exec_command(umount_cmd)
+        exit_code = stdout.channel.recv_exit_status()
+
+        if exit_code:
+            LOGGER.error(f'"{umount_cmd}" failed with exit code {exit_code}: {stderr.read().decode()}')
+            failed_unmounts.append(mount_point)
+            continue
+
+        LOGGER.info(f'Successfully unmounted {mount_point} on {hostname}')
+
+    if failed_unmounts:
+        raise FilesystemError(f'Failed to unmount {len(failed_unmounts)}/{len(mount_points)} filesystems.')
+
+
+@convert_ssh_exception
+def unmap_rbd_devices(ssh_client, hostname):
+    """Unmap all RBD devices on the given host.
+
+    Args:
+        ssh_client (paramiko.SSHClient): the SSH client connected to the host
+            where commands should be executed
+        hostname (str): the hostname associated with the ssh_client (for logging)
+
+    Raises:
+        FilesystemError: if there is a failure to unmap RBD devices
+    """
+    rbdmap_cmd = 'rbdmap unmap-all'
+    _, stdout, stderr = ssh_client.exec_command(rbdmap_cmd)
+    exit_status = stdout.channel.recv_exit_status()
+    if exit_status != 0:
+        raise FilesystemError(
+            f'Failed to unmap all RBD devices on {hostname}. Command '
+            f'"{rbdmap_cmd}" exited with exit code {exit_status}: {stderr.read().decode()}'
+        )
+
+
+def do_ceph_unmounts(ssh_client, hostname):
+    """Find all filesystems provided by Ceph and unmount them on the given host.
+
+    Find all filesystems which are backed by Ceph storage (filesystems of type
+    ceph or fuse.s3fs or filesystems on RBD devices), check whether the mounts
+    are in use, and then unmount the filesystems when the admin has stopped any
+    processes using the mount points.
+
+    Args:
+        ssh_client (paramiko.SSHClient): the SSH client to use to connect to ncn-m001
+        hostname (str): the hostname to connect to
+
+    Raises:
+        FilesystemError: if there is an error finding and unmounting filesystems.
+    """
+    inflector = engine()
+
+    try:
+        ssh_client.connect(hostname)
+    except SSHException as err:
+        raise FilesystemError(f'Failed to connect to {hostname} via SSH: {err}')
+
+    fs_descriptor = 'mounted RBD device'
+    LOGGER.info(f'Finding {inflector.plural(fs_descriptor)} on {hostname}')
+    rbd_device_mounts = find_rbd_device_mounts(ssh_client, hostname)
+    LOGGER.info(f'Found {inflector.no(fs_descriptor, len(rbd_device_mounts))} on {hostname}')
+
+    fs_descriptor = 'mounted Ceph or s3fs filesystem'
+    LOGGER.info(f'Finding {inflector.plural(fs_descriptor)} on {hostname}')
+    ceph_s3fs_mounts = find_ceph_and_s3fs_mounts(ssh_client, hostname)
+    LOGGER.info(f'Found {inflector.no(fs_descriptor, len(ceph_s3fs_mounts))} on {hostname}')
+
+    if not(rbd_device_mounts or ceph_s3fs_mounts):
+        return
+
+    LOGGER.info(f'Checking whether mounts are in use on {hostname}')
+    mount_points = ceph_s3fs_mounts + rbd_device_mounts
+    check_mount_activity(ssh_client, hostname, mount_points)
+
+    LOGGER.info(f'Disabling cron job that ensures Ceph and s3fs filesystems are mounted on {hostname}')
+    modify_ensure_ceph_mounts_cron_job(ssh_client, hostname, enabled=False)
+    LOGGER.info(f'Successfully disabled cron job on {hostname}')
+
+    fs_descriptor = f'{inflector.no("filesystem", len(mount_points))} on {hostname}'
+    LOGGER.info(f'Unmounting {fs_descriptor}')
+    unmount_filesystems(ssh_client, hostname, mount_points)
+    LOGGER.info(f'Successfully unmounted {fs_descriptor}')
+
+    LOGGER.info(f'Unmapping all RBD devices on {hostname}')
+    unmap_rbd_devices(ssh_client, hostname)
+    LOGGER.info(f'Successfully unmapped all RBD devices on {hostname}')

--- a/tests/cli/bootsys/test_cron.py
+++ b/tests/cli/bootsys/test_cron.py
@@ -1,0 +1,162 @@
+#
+# MIT License
+#
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""
+Tests for cron job enable/disable functionality in cron module.
+"""
+import logging
+import os
+import shlex
+import subprocess
+from tempfile import NamedTemporaryFile
+import unittest
+from unittest.mock import MagicMock
+import uuid
+
+from sat.cli.bootsys.cron import CronJobError, modify_cron_job
+
+
+class TestModifyCronJob(unittest.TestCase):
+
+    def setUp(self):
+        """Create temporary files containing fake cron tab entries."""
+        self.enabled_cron_file = NamedTemporaryFile(mode='w', delete=False)
+        self.enabled_cron_lines = [
+            '# This job executes some-script.sh every minute',
+            '* * * * * root /usr/bin/some-script.sh'
+        ]
+        self.enabled_cron_file.write('\n'.join(self.enabled_cron_lines) + '\n')
+        self.enabled_cron_file.close()
+
+        self.disabled_cron_file = NamedTemporaryFile(mode='w', delete=False)
+        self.disabled_cron_lines = [
+            '# This job executes another-script.sh every hour on the hour',
+            '# COMMENTED_BY_SAT 0 * * * * root /usr/bin/another-script.sh'
+        ]
+        self.disabled_cron_file.write('\n'.join(self.disabled_cron_lines) + '\n')
+        self.disabled_cron_file.close()
+
+        self.other_disabled_cron_file = NamedTemporaryFile(mode='w', delete=False)
+        self.other_disabled_cron_lines = [
+            '# This job executes yet-another-script.sh every day at midnight',
+            '# 0 0 * * * root /usr/bin/yet-another-script.sh'
+        ]
+        self.other_disabled_cron_file.write('\n'.join(self.other_disabled_cron_lines) + '\n')
+        self.other_disabled_cron_file.close()
+
+        def fake_ssh_exec_command(command):
+            """Fake execution of a command via SSH by executing it locally."""
+            process = subprocess.run(shlex.split(command), capture_output=True)
+            stdin = MagicMock()
+            stderr = MagicMock()
+            stdout = MagicMock()
+            stdout.channel.recv_exit_status.return_value = process.returncode
+            return stdin, stdout, stderr
+
+        self.mock_ssh_client = MagicMock()
+        self.mock_ssh_client.exec_command.side_effect = fake_ssh_exec_command
+
+    def tearDown(self):
+        os.remove(self.enabled_cron_file.name)
+        os.remove(self.disabled_cron_file.name)
+
+    def test_disable_enabled_cron_job(self):
+        """Test disabling an enabled cron job"""
+        modify_cron_job(self.mock_ssh_client, 'localhost', self.enabled_cron_file.name, enabled=False)
+        with open(self.enabled_cron_file.name) as f:
+            self.assertEqual(
+                [
+                    self.enabled_cron_lines[0],
+                    f'# COMMENTED_BY_SAT {self.enabled_cron_lines[1]}'
+                ],
+                f.read().splitlines()
+            )
+
+    def test_disable_then_enable_cron_job(self):
+        """Test disabling and then re-enabling a cron job results in no changes."""
+        modify_cron_job(self.mock_ssh_client, 'localhost', self.enabled_cron_file.name, enabled=False)
+        modify_cron_job(self.mock_ssh_client, 'localhost', self.enabled_cron_file.name, enabled=True)
+        with open(self.enabled_cron_file.name) as f:
+            self.assertEqual(self.enabled_cron_lines, f.read().splitlines())
+
+    def test_disable_disabled_cron_job(self):
+        """Test disabling a disabled cron job"""
+        modify_cron_job(self.mock_ssh_client, 'localhost', self.disabled_cron_file.name, enabled=False)
+        with open(self.disabled_cron_file.name) as f:
+            self.assertEqual(
+                self.disabled_cron_lines,
+                f.read().splitlines()
+            )
+
+    def test_enable_disabled_cron_job(self):
+        """Test enabling a disabled cron job"""
+        modify_cron_job(self.mock_ssh_client, 'localhost', self.disabled_cron_file.name, enabled=True)
+        with open(self.disabled_cron_file.name) as f:
+            self.assertEqual(
+                [
+                    self.disabled_cron_lines[0],
+                    '0 * * * * root /usr/bin/another-script.sh'
+                ],
+                f.read().splitlines()
+            )
+
+    def test_enable_enabled_cron_job(self):
+        """Test enabling an already enabled cron job"""
+        modify_cron_job(self.mock_ssh_client, 'localhost', self.enabled_cron_file.name, enabled=True)
+        with open(self.enabled_cron_file.name) as f:
+            self.assertEqual(self.enabled_cron_lines, f.read().splitlines())
+
+    def test_enable_then_disable_cron_job(self):
+        """Test enabling and then disabling a disable cron job results in no changes"""
+        modify_cron_job(self.mock_ssh_client, 'localhost', self.disabled_cron_file.name, enabled=True)
+        modify_cron_job(self.mock_ssh_client, 'localhost', self.disabled_cron_file.name, enabled=False)
+        with open(self.disabled_cron_file.name) as f:
+            self.assertEqual(self.disabled_cron_lines, f.read().splitlines())
+
+    def test_enable_cron_job_not_disabled_by_sat(self):
+        """Test enabling a cron job that was not disabled by SAT"""
+        modify_cron_job(self.mock_ssh_client, 'localhost', self.other_disabled_cron_file.name, enabled=True)
+        with open(self.other_disabled_cron_file.name) as f:
+            self.assertEqual(self.other_disabled_cron_lines, f.read().splitlines())
+
+    def test_disable_non_existent_cron_job(self):
+        """Test disabling a non-existent cronjob"""
+        non_existent_file_path = f'/some/non/existent/file/path/{uuid.uuid4()}'
+        with self.assertLogs(level=logging.INFO) as logs_cm:
+            modify_cron_job(self.mock_ssh_client, 'localhost', non_existent_file_path, enabled=False)
+        self.assertEqual(1, len(logs_cm.records))
+        self.assertEqual(f'Cron job {non_existent_file_path} does not exist on localhost, '
+                         f'so it does not need to be disabled',
+                         logs_cm.records[0].message)
+
+    def test_enable_non_existent_cron_job(self):
+        """Test enabling a non-existent cronjob"""
+        non_existent_file_path = f'/some/non/existent/file/path/{uuid.uuid4()}'
+        with self.assertRaisesRegex(CronJobError,
+                                    f'Cron job {non_existent_file_path} does not '
+                                    f'exist on localhost, so it cannot be enabled'):
+            modify_cron_job(self.mock_ssh_client, 'localhost', non_existent_file_path, enabled=True)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/cli/bootsys/test_filesystems.py
+++ b/tests/cli/bootsys/test_filesystems.py
@@ -1,0 +1,575 @@
+#
+# MIT License
+#
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""
+Tests for filesystem discovery, activity checking, and mounting in filesystems module.
+"""
+import json
+import unittest
+from unittest.mock import MagicMock, patch
+
+from sat.cli.bootsys.filesystems import (
+    FilesystemError,
+    check_mount_activity,
+    do_ceph_unmounts,
+    find_rbd_device_mounts,
+    find_ceph_and_s3fs_mounts,
+    modify_ensure_ceph_mounts_cron_job,
+    unmap_rbd_devices,
+    unmount_filesystems,
+)
+
+
+class TestModifyEnsureCephMountsCronJob(unittest.TestCase):
+
+    def setUp(self):
+        self.mock_ssh_client = MagicMock()
+        self.hostname = 'ncn-m001'
+        self.cron_job_file = '/etc/cron.d/ensure-ceph-mounts'
+
+    def test_modify_ensure_ceph_mounts_cron_job_enable(self):
+        """Test that the function enables the cron job."""
+        with patch('sat.cli.bootsys.filesystems.modify_cron_job') as mock_modify_cron_job:
+            modify_ensure_ceph_mounts_cron_job(self.mock_ssh_client, self.hostname, enabled=True)
+        mock_modify_cron_job.assert_called_once_with(self.mock_ssh_client, self.hostname,
+                                                     self.cron_job_file, enabled=True)
+
+    def test_modify_ensure_ceph_mounts_cron_job_disable(self):
+        """Test that the function disables the cron job."""
+        with patch('sat.cli.bootsys.filesystems.modify_cron_job') as mock_modify_cron_job:
+            modify_ensure_ceph_mounts_cron_job(self.mock_ssh_client, self.hostname, enabled=False)
+        mock_modify_cron_job.assert_called_once_with(self.mock_ssh_client, self.hostname,
+                                                     self.cron_job_file, enabled=False)
+
+
+class TestFindRbdDeviceMounts(unittest.TestCase):
+
+    def setUp(self):
+        """Create a temporary file containing fake mount entries."""
+        self.fake_rbd_devices = [
+            {
+                'id': 0,
+                'pool': 'kube',
+                'namespace': '',
+                'name': 'admin',
+                'snap': '-',
+                'device': '/dev/rbd0'
+            },
+            {
+                'id': 1,
+                'pool': 'kube',
+                'namespace': '',
+                'name': 'developer',
+                'snap': '-',
+                'device': '/dev/rbd1'
+            }
+        ]
+
+        self.rbd_device_list_exit_status = 0
+        self.findmnt_exit_status = 0
+        self.rbd_devices_mounted = True
+
+        def fake_ssh_exec_command(command):
+            """Fake execution of a command via SSH by executing it locally."""
+            output = ''
+            exit_status = 0
+            if 'rbd device list' in command:
+                output = json.dumps(self.fake_rbd_devices)
+                exit_status = self.rbd_device_list_exit_status
+            elif 'findmnt' in command:
+                if self.rbd_devices_mounted:
+                    for device in self.fake_rbd_devices:
+                        if device['device'] in command:
+                            output = f'/mnt/{device["name"]}'
+                            break
+                exit_status = self.findmnt_exit_status
+
+            stdin = MagicMock()
+            stderr = MagicMock()
+            stdout = MagicMock()
+            stdout.channel.recv_exit_status.return_value = exit_status
+            stdout.read.return_value = output.encode()
+            return stdin, stdout, stderr
+
+        self.mock_ssh_client = MagicMock()
+        self.mock_ssh_client.exec_command.side_effect = fake_ssh_exec_command
+        self.hostname = 'ncn-m001'
+
+    def test_find_rbd_device_mounts(self):
+        """Test that the function returns the expected RBD device mounts."""
+        rbd_device_mounts = find_rbd_device_mounts(self.mock_ssh_client, self.hostname)
+        self.assertEqual(rbd_device_mounts,
+                         ['/mnt/admin', '/mnt/developer'])
+
+    def test_find_rbd_device_mounts_no_rbd_devices(self):
+        """Test that the function returns an empty list when there are no RBD devices."""
+        self.fake_rbd_devices = []
+        rbd_device_mounts = find_rbd_device_mounts(self.mock_ssh_client, self.hostname)
+        self.assertEqual(rbd_device_mounts, [])
+
+    def test_find_rbd_device_mounts_no_mounts(self):
+        """Test that the function returns an empty list when there are no mounts."""
+        self.rbd_devices_mounted = False
+        rbd_device_mounts = find_rbd_device_mounts(self.mock_ssh_client, self.hostname)
+        self.assertEqual(rbd_device_mounts, [])
+
+    def test_find_rbd_device_mounts_rbd_device_list_error(self):
+        """Test that the function returns an empty list when 'rbd device list' exits with an error."""
+        self.rbd_device_list_exit_status = 1
+        with self.assertRaisesRegex(FilesystemError, 'failed to list mapped RBD devices'):
+            find_rbd_device_mounts(self.mock_ssh_client, self.hostname)
+
+    def test_find_rbd_device_mounts_findmnt_error(self):
+        """Test that the function returns an empty list when 'findmnt' exits with an error."""
+        self.findmnt_exit_status = 1
+        with self.assertLogs(level='INFO') as logs_cm:
+            rbd_device_mounts = find_rbd_device_mounts(self.mock_ssh_client, self.hostname)
+        self.assertEqual(rbd_device_mounts, [])
+        self.assertEqual(4, len(logs_cm.records))
+        self.assertEqual(f'No mount of RBD device /dev/rbd0 found on {self.hostname}',
+                         logs_cm.records[1].message)
+        self.assertEqual(f'No mount of RBD device /dev/rbd1 found on {self.hostname}',
+                         logs_cm.records[3].message)
+
+    def test_find_rbd_device_mounts_missing_device_key(self):
+        """Test that the function logs a warning and skips any RBD devices missing the 'device' key."""
+        self.fake_rbd_devices.append(
+            # Add an RBD device where the 'device' key is missing
+            {
+                'id': 2,
+                'pool': 'kube',
+                'namespace': '',
+                'name': 'missing',
+                'snap': '-'
+            }
+        )
+        with self.assertLogs(level='WARNING') as logs_cm:
+            rbd_device_mounts = find_rbd_device_mounts(self.mock_ssh_client, self.hostname)
+        self.assertEqual(rbd_device_mounts, ['/mnt/admin', '/mnt/developer'])
+        self.assertEqual(1, len(logs_cm.records))
+        self.assertRegex(logs_cm.records[0].message,
+                         r'Unable to determine device path for RBD device .* skipping')
+
+
+class TestFindCephAndS3fsMounts(unittest.TestCase):
+
+    def setUp(self):
+        """Set up fake mount entries."""
+        self.fake_ceph_mount_points = [
+            '/etc/cray/upgrade/csm'
+        ]
+        self.fake_s3fs_mount_points = [
+            '/var/opt/cray/sdu/collection-mount',
+            '/var/opt/cray/config-data'
+        ]
+        self.mount_points = self.fake_ceph_mount_points + self.fake_s3fs_mount_points
+        self.find_mnt_exit_code = 0
+
+        def fake_ssh_exec_command(command):
+            """Fake execution of a command via SSH by executing it locally."""
+            stdin = MagicMock()
+            stderr = MagicMock()
+            stdout = MagicMock()
+            if 'findmnt' in command:
+                stdout.channel.recv_exit_status.return_value = self.find_mnt_exit_code
+                stdout.read.return_value = '\n'.join(self.mount_points).encode()
+            else:
+                # Only 'findmnt' is expected to be called
+                stdout.channel.recv_exit_status.return_value = 1
+                stderr.read.return_value = 'command not found'.encode()
+            return stdin, stdout, stderr
+
+        self.mock_ssh_client = MagicMock()
+        self.mock_ssh_client.exec_command.side_effect = fake_ssh_exec_command
+        self.hostname = 'ncn-m001'
+
+    def test_find_ceph_and_s3fs_mounts(self):
+        """Test that the function returns the expected Ceph and S3FS mount points."""
+        mount_points = find_ceph_and_s3fs_mounts(self.mock_ssh_client, self.hostname)
+        self.assertEqual(self.mount_points, mount_points)
+
+    def test_find_ceph_and_s3fs_mounts_no_mounts(self):
+        """Test that the function returns an empty list when there are no mounts."""
+        self.mount_points = []
+        mount_points = find_ceph_and_s3fs_mounts(self.mock_ssh_client, self.hostname)
+        self.assertEqual(mount_points, [])
+
+    def test_find_ceph_and_s3fs_mounts_findmnt_error(self):
+        """Test that the function returns an empty list when 'findmnt' exits with an error."""
+        self.find_mnt_exit_code = 1
+        self.mount_points = []
+        with self.assertRaisesRegex(FilesystemError, 'failed to list mounted Ceph or s3fs filesystems'):
+            find_ceph_and_s3fs_mounts(self.mock_ssh_client, self.hostname)
+
+
+class TestCheckMountActivity(unittest.TestCase):
+
+    def setUp(self):
+        self.hostname = 'ncn-m001'
+        # This dictionary maps from a mount point name to a boolean indicating
+        # whether the mount point is in use
+        self.mount_points_to_status = {
+            '/mnt/admin': False,
+            '/mnt/developer': False
+        }
+        self.lsof_output = '\n'.join([
+            'COMMAND     PID USER   FD   TYPE DEVICE SIZE/OFF NODE NAME',
+            'bash       1234 root  cwd    DIR  253,0     4096    2 {mount_point}'
+        ])
+
+        def fake_ssh_exec_command(command):
+            """Fake execution of the lsof command via SSH"""
+            stdin = MagicMock()
+            stderr = MagicMock()
+            stdout = MagicMock()
+            if 'lsof' in command:
+                # Begin by assuming mount point not recognized
+                stdout.channel.recv_exit_status.return_value = 1
+                for mount_point, in_use in self.mount_points_to_status.items():
+                    if mount_point in command and in_use:
+                        stdout.channel.recv_exit_status.return_value = 0
+                        stdout.read.return_value = self.lsof_output.format(mount_point=mount_point).encode()
+            else:
+                # Only 'lsof' is expected to be called
+                stdout.channel.recv_exit_status.return_value = 1
+                stderr.read.return_value = 'command not found'.encode()
+            return stdin, stdout, stderr
+
+        self.mock_ssh_client = MagicMock()
+        self.mock_ssh_client.exec_command.side_effect = fake_ssh_exec_command
+
+    def test_check_mount_activity_one_mount_in_use(self):
+        """Test that the function prompts the user to continue when one mount point is in use."""
+        # Set one of the mount points to be in use
+        mount_point_in_use = '/mnt/admin'
+        mount_point_not_in_use = '/mnt/developer'
+        self.mount_points_to_status[mount_point_in_use] = True
+
+        # Mock prompt_continue to simulate admin stopping processes currently
+        # using the mount point and then continuing
+        def fake_prompt_continue(*args, **kwargs):
+            for mount_point in self.mount_points_to_status.keys():
+                self.mount_points_to_status[mount_point] = False
+            return True
+
+        with patch('sat.cli.bootsys.filesystems.prompt_continue', side_effect=fake_prompt_continue):
+            with self.assertLogs(level='INFO') as logs_cm:
+                check_mount_activity(self.mock_ssh_client, self.hostname,
+                                     self.mount_points_to_status.keys())
+
+        info_log_messages = [record.message for record in logs_cm.records if record.levelname == 'INFO']
+        self.assertEqual(10, len(info_log_messages))
+        self.assertEqual(
+            [
+                f'Checking whether mount point {mount_point_in_use} is in use on {self.hostname}',
+                f'Mount point {mount_point_in_use} is in use by the following processes on {self.hostname}:',
+                self.lsof_output.format(mount_point=mount_point_in_use),
+                f'Checking whether mount point {mount_point_not_in_use} is in use on {self.hostname}',
+                f'Mount point {mount_point_not_in_use} is not in use on {self.hostname}',
+                f'Checking whether mount point {mount_point_in_use} is in use on {self.hostname}',
+                f'Mount point {mount_point_in_use} is not in use on {self.hostname}',
+                f'Checking whether mount point {mount_point_not_in_use} is in use on {self.hostname}',
+                f'Mount point {mount_point_not_in_use} is not in use on {self.hostname}',
+                'All mount points are not in use and ready to be unmounted'
+            ],
+            info_log_messages
+        )
+
+    def test_check_mount_activity_all_mounts_in_use(self):
+        """Test that the function prompts the user to continue when all mount points are in use."""
+        # Set all mount points to be in use
+        mount_points = list(self.mount_points_to_status.keys())
+        for mount_point in mount_points:
+            self.mount_points_to_status[mount_point] = True
+
+        # Mock prompt_continue to simulate admin stopping processes currently
+        # using the mount point and then continuing
+        def fake_prompt_continue(*args, **kwargs):
+            for mp in mount_points:
+                self.mount_points_to_status[mp] = False
+            return True
+
+        with patch('sat.cli.bootsys.filesystems.prompt_continue', side_effect=fake_prompt_continue):
+            with self.assertLogs(level='INFO') as logs_cm:
+                check_mount_activity(self.mock_ssh_client, self.hostname,
+                                     mount_points)
+
+        info_log_messages = [record.message for record in logs_cm.records if record.levelname == 'INFO']
+        self.assertEqual(11, len(info_log_messages))
+        self.assertEqual(
+            [
+                f'Checking whether mount point {mount_points[0]} is in use on {self.hostname}',
+                f'Mount point {mount_points[0]} is in use by the following processes on {self.hostname}:',
+                self.lsof_output.format(mount_point=mount_points[0]),
+                f'Checking whether mount point {mount_points[1]} is in use on {self.hostname}',
+                f'Mount point {mount_points[1]} is in use by the following processes on {self.hostname}:',
+                self.lsof_output.format(mount_point=mount_points[1]),
+                f'Checking whether mount point {mount_points[0]} is in use on {self.hostname}',
+                f'Mount point {mount_points[0]} is not in use on {self.hostname}',
+                f'Checking whether mount point {mount_points[1]} is in use on {self.hostname}',
+                f'Mount point {mount_points[1]} is not in use on {self.hostname}',
+                'All mount points are not in use and ready to be unmounted'
+            ],
+            info_log_messages
+        )
+
+    def test_check_mount_activity_no_mounts_in_use(self):
+        """Test that the function does not prompt the user to continue when no mount points are in use."""
+        # Set all mount points to be not in use (already default from setUp)
+        for mount_point in self.mount_points_to_status.keys():
+            self.mount_points_to_status[mount_point] = False
+
+        with self.assertLogs(level='INFO') as logs_cm:
+            check_mount_activity(self.mock_ssh_client, self.hostname,
+                                 self.mount_points_to_status.keys())
+
+        info_log_messages = [record.message for record in logs_cm.records if record.levelname == 'INFO']
+        self.assertEqual(5, len(info_log_messages))
+        self.assertEqual(
+            [
+                f'Checking whether mount point /mnt/admin is in use on {self.hostname}',
+                f'Mount point /mnt/admin is not in use on {self.hostname}',
+                f'Checking whether mount point /mnt/developer is in use on {self.hostname}',
+                f'Mount point /mnt/developer is not in use on {self.hostname}',
+                'All mount points are not in use and ready to be unmounted'
+            ],
+            info_log_messages
+        )
+
+    def test_check_mount_activity_no_mounts(self):
+        """Test that the function does not prompt the user to continue when no mount points are provided."""
+        with self.assertLogs(level='DEBUG') as logs_cm:
+            check_mount_activity(self.mock_ssh_client, self.hostname, [])
+
+        debug_log_messages = [record.message for record in logs_cm.records if record.levelname == 'DEBUG']
+        self.assertEqual(1, len(debug_log_messages))
+        self.assertEqual(
+            [
+                'No mount points to be checked'
+            ],
+            debug_log_messages
+        )
+
+
+class TestUnmountFilesystems(unittest.TestCase):
+
+    def setUp(self):
+        self.hostname = 'ncn-m001'
+        self.umount_success_by_mount_point = {
+            '/mnt/admin': True,
+            '/mnt/developer': True
+        }
+        self.mount_points = list(self.umount_success_by_mount_point.keys())
+
+        def fake_ssh_exec_command(command):
+            """Fake execution of the umount command via SSH"""
+            stdin = MagicMock()
+            stderr = MagicMock()
+            stdout = MagicMock()
+            if 'umount' in command:
+                # if the mount point is unknown, we will fail
+                stdout.channel.recv_exit_status.return_value = 1
+                for mount_point, success in self.umount_success_by_mount_point.items():
+                    if mount_point in command:
+                        if success:
+                            stdout.channel.recv_exit_status.return_value = 0
+                        else:
+                            stdout.channel.recv_exit_status.return_value = 1
+                            stderr.read.return_value = f'mount point busy'.encode()
+            else:
+                # Only 'umount' is expected to be called
+                stdout.channel.recv_exit_status.return_value = 1
+                stderr.read.return_value = 'command not found'.encode()
+            return stdin, stdout, stderr
+
+        self.mock_ssh_client = MagicMock()
+        self.mock_ssh_client.exec_command.side_effect = fake_ssh_exec_command
+
+    def test_unmount_filesystems(self):
+        """Test that the function successfully unmounts the filesystems."""
+        with self.assertLogs(level='INFO') as logs_cm:
+            unmount_filesystems(self.mock_ssh_client, self.hostname, self.mount_points)
+
+        info_log_messages = [record.message for record in logs_cm.records if record.levelname == 'INFO']
+        self.assertEqual(4, len(info_log_messages))
+        self.assertEqual(
+            [
+                f'Unmounting {self.mount_points[0]} on {self.hostname}',
+                f'Successfully unmounted {self.mount_points[0]} on {self.hostname}',
+                f'Unmounting {self.mount_points[1]} on {self.hostname}',
+                f'Successfully unmounted {self.mount_points[1]} on {self.hostname}'
+            ],
+            info_log_messages
+        )
+
+    def test_unmount_filesystems_one_failure(self):
+        """Test that the function logs an error when unmounting one mount point fails."""
+        self.umount_success_by_mount_point[self.mount_points[0]] = False
+        with self.assertRaisesRegex(FilesystemError, 'Failed to unmount 1/2 filesystems'):
+            with self.assertLogs(level='ERROR') as logs_cm:
+                unmount_filesystems(self.mock_ssh_client, self.hostname, self.mount_points)
+
+        error_log_messages = [record.message for record in logs_cm.records if record.levelname == 'ERROR']
+        self.assertEqual(1, len(error_log_messages))
+        self.assertEqual(
+            f'"umount {self.mount_points[0]}" failed with exit code 1: mount point busy',
+            error_log_messages[0]
+        )
+
+    def test_unmount_filesystems_both_fail(self):
+        """Test that the function logs an error when unmounting both mount points fails."""
+        for mount_point in self.mount_points:
+            self.umount_success_by_mount_point[mount_point] = False
+
+        with self.assertRaisesRegex(FilesystemError, 'Failed to unmount 2/2 filesystems'):
+            with self.assertLogs(level='ERROR') as logs_cm:
+                unmount_filesystems(self.mock_ssh_client, self.hostname, self.mount_points)
+
+        error_log_messages = [record.message for record in logs_cm.records if record.levelname == 'ERROR']
+        self.assertEqual(2, len(error_log_messages))
+        self.assertEqual(
+            [
+                f'"umount {self.mount_points[0]}" failed with exit code 1: mount point busy',
+                f'"umount {self.mount_points[1]}" failed with exit code 1: mount point busy'
+            ],
+            error_log_messages
+        )
+
+    def test_unmount_filesystems_no_mount_points(self):
+        """Test that the function does nothing no mount points are provided."""
+        unmount_filesystems(self.mock_ssh_client, self.hostname, [])
+        self.mock_ssh_client.exec_command.assert_not_called()
+
+
+class TestUnmapRbdDevices(unittest.TestCase):
+
+    def setUp(self):
+        self.hostname = 'ncn-m001'
+        self.rbd_unmap_all_exit_status = 0
+
+        def fake_ssh_exec_command(command):
+            """Fake execution of the "rbd unmap-all" command via SSH"""
+            stdin = MagicMock()
+            stderr = MagicMock()
+            stdout = MagicMock()
+            if 'rbdmap unmap-all' in command:
+                stdout.channel.recv_exit_status.return_value = self.rbd_unmap_all_exit_status
+            else:
+                # Only 'rbdmap unmap-all' is expected to be called
+                stdout.channel.recv_exit_status.return_value = 1
+                stderr.read.return_value = 'command not found'.encode()
+            return stdin, stdout, stderr
+
+        self.mock_ssh_client = MagicMock()
+        self.mock_ssh_client.exec_command.side_effect = fake_ssh_exec_command
+
+    def test_unmap_rbd_devices(self):
+        """Test that the function successfully unmaps the RBD devices."""
+        unmap_rbd_devices(self.mock_ssh_client, self.hostname)
+        self.mock_ssh_client.exec_command.assert_called_once_with('rbdmap unmap-all')
+
+    def test_unmap_rbd_devices_error(self):
+        """Test that the function raises an exception when unmap-all fails."""
+        self.rbd_unmap_all_exit_status = 1
+        with self.assertRaisesRegex(FilesystemError, 'Failed to unmap all RBD devices'):
+            unmap_rbd_devices(self.mock_ssh_client, self.hostname)
+
+
+class TestDoCephUnmounts(unittest.TestCase):
+
+    def setUp(self):
+        # create a mock ssh_client that does nothing
+        self.mock_ssh_client = MagicMock()
+        self.hostname = 'ncn-m001'
+        self.rbd_mounts = [
+            '/mnt/admin',
+            '/mnt/developer'
+        ]
+        self.ceph_and_s3fs_mounts = [
+            '/etc/cray/upgrade/csm',
+            '/var/opt/cray/sdu/collection-mount',
+            '/var/opt/cray/config-data'
+        ]
+        # Mock functions called by do_ceph_unmounts
+        self.mock_find_rbd_device_mounts = patch('sat.cli.bootsys.filesystems.find_rbd_device_mounts').start()
+        self.mock_find_rbd_device_mounts.return_value = self.rbd_mounts
+        self.mock_find_ceph_and_s3fs_mounts = patch('sat.cli.bootsys.filesystems.find_ceph_and_s3fs_mounts').start()
+        self.mock_find_ceph_and_s3fs_mounts.return_value = self.ceph_and_s3fs_mounts
+        self.mock_check_mount_activity = patch('sat.cli.bootsys.filesystems.check_mount_activity').start()
+        self.mock_modify_ensure_ceph_mounts_cron_job = patch(
+            'sat.cli.bootsys.filesystems.modify_ensure_ceph_mounts_cron_job').start()
+        self.mock_unmount_filesystems = patch('sat.cli.bootsys.filesystems.unmount_filesystems').start()
+        self.mock_unmap_rbd_devices = patch('sat.cli.bootsys.filesystems.unmap_rbd_devices').start()
+
+    def tearDown(self):
+        patch.stopall()
+
+    def test_do_ceph_unmounts(self):
+        """Test that the function successfully unmounts Ceph/s3fs filesystems and unmaps RBD devices"""
+        with self.assertLogs(level='INFO') as logs_cm:
+            do_ceph_unmounts(self.mock_ssh_client, self.hostname)
+
+        info_log_messages = [record.message for record in logs_cm.records if record.levelname == 'INFO']
+        self.assertEqual(11, len(logs_cm.records))
+        self.assertEqual(
+            [
+                f'Finding mounted RBD devices on {self.hostname}',
+                f'Found {len(self.rbd_mounts)} mounted RBD devices on {self.hostname}',
+                f'Finding mounted Ceph or s3fs filesystems on {self.hostname}',
+                f'Found {len(self.ceph_and_s3fs_mounts)} mounted Ceph or s3fs filesystems on {self.hostname}',
+                f'Checking whether mounts are in use on {self.hostname}',
+                f'Disabling cron job that ensures Ceph and s3fs filesystems are mounted on {self.hostname}',
+                f'Successfully disabled cron job on {self.hostname}',
+                f'Unmounting {len(self.rbd_mounts) + len(self.ceph_and_s3fs_mounts)} filesystems on {self.hostname}',
+                (
+                    f'Successfully unmounted {len(self.rbd_mounts) + len(self.ceph_and_s3fs_mounts)} '
+                    f'filesystems on {self.hostname}'
+                ),
+                f'Unmapping all RBD devices on {self.hostname}',
+                f'Successfully unmapped all RBD devices on {self.hostname}'
+            ],
+            info_log_messages
+        )
+
+    def test_do_ceph_unmounts_no_mounts(self):
+        """Test that the function does nothing when there are no mounted RBD devices or Ceph/s3fs filesystems."""
+        self.mock_find_rbd_device_mounts.return_value = []
+        self.mock_find_ceph_and_s3fs_mounts.return_value = []
+        do_ceph_unmounts(self.mock_ssh_client, self.hostname)
+        self.mock_check_mount_activity.assert_not_called()
+        self.mock_modify_ensure_ceph_mounts_cron_job.assert_not_called()
+        self.mock_unmount_filesystems.assert_not_called()
+        self.mock_unmap_rbd_devices.assert_not_called()
+
+    def test_do_ceph_unmounts_check_mount_activity_exit(self):
+        """Test that the function raises a FilesystemError when check_mount_activity raises SystemExit."""
+        self.mock_check_mount_activity.side_effect = SystemExit(1)
+
+        with self.assertRaises(SystemExit) as err_cm:
+            do_ceph_unmounts(self.mock_ssh_client, self.hostname)
+
+        self.assertEqual(1, err_cm.exception.code)
+        # assert all functions after check_mount_activity are not called
+        self.mock_modify_ensure_ceph_mounts_cron_job.assert_not_called()
+        self.mock_unmount_filesystems.assert_not_called()
+        self.mock_unmap_rbd_devices.assert_not_called()

--- a/tests/cli/bootsys/test_mgmt_power.py
+++ b/tests/cli/bootsys/test_mgmt_power.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2021, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -41,6 +41,7 @@ from sat.waiting import WaitingFailure
 class TestSSHAvailableWaiter(unittest.TestCase):
     """Tests for the sat.cli.bootsys.mgmt_power.SSHAvailableWaiter class"""
     def setUp(self):
+        self.mock_filtered_host_keys = patch('sat.cli.bootsys.mgmt_power.FilteredHostKeys').start()
         self.mock_get_ssh_client = patch('sat.cli.bootsys.mgmt_power.get_ssh_client').start()
         self.mock_ssh_client = self.mock_get_ssh_client.return_value
         self.members = ['ncn-w002', 'ncn-s001']
@@ -52,7 +53,9 @@ class TestSSHAvailableWaiter(unittest.TestCase):
     def test_pre_wait_action_loads_keys(self):
         """Test the SSH waiter loads system host keys through get_ssh_client."""
         SSHAvailableWaiter(self.members, self.timeout).pre_wait_action()
-        self.mock_get_ssh_client.assert_called_once_with()
+        self.mock_get_ssh_client.assert_called_once_with(
+            host_keys=self.mock_filtered_host_keys.return_value
+        )
 
     def test_ssh_available(self):
         """Test the SSH waiter detects available nodes"""


### PR DESCRIPTION
## Summary and Scope

Unmount filesystems of type `ceph` and `fuse.s3fs` on ncn-m001 when shutting down. Also do the same for any filesystems mounted from RBD devices.

Add an activity check that uses `lsof` to check if filesystems can be unmounted or if there are active processes using them, and report these to the admin, so they can stop the offending processes as appropriate.

Disable the cron job that automatically mounts Ceph and s3fs filesystems on ncn-m001, so that they won't get remounted before the node is shut down. Re-enable it at the appropriate time during the power on.

## Issues and Related PRs

* Resolves CRAYSAT-1861
* Resolves CRAYSAT-1872

## Testing

### Tested on:

  * fanta

### Test description:

Minimal testing so far. Just tested the functions on their own to limit system disruption.

Still need to test full-system power down.

## Risks and Mitigations

Adds a significant amount of code and output to `sat bootsys`, so we will want to update the docs, but overall this should be a really positive improvement to the robustness and completeness of the system shutdown automation.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
