### PR TITLE
CRAYSAT-1866, CRAYSAT-1871: Backport `sat status` fixes to release/3.21 for CSM 1.4 and SAT 2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed issue where `sat status` made unnecessary queries to BOS, CFS, and SLS
   APIs when types other than `Node` were specified.
+- Fixed issue in `sat status` to limit SLS query to only node-type components,
+  which is the only component type where SLS data is used.
 
 ## [3.21.11] - 2024-06-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.21.12] - 2024-07-03
+
+### Fixed
+- Fixed issue where `sat status` made unnecessary queries to BOS, CFS, and SLS
+  APIs when types other than `Node` were specified.
+
 ## [3.21.11] - 2024-06-11
 
 ### Fixed

--- a/sat/cli/status/main.py
+++ b/sat/cli/status/main.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2022, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -198,16 +198,17 @@ def do_status(args):
                 modules.append(module_cls)
             seen_module_names.add(module_name)
 
-    types = COMPONENT_TYPES if 'all' in args.types else args.types
+    # Safeguard against `args.types` being None even though the default value is ["Node"]
+    types = COMPONENT_TYPES if args.types is None or 'all' in args.types else args.types
     multiple_reports = len(types) != 1
     report_strings = []
 
     components = StatusModule.get_populated_rows(
         primary_key='xname',
-        primary_key_type=XName,
-        limit_modules=modules,
         session=session,
         component_types=types,
+        limit_modules=modules,
+        primary_key_type=XName,
     )
 
     for component_type, components_by_type in group_dicts_by('Type', components).items():

--- a/sat/cli/status/status_module.py
+++ b/sat/cli/status/status_module.py
@@ -410,7 +410,11 @@ class SLSStatusModule(StatusModule):
         sls_client = SLSClient(self.session)
 
         try:
-            sls_response = sls_client.get('hardware').json()
+            # Per SLSStatusModule.component_types, this module only applies to the Node type in
+            # HSM, for which the corresponding SLS type is comptype_node. In the future, if other
+            # types may have aliases that should be presented by `sat status`, this may need to be
+            # extended.
+            sls_response = sls_client.get('search', 'hardware', params={'type': 'comptype_node'}).json()
         except APIError as err:
             raise StatusModuleException(f'Could not query SLS for component aliases: {err}') from err
         except ValueError as err:

--- a/sat/cli/status/status_module.py
+++ b/sat/cli/status/status_module.py
@@ -189,12 +189,12 @@ class StatusModule(ABC):
         return True
 
     @classmethod
-    def get_relevant_modules(cls, component_type=None, limit_modules=None):
-        """Get a list of relevant modules for some component type.
+    def get_relevant_modules(cls, component_types, limit_modules=None):
+        """Get a list of relevant modules for some component type(s).
 
         Args:
-            component_type (None or str): if None, return all modules. If a str,
-                return modules relevant to the given component type.
+            component_types (list of str): return modules relevant to the
+                given list of component types.
             limit_modules (None or list): if None, return all modules relevant to the
                 given `component_type`. If a list, return a subset of the given
                 modules relevant to the given `component_type`.
@@ -204,15 +204,15 @@ class StatusModule(ABC):
         """
         modules = cls.modules() if limit_modules is None else limit_modules
 
-        if component_type is not None:
-            return [module for module in modules
-                    if module.can_use()[0] and
-                    (not module.component_types or component_type in module.component_types)]
-        return modules
+        return [module for module in modules
+                if module.can_use()[0] and
+                (not module.component_types or
+                 any(component_type in module.component_types
+                     for component_type in component_types))]
 
     @classmethod
     def get_all_headings(cls, primary_key, limit_modules=None, initial_headings=None, component_type=None):
-        """Get a list of headings applicable to the given modules and component types.
+        """Get a list of headings applicable to the given modules and component type.
 
         Headings from modules are filtered based on their `include_headings`
         method.
@@ -228,13 +228,14 @@ class StatusModule(ABC):
                 placed at the beginning of the list following the primary key.
                 Headings are not repeated.
             component_type (None or str): if None, return all headings from all
-                modules. If a list, return the subset of headings from modules
+                modules. If a str, return the subset of headings from modules
                 relevant to the given component type.
 
         Returns:
             [str]: the applicable headings
         """
-        modules = cls.get_relevant_modules(limit_modules=limit_modules, component_type=component_type)
+        modules = cls.get_relevant_modules(component_types=[component_type],
+                                           limit_modules=limit_modules)
         if not modules:
             return []
 
@@ -269,7 +270,8 @@ class StatusModule(ABC):
         return primaries.pop()
 
     @classmethod
-    def get_populated_rows(cls, *, primary_key, session, limit_modules=None, primary_key_type=str, **kwargs):
+    def get_populated_rows(cls, *, primary_key, session, component_types, limit_modules=None,
+                           primary_key_type=str, **kwargs):
         """Return a list of rows joining data from all defined modules.
 
         Additional keyword arguments are passed through to StatusModule
@@ -286,6 +288,7 @@ class StatusModule(ABC):
             primary_key_type (str -> Any): a callable (or type) which takes a string
                 and returns an object. The primary key of the populated rows
                 will have this type.
+            component_types (list of str): the list of component types to get data for
 
         Returns:
             [dict]: data from the status modules as described above,
@@ -294,13 +297,15 @@ class StatusModule(ABC):
         items_by_primary_key = defaultdict(dict)
         primary_module = cls.get_primary()
 
-        modules = cls.get_relevant_modules(limit_modules=limit_modules)
+        modules = cls.get_relevant_modules(component_types=component_types,
+                                           limit_modules=limit_modules)
         if primary_module not in modules:
             modules = [primary_module, *modules]
 
         for module in sorted(modules, key=cls._module_index):
             module_instance = module(session=session,
                                      primary_keys=items_by_primary_key.keys(),
+                                     component_types=component_types,
                                      **kwargs)
 
             try:


### PR DESCRIPTION
## Summary and Scope

Backport the following changes to release/3.21 for inclusion in CSM 1.4 and SAT 2.5.

* #221 
* #228 

## Issues and Related PRs

* Resolves CRAYSAT-1866
* Resolves CRAYSAT-1871

## Testing

See linked PRs above.

## Risks and Mitigations

See linked PRs above.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
