### PR TITLE
CRAYSAT-1869: Addressing the value rounding bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.28.7] - 2024-06-26
+
+### Fixed
+- Improve info messages logged by `sat bootsys` in the `bos-operations` stage to
+  use more precision when displaying percent successful values in order to avoid
+  prematurely reporting that a BOS session is 100% complete when the actual
+  percentage is between 99 and 100%.
+
 ## [3.28.6] - 2024-06-10
 
 ### Fixed

--- a/sat/cli/bootsys/bos.py
+++ b/sat/cli/bootsys/bos.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -255,10 +255,16 @@ class BOSV2SessionWaiter(Waiter):
                 # Only log progress update when components succeed or fail
                 self.pct_successful = float(self.session_status['percent_successful'])
                 self.pct_failed = float(self.session_status['percent_failed'])
-                LOGGER.info(
-                    'Session %s: %.0f%% components succeeded, %.0f%% components failed',
-                    self.bos_session_thread.session_id, self.pct_successful, self.pct_failed
-                )
+                if 99 < self.pct_successful < 100:
+                    LOGGER.info(
+                        'Session %s: %.6f%% components succeeded, %.2f%% components failed',
+                        self.bos_session_thread.session_id, self.pct_successful, self.pct_failed
+                    )
+                else:
+                    LOGGER.info(
+                        'Session %s: %.2f%% components succeeded, %.2f%% components failed',
+                        self.bos_session_thread.session_id, self.pct_successful, self.pct_failed
+                    )
 
             if self.session_status['status'] in self.target_states:
                 if not self.session_status.get('managed_components_count'):
@@ -651,7 +657,7 @@ def do_parallel_bos_operations(session_templates, operation, timeout, limit=None
 
         if thread.bos_session_status:
             LOGGER.info(
-                'Session %s: %.0f%% components succeeded, %.0f%% components failed',
+                'Session %s: %.2f%% components succeeded, %.2f%% components failed',
                 thread.session_id,
                 thread.bos_session_status['percent_successful'],
                 thread.bos_session_status['percent_failed']


### PR DESCRIPTION
IM:CRAYSAT-1869
Reviewer:Ryan

## Summary and Scope
There is a rounding error when SAT reports status on percentage done. It rounds up to 100% when the actual number reported by BOS is something like 99.9475. For anything other than 100%, most people would not care. But 100% means it is all done, so why would SAT still be waiting for it to go over 100%

Hence, Updating the rounding to 2 decimal places instead of no decimal places and then not rounding if the value above 99 to address the bug and showing upto 10 decimal places.

The same case is added part of the unit test for the class.


## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CRAYSAT-1869](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1869)


## Testing

_List the environments in which these changes were tested._

### Tested on:

Would need a large system to validate this changes. hence a unittest case has been added to validate the scenario.
### Test description:

Will have to power off and power on the nodes to verify using a BOS session template



## Risks and Mitigations

minimal

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

