### PR TITLE
CRAYSAT-1330: Specify image name directly in CFS session when possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.30.0] - 2024-08-09
+
+### Changed
+- Update to a new version of the `csm-api-client` that allows querying the CFS
+  version from the CFS API.
+- Update to version 3.0.2 of the `semver` package. The only breaking change
+  appears to be related to supported Python versions, but it should not affect
+  SAT.
+
 ## [3.29.2] - 2024-08-06
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [3.30.0] - 2024-08-09
 
 ### Changed
+- When customizing images with `sat bootprep`, pass the desired image name
+  directly to CFS when creating the image customization session, if supported by
+  the version of CFS on the system. This improves the performance and
+  reliability of `sat bootprep`.
 - Update to a new version of the `csm-api-client` that allows querying the CFS
   version from the CFS API.
 - Update to version 3.0.2 of the `semver` package. The only breaking change

--- a/requirements-dev.lock.txt
+++ b/requirements-dev.lock.txt
@@ -14,7 +14,7 @@ coverage==6.3.2
 cray-product-catalog==1.6.0
 croniter==0.3.37
 cryptography==42.0.4
-csm-api-client==1.2.4
+csm-api-client==2.0.0
 dataclasses-json==0.5.6
 docutils==0.17.1
 google-auth==2.6.0
@@ -54,7 +54,7 @@ requests==2.32.2
 requests-oauthlib==1.3.1
 rsa==4.8
 s3transfer==0.5.2
-semver==2.13.0
+semver==3.0.2
 six==1.16.0
 snowballstemmer==2.2.0
 Sphinx==2.4.5

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -11,7 +11,7 @@ click==8.0.4
 cray-product-catalog==1.6.0
 croniter==0.3.37
 cryptography==42.0.4
-csm-api-client==1.2.4
+csm-api-client==2.0.0
 dataclasses-json==0.5.6
 google-auth==2.6.0
 htmlmin==0.1.12
@@ -45,7 +45,7 @@ requests==2.32.2
 requests-oauthlib==1.3.1
 rsa==4.8
 s3transfer==0.5.2
-semver==2.13.0
+semver==3.0.2
 six==1.16.0
 sseclient-py==1.7.2
 toml==0.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ argcomplete
 boto3
 botocore
 cray-product-catalog >= 1.6.0
-csm-api-client >= 1.2.4, <2.0
+csm-api-client >= 2.0.0, <3.0
 croniter >= 0.3, < 1.0
 inflect >= 0.2.5, < 3.0
 Jinja2 >= 3.0, < 4.0
@@ -36,7 +36,7 @@ python-dateutil >= 2.7.3, < 3.0
 pyyaml >= 6.0.1, < 7.0
 requests < 3.0
 requests-oauthlib
-semver >= 2.13.0, < 3.0
+semver >= 3.0.2, < 4.0
 sseclient-py >= 1.7
 toml == 0.10.0
 urllib3 >= 1.26.5, < 2.0


### PR DESCRIPTION
## Summary and Scope
* CRAYSAT-1330: Specify image name directly in CFS session when possible

  When possible, specify the desired resulting image name directly when
  creating the CFS session instead of requiring a costly and failure-prone
  image rename operation after the CFS configuration has been completed.

  This greatly improves the reliability and performance of `sat bootprep`
  for image customization.

  Test Description:
  Not tested yet.

* CRAYSAT-1330: Update to version 2.0.0 of csm-api-client

  Version 2.0.0 of `csm-api-client` introduces the ability to specify the
  name of images when images are customized in CFS.

## Issues and Related PRs

* Resolves CRAYSAT-1330
* Requires merge of Cray-HPE/python-csm-api-client#30

## Testing

### Tested on:

  * rocket

### Test description:

Created a build of the sat container image and tested as follows:

Created a bootprep file that builds and customizes an image from the CSM barebones image. Also tested the same thing but with it building the image from recipe first.

Verified that the CFS session specified the destination image name, and that SAT didn't have to rename the image. Verified that the image existed afterwards.

## Risks and Mitigations

This has the same risks as mentioned in Cray-HPE/python-csm-api-client#30

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
- [x] Remove commit that uses unstable builds of csm-api-client when stable build is published