### PR TITLE
CRAYSAT-1581: Updating acceptable checks in ceph health validation stage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ncn power stage
 - If containers fail to stop, automate the procedure of trying to stop them again
   in the `platform-services` stage.
+- Adding PG_NOT_DEEP_SCRUBBED in allowable checks excluded during ceph health check as it is
+  ignorable. 
 
 ### Fixed
 - Updated `sat bootsys` to increase the default management NCN shutdown timeout

--- a/sat/cli/bootsys/ceph.py
+++ b/sat/cli/bootsys/ceph.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2021, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -151,7 +151,8 @@ def validate_ceph_warning_state(ceph_check_data, allow_osdmap_flags=True):
     Raises:
         CephHealthCheckError: if Ceph is not healthy.
     """
-    acceptable_checks = ['LARGE_OMAP_OBJECTS', 'TOO_FEW_PGS', 'POOL_NEAR_FULL', 'OSD_NEARFULL', 'OSDMAP_FLAGS']
+    acceptable_checks = ['LARGE_OMAP_OBJECTS', 'TOO_FEW_PGS', 'POOL_NEAR_FULL', 'OSD_NEARFULL', 'OSDMAP_FLAGS',
+                         'PG_NOT_DEEP_SCRUBBED']
     unacceptable_checks_found = [check for check in ceph_check_data if check not in acceptable_checks]
     if unacceptable_checks_found:
         raise CephHealthCheckError(

--- a/tests/cli/bootsys/test_ceph.py
+++ b/tests/cli/bootsys/test_ceph.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2021, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -193,7 +193,8 @@ class TestCheckCephHealth(ExtendedTestCase):
                 'status': 'HEALTH_WARN',
                 'checks': {
                     'LARGE_OMAP_OBJECTS': {},
-                    'TOO_FEW_PGS': {}
+                    'TOO_FEW_PGS': {},
+                    'PG_NOT_DEEP_SCRUBBED': {}
                 }
             }
         })
@@ -302,7 +303,8 @@ class TestCheckCephHealth(ExtendedTestCase):
         with self.assertLogs(level=logging.WARNING) as logs:
             check_ceph_health()
         self.ceph_health_command.assert_called_once_with(['ceph', '-s', '--format=json'])
-        self.assert_in_element('Ceph is healthy with warnings: LARGE_OMAP_OBJECTS,TOO_FEW_PGS', logs.output)
+        self.assert_in_element('Ceph is healthy with warnings: LARGE_OMAP_OBJECTS,TOO_FEW_PGS,'
+                               'PG_NOT_DEEP_SCRUBBED', logs.output)
 
     def test_ceph_warn_unhealthy(self):
         """Test check_ceph_health raises CephHealthCheckError when ceph is in an 'unacceptable' warning state."""


### PR DESCRIPTION
IM:CRAYSAT-1581
Reviewer:Ryan


## Summary and Scope

During the ceph health validation,in ncn-power stage.PG_NOT_DEEP_SCRUBBED check would be in health_warn status and that would abort the next steps following ceph health check as pgs not deep-scrubbed in time. Since it can be ignored, we are adding it to the acceptable checkswhich can be not considered while returning the ceph health.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CRAYSAT-1581](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1581)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Yet to be tested

### Test description:

Will have power on and power off the ncn's. To validate the changes and see how it behaves during the ceph health check.



## Risks and Mitigations

minimal


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

