### PR TITLE
CRAYSAT-1859: Improve BOS failure handling in `sat bootsys`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed a traceback that occurs during the `bos-operations` stage of `sat
   bootsys` if the BOS API fails to create a BOS session.
+- Fixed the prompt in the `bos-operations` stage of `sat bootsys shutdown` and
+  `sat bootsys reboot` to say "nodes" rather than "compute nodes and UANs",
+  which is not always accurate.
 
 ## [3.28.11] - 2024-07-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.28.12] - 2024-07-15
+
+### Fixed
+- Fixed a traceback that occurs during the `bos-operations` stage of `sat
+  bootsys` if the BOS API fails to create a BOS session.
+
 ## [3.28.11] - 2024-07-09
 
 ### Security

--- a/sat/cli/bootsys/bos.py
+++ b/sat/cli/bootsys/bos.py
@@ -888,7 +888,7 @@ def do_bos_shutdowns(args):
     Returns: None
     """
     if not (args.disruptive or args.staged_session):
-        prompt_continue('shutdown of compute nodes and UANs using BOS')
+        prompt_continue('shutdown of nodes using BOS')
 
     try:
         do_bos_operations('shutdown', get_config_value('bootsys.bos_shutdown_timeout'),
@@ -925,7 +925,7 @@ def do_bos_reboots(args: Namespace):
     Returns: None
     """
     if not (args.disruptive or args.staged_session):
-        prompt_continue('reboot of compute nodes and UANs using BOS')
+        prompt_continue('reboot of nodes using BOS')
 
     try:
         do_bos_operations(


### PR DESCRIPTION
## Summary and Scope

If `sat bootsys` fails to create a BOS session for a BOS session template, it will still attempt to check the status of a non-existent BOS session, which results in a `TypeError` traceback when attempting to get information about a BOS session with `None` as its ID.

## Issues and Related PRs

* Resolves CRAYSAT-1859

## Testing

### Tested on:

  * rocket

### Test description:

Tested on rocket by passing in a non-existent BOS session template to `sat bootsys boot --stage bos-operations`. Tested with and without this fix to see the difference. With this fix, a traceback no longer occurs.

Tested also with a valid BOS session template to ensure it still works as it should, waiting on the BOS session which is created.

See output in comments.

## Risks and Mitigations

This is a pretty low-risk change as it only affects whether we attempt to wait on failed BOS sessions and re-orders an info log message.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
