### PR TITLE
CRAYSAT-1392: Graceful handle of user token expiry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.30.1] - 2024-08-13
+
+### Fixed
+-  When the token used to access the API gateway is expired, log a helpful error
+  message instructing the user to reauthenticate with `sat auth` and then exit
+  instead of printing a traceback and exiting.
+
 ## [3.30.0] - 2024-08-09
 
 ### Changed

--- a/sat/main.py
+++ b/sat/main.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -32,6 +32,7 @@ import sys
 
 import argcomplete
 
+from oauthlib.oauth2 import InvalidGrantError
 from sat.config import ConfigFileExistsError, DEFAULT_CONFIG_PATH, generate_default_config, load_config
 from sat.warnings import configure_insecure_request_warnings
 from sat.logging import bootstrap_logging, configure_logging
@@ -119,7 +120,11 @@ def main():
                          args.command, args.command)
             sys.exit(1)
 
-        subcommand(args)
+        try:
+            subcommand(args)
+        except InvalidGrantError:
+            LOGGER.error("The token is not active or is invalid. "
+                         "Please re-authenticate using 'sat auth' to obtain a new token")
 
     except KeyboardInterrupt:
         LOGGER.info("Received keyboard interrupt; quitting.", exc_info=True)


### PR DESCRIPTION
## Summary and Scope

During the sat status execution if the user token is expired, there is a traceback which comes as the output. Hence graceful handling of the token expiry is added to inform the user.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CRAYSAT-1392](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1392)


## Testing

_List the environments in which these changes were tested._

### Tested on:

  * rocket
  

### Test description:

Manually the expiry date was updated in ~/.config/sat/tokens/api_gw_service_nmn_local.vers.json to replicate the issue.
And then the sat commands such as sat status, hwinv, hwmatch were executed to validate the changes

## Risks and Mitigations

Low risk

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

