### PR TITLE
CRAYSAT-1787: Adding ceph health check bypass in sat bootsys ncn-power

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ignorable. 
 - Automate the procedure of setting next boot device to disk before the management nodes are
   powered off as part of the full-system shutdown.
+- Adding a ceph health check bypass prompt to take input from user and act accordingly.
+  unfreezing of ceph would be done, only the wait period will be skipped if user wishes to.
 
 ### Fixed
 - Updated `sat bootsys` to increase the default management NCN shutdown timeout

--- a/sat/cli/bootsys/mgmt_power.py
+++ b/sat/cli/bootsys/mgmt_power.py
@@ -477,10 +477,19 @@ def do_power_on_ncns(args):
                     if ncn_group == included_ncn_groups['storage']:
                         try:
                             do_ceph_unfreeze(included_ncn_groups)
+                            LOGGER.info('Ceph unfreeze completed successfully on storage NCNs.')
+
                         except FatalPlatformError as err:
                             LOGGER.error(f'Failed to unfreeze Ceph on storage NCNs: {err}')
-                            sys.exit(1)
-                        LOGGER.info('Ceph unfreeze completed successfully on storage NCNs.')
+                            # Use pester_choices to prompt the user
+                            user_choice = pester_choices('Ceph is not healthy. Do you want to continue anyway?',
+                                                         ['yes', 'no'])
+                            if user_choice == 'no':
+                                LOGGER.info('Exiting as per user\'s decision.')
+                                sys.exit(1)
+                            else:
+                                LOGGER.info('Continuing despite Ceph not being healthy as per user\'s input, '
+                                            'make sure to verify it later.')
 
                         # Mount Ceph and S3FS filesystems on ncn-m001
                         try:


### PR DESCRIPTION
IM:CRAYSAT-1787
Reviewer:Ryan


## Summary and Scope

Adding ceph health check bypass prompt for the user to decide whether to wait or proceed with skipping the health check after unfreezing of ceph is done. As it may take some time and the next steps may not explicitly require, by the time it comes back it would be good to use.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CRAYSAT-1787](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1787)



## Testing

_List the environments in which these changes were tested._

### Tested on:

Tested on Rocket system

### Test description:

Will have to power off and power on the ncn's to verify how the unfreeze ceph and ceph health check bypass works during ncn-power stage of sat bootsys

## Risks and Mitigations

minimal

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

