### PR TITLE
CRAYSAT-1890: Fix `sat.waiting` logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.29.1] - 2024-08-02
+
+### Fixed
+- Fixed a logging issue with messages logged by the `waiting` module used in
+  `sat bootsys` and other commands, so that log messages emitted by this module
+  are correctly handled and formatted.
+
 ## [3.29.0] - 2024-08-01
 
 ### Changed

--- a/sat/waiting.py
+++ b/sat/waiting.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2022, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -34,7 +34,7 @@ import inflect
 
 
 inf = inflect.engine()
-LOGGER = logging.getLogger(__file__)
+LOGGER = logging.getLogger(__name__)
 
 
 class WaitingFailure(Exception):


### PR DESCRIPTION
## Summary and Scope

The `LOGGER` was incorrectly created with `__file__` as the logger name instead of `__name__`. As a result, it was not included under the `sat` package logger's hierarchy, and the expected log handlers were not applied to messages logged by this module. Fix this by specifying `__name__` instead, so the logger has the name `sat.waiting`, which is under the `sat` logger.

## Issues and Related PRs

* Resolves CRAYSAT-1890

## Testing

### Tested on:

  * rocket

### Test description:

Ran `sat bootsys shutdown --stage capture-state` followed by `sat
bootsys boot --stage k8s-check --k8s-timeout 10` to force a
`Waiter` subclass to timeout, so I could observe the error log message.
As expected, it timed out waiting on new pods that were created by K8s
Jobs to reach a running or completed state, and it emitted the correctly
formatted log message of the form:

```
ERROR: Waiting for condition "..." timed out after 10 seconds
```

## Risks and Mitigations

Very low risk logging fix.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable