### PR TITLE
CRAYSAT-1860:Handling sat bootsys stage platform-services paramiko SSH warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to missing too many start times. The problem this attempted to solve should no
   longer occur with the CronJobControllerV2 being the default starting in
   Kubernetes 1.21.
+- Changed the missing host key policy used with Paramiko in sat bootsys to the AutoAddPolicy to 
+  reduce warning messages displayed to the user.
 
 ### Fixed
 - Updated `sat bootsys` to increase the default management NCN shutdown timeout

--- a/sat/cli/bootsys/util.py
+++ b/sat/cli/bootsys/util.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2021, 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2021, 2023-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -30,7 +30,7 @@ import re
 from collections import defaultdict
 
 import yaml
-from paramiko import SSHClient, WarningPolicy
+from paramiko import SSHClient, AutoAddPolicy
 
 from sat.util import pester_choices
 
@@ -226,6 +226,6 @@ def get_ssh_client(host_keys=None):
     if host_keys is not None:
         ssh_client._system_host_keys = host_keys
     ssh_client.load_system_host_keys()
-    ssh_client.set_missing_host_key_policy(WarningPolicy)
+    ssh_client.set_missing_host_key_policy(AutoAddPolicy)
 
     return ssh_client

--- a/tests/cli/bootsys/test_util.py
+++ b/tests/cli/bootsys/test_util.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2021, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -356,10 +356,10 @@ class TestGetSSHClient(unittest.TestCase):
     """Tests for get_ssh_client function."""
 
     def setUp(self):
-        """Set up mocks of paramiko SSHClient and WarningPolicy."""
+        """Set up mocks of paramiko SSHClient and AutoAddPolicy."""
         self.mock_ssh_client_cls = patch('sat.cli.bootsys.util.SSHClient').start()
         self.mock_ssh_client = self.mock_ssh_client_cls.return_value
-        self.mock_warning_policy = patch('sat.cli.bootsys.util.WarningPolicy').start()
+        self.mock_auto_add_policy = patch('sat.cli.bootsys.util.AutoAddPolicy').start()
 
     def tearDown(self):
         patch.stopall()
@@ -371,5 +371,5 @@ class TestGetSSHClient(unittest.TestCase):
         self.mock_ssh_client_cls.assert_called_once_with()
         self.mock_ssh_client.load_system_host_keys.assert_called_once_with()
         self.mock_ssh_client.set_missing_host_key_policy.assert_called_once_with(
-            self.mock_warning_policy
+            self.mock_auto_add_policy
         )


### PR DESCRIPTION
IM:CRAYSAT-1860
Reviewer:Ryan

## Summary and Scope

Change the missing host key policy used with Paramiko in sat bootsys to the AutoAddPolicy to reduce warning messages displayed to the user.It will silence the warnings and auto-add every key it encounters for a host it doesn't have a known hosts entry for yet.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CRAYSAT-1860](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1860)

## Testing

_List the environments in which these changes were tested._

### Tested on:

 Yet to be tested

### Test description:


## Risks and Mitigations

minimal


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

