### PR TITLE
CRAYSAT-1878: Remove automatic cronjob recreation from `bootsys`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,11 +49,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - If containers fail to stop, automate the procedure of trying to stop them again
   in the `platform-services` stage.
 - Adding PG_NOT_DEEP_SCRUBBED in allowable checks excluded during ceph health check as it is
-  ignorable. 
+  ignorable.
 - Automate the procedure of setting next boot device to disk before the management nodes are
   powered off as part of the full-system shutdown.
 - Adding a ceph health check bypass prompt to take input from user and act accordingly.
   unfreezing of ceph would be done, only the wait period will be skipped if user wishes to.
+- Improved logic in `cabinet-power` stage of `sat bootsys boot` to more reliably
+  determine when the a Job has been scheduled for the `hms-discovery` Kubernetes
+  CronJob after it has been resumed.
+- Remove unreliable step from the `platform-services` stage of `sat bootsys
+  boot` that checked for Kubernetes CronJobs that were not being scheduled due
+  to missing too many start times. The problem this attempted to solve should no
+  longer occur with the CronJobControllerV2 being the default starting in
+  Kubernetes 1.21.
 
 ### Fixed
 - Updated `sat bootsys` to increase the default management NCN shutdown timeout

--- a/sat/cli/bootsys/cabinet_power.py
+++ b/sat/cli/bootsys/cabinet_power.py
@@ -69,7 +69,7 @@ def do_air_cooled_cabinets_power_off(args):
     node_xnames = list(set(river_nodes) - set(river_mgmt_nodes))
 
     if not node_xnames:
-        LOGGER.info(f'No non-management nodes in air-cooled cabinets to power off.')
+        LOGGER.info('No non-management nodes in air-cooled cabinets to power off.')
         return
 
     LOGGER.info(f'Powering off {len(node_xnames)} non-management nodes in air-cooled cabinets.')

--- a/sat/cli/bootsys/platform.py
+++ b/sat/cli/bootsys/platform.py
@@ -612,7 +612,6 @@ STEPS_BY_ACTION = {
         PlatformServicesStep('Ensure etcd is running and enabled on all Kubernetes manager NCNs.',
                              do_etcd_start),
         PlatformServicesStep('Start and enable kubelet on all Kubernetes NCNs.', do_kubelet_start),
-        PlatformServicesStep('Recreate cron jobs that have become stuck', do_recreate_cronjobs),
     ],
     # The ordered steps to stop platform services
     'stop': [

--- a/sat/cronjob.py
+++ b/sat/cronjob.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -95,6 +95,19 @@ def recreate_cronjob(batch_api, cronjob):
 
 def recreate_namespaced_stuck_cronjobs(batch_api, namespace):
     """Find cronjobs that are not being scheduled and recreate them.
+
+    This should no longer be necessary since Kubernetes 1.21.0, which made
+    the new CronJobControllerV2 the default. We retain this function in case
+    it is still necessary to check for cronjobs that need to be re-created
+    due to unforeseen circumstances.
+
+    The CronJobControllerV2 handles CronJobs that have missed too many start
+    times differently than the CronJobController. When a CronJob missed too
+    many start times under the original CronJobController, it would issue a
+    "FailedNeedsStart" warning event and then not schedule a job for the
+    CronJob. On the other hand, the CronJobControllerV2 issues a
+    "TooManyMissedTimes" warning event and then does still schedule a Job for
+    the CronJob.
 
     Args:
         batch_api (kubernetes.client.BatchV1Api): the Kubernetes API client


### PR DESCRIPTION
## Summary and Scope

Remove the step that automatically checks for and re-creates stuck
Kubernetes CronJobs from the `platform-services` stage of `sat bootsys
boot`. This should not be necessary anymore starting in Kubernetes 1.21,
which made a new CronJobControllerV2 the default.

In addition, improve the logic of the HMSDiscoveryScheduledWaiter, so
that it will more reliably detect when an `hms-discovery` Job has been
scheduled for the CronJob. Pass in an explicit `start_time`, so that we
can look for any jobs created for the CronJob after it is re-enabled.
This ensures we won't miss the first one, which could be scheduled
between when we set `suspend=False` on the CronJob and when we create
the `HMSDiscoveryScheduledWaiter`.

## Issues and Related PRs

* Resolves CRAYSAT-1878

## Testing

### Tested on:

  * rocket

### Test description:

Tested on rocket as follows:

* Suspended the `hms-discovery` CronJob
* Ran `sat bootsys boot --stage cabinet-power`
* Verified that it correctly identified when the CronJob was scheduled

## Risks and Mitigations

Should be pretty low-risk. This removes functionality that has caused more problems than it solved. It can always be executed manually as documented, if needed.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
