### PR TITLE
CRAYSAT-1876: Backport cfs fixes to release/3.25 for CSM 1.5 and SAT 2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.25.14] - 2024-07-10
+
+### Fixed
+- Update the `_update_container_status` method of the
+  CFSImageConfigurationSession class in csm_api_client.service.cfs to handle
+  the case when either `init_container_statuses` or `container_statuses` or
+  both are None.
+
 ## [3.25.13] - 2024-07-03
 
 ### Fixed

--- a/requirements-dev.lock.txt
+++ b/requirements-dev.lock.txt
@@ -14,7 +14,7 @@ coverage==6.3.2
 cray-product-catalog==1.6.0
 croniter==0.3.37
 cryptography==42.0.4
-csm-api-client==1.1.5
+csm-api-client==1.2.2
 dataclasses-json==0.5.6
 docutils==0.17.1
 google-auth==2.6.0

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -11,7 +11,7 @@ click==8.0.4
 cray-product-catalog==1.6.0
 croniter==0.3.37
 cryptography==42.0.4
-csm-api-client==1.1.5
+csm-api-client==1.2.2
 dataclasses-json==0.5.6
 google-auth==2.6.0
 htmlmin==0.1.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ argcomplete
 boto3
 botocore
 cray-product-catalog >= 1.6.0
-csm-api-client >= 1.1.4, <2.0
+csm-api-client >= 1.2.2, <2.0
 croniter >= 0.3, < 1.0
 inflect >= 0.2.5, < 3.0
 Jinja2 >= 3.0, < 4.0


### PR DESCRIPTION
Update the _update_container_status method of the CFSImageConfigurationSession class in csm_api_client.service.cfs to handle the case when either init_container_statuses or container_statuses or both are None.

(cherry picked from commit dc5b6ae4bff1cbe7ac25df1ed30c188e03f2e517)

## Summary and Scope

_Backport the following changes to release/3.25 for inclusion in CSM 1.5 and SAT 2.6._

- https://github.com/Cray-HPE/sat/pull/205

## Issues and Related PRs

Resolves [CRAYSAT-1876](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1876)

## Testing

_List the environments in which these changes were tested._

### Tested on:

 Baldar

### Test description:

Sanity tested on baldar

## Risks and Mitigations

_Low_

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

