### PR TITLE
CRAYSAT-1871: Limit SLS query in `sat status` to only Nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.28.8] - 2024-07-03
+
+### Fixed
+- Fixed issue in `sat status` to limit SLS query to only node-type components,
+  which is the only component type where SLS data is used.
+
 ## [3.28.7] - 2024-06-26
 
 ### Fixed

--- a/sat/cli/status/status_module.py
+++ b/sat/cli/status/status_module.py
@@ -410,7 +410,11 @@ class SLSStatusModule(StatusModule):
         sls_client = SLSClient(self.session)
 
         try:
-            sls_response = sls_client.get('hardware').json()
+            # Per SLSStatusModule.component_types, this module only applies to the Node type in
+            # HSM, for which the corresponding SLS type is comptype_node. In the future, if other
+            # types may have aliases that should be presented by `sat status`, this may need to be
+            # extended.
+            sls_response = sls_client.get('search', 'hardware', params={'type': 'comptype_node'}).json()
         except APIError as err:
             raise StatusModuleException(f'Could not query SLS for component aliases: {err}') from err
         except ValueError as err:


### PR DESCRIPTION
## Summary and Scope

The `SLSStatusModule` used by `sat status` has only `Node` as its `component_types`, meaning information from SLS is only added for nodes. The query, however, obtains SLS data for all components known to SLS. Modify this query to use the `/search/hardware` endpoint of SLS with `type=comptype_node` as a query parameter to limit the results to only the node components.

## Issues and Related PRs

* Resolves CRAYSAT-1871

## Testing

### Tested on:

  * Local virtual environment against drax

### Test description:

Ran `sat status` from my macbook against drax with debug logging enabled to verify API requests made. Executed with multiple option combinations, including:

* `--types Node`
* `--types NodeBMC`
* `--types Node NodeBMC`
* `--types all`
* Same as above but with addition of `--sls-fields` option

## Risks and Mitigations

This is pretty low-risk. The data format returned by the two SLS API endpoints is the same, and this just limits the amount of data returned by SLS to the data for node-type components.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
