### PR TITLE
CRAYSAT-1865: Recreate SDU collection link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Kubernetes 1.21.
 - Changed the missing host key policy used with Paramiko in sat bootsys to the AutoAddPolicy to 
   reduce warning messages displayed to the user.
+- Automate the steps to recreate the /var/opt/cray/sdu/collection symbolic link to point at
+  the collection-mount location where the fuse.s3fs filesystem is mounted.
 
 ### Fixed
 - Updated `sat bootsys` to increase the default management NCN shutdown timeout


### PR DESCRIPTION
## Summary and Scope

_Automate the steps to recreate the /var/opt/cray/sdu/collection symbolic link to point at the collection-mount location where the fuse.s3fs filesystem is mounted._

_Restarting cray-sdu-rda is one of the way to fix the symbolic link when it points at the local directory, collection-local, instead of the s3fs mount, collection-mount on ncn-m001_

## Issues and Related PRs

_[CRAYSAT-1865](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1865)_

## Testing

_List the environments in which these changes were tested._

### Tested on:

  Rocket

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

Tested whether /var/opt/cray/sdu/collection symbolic link point at the collection-mount location where the fuse.s3fs filesystem is mounted
Tested for different scenario where I manually unmounted `fuse.s3fs` and stopped `cray-sdu-rda` service as per the requirement for testing and executed `sat bootsys boot --stage ncn-power --ncn-boot-timeout 900` which should mount collection-mount and points the collection link to collection-mount

## Risks and Mitigations

_Risk is low as we just `try-restart` the `cray-sdu-rda` service where collection points to collection-mount when service is actively running_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

