### PR TITLE
Craysat 1870 dependabot security updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.28.10] - 2024-07-04
+
+### Security
+- Update the version of requests from 2.31.0 to 2.32.2 to address CVE-2024-35195
+- Update the version of urllib3 from 1.26.18 to 1.26.19 to address CVE-2024-37891
+
 ## [3.28.9] - 2024-07-04
 
 ### Security

--- a/requirements-dev.lock.txt
+++ b/requirements-dev.lock.txt
@@ -50,7 +50,7 @@ pyrsistent==0.18.1
 python-dateutil==2.8.2
 pytz==2021.3
 PyYAML==6.0.1
-requests==2.31.0
+requests==2.32.2
 requests-oauthlib==1.3.1
 rsa==4.8
 s3transfer==0.5.2

--- a/requirements-dev.lock.txt
+++ b/requirements-dev.lock.txt
@@ -68,5 +68,5 @@ sseclient-py==1.7.2
 toml==0.10.0
 typing-inspect==0.7.1
 typing_extensions==4.1.1
-urllib3==1.26.18
+urllib3==1.26.19
 websocket-client==1.3.1

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -41,7 +41,7 @@ pyrsistent==0.18.1
 python-dateutil==2.8.2
 pytz==2021.3
 PyYAML==6.0.1
-requests==2.31.0
+requests==2.32.2
 requests-oauthlib==1.3.1
 rsa==4.8
 s3transfer==0.5.2

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -51,5 +51,5 @@ sseclient-py==1.7.2
 toml==0.10.0
 typing-inspect==0.7.1
 typing_extensions==4.1.1
-urllib3==1.26.18
+urllib3==1.26.19
 websocket-client==1.3.1


### PR DESCRIPTION
## Summary and Scope

_Combines https://github.com/Cray-HPE/sat/pull/233 and https://github.com/Cray-HPE/sat/pull/226 from dependabot into a single PR with a changelog update._

## Issues and Related PRs

_Resolves 2 dependabot alerts in [CRAYSAT-1870](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1870)._


## Testing

_List the environments in which these changes were tested._

### Tested on:

_Baldar_

### Test description:

_Basic testing of  `sat` commands which uses `requests` and `urllib`_


## Risks and Mitigations

_N/A_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable