### PR TITLE
CRAYSAT-1888: Boot Kubernetes master and worker nodes simultaneously

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.29.2] - 2024-08-06
+
+### Changed
+- Modify `sat bootsys boot --stage ncn-power` to boot the master nodes (other than `ncn-m001`)
+  and the worker nodes at the same time.
+
 ## [3.29.1] - 2024-08-02
 
 ### Fixed

--- a/sat/cli/bootsys/mgmt_power.py
+++ b/sat/cli/bootsys/mgmt_power.py
@@ -444,7 +444,7 @@ def do_power_on_ncns(args):
         LOGGER.error(f'Not proceeding with NCN power on: {err}')
         raise SystemExit(1)
 
-    ordered_boot_groups = [included_ncn_groups[role] for role in ('storage', 'managers', 'workers')]
+    ordered_boot_groups = [included_ncn_groups['storage'], included_ncn_groups['kubernetes']]
     # flatten lists of ncn groups
     affected_ncns = list({ncn for sublist in ordered_boot_groups for ncn in sublist})
 


### PR DESCRIPTION
## Summary and Scope

_Backport cray-sat 3.29.1 through 3.29.2_

## Issues and Related PRs

* [CRAYSAT-1888](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1888): https://github.com/Cray-HPE/sat/pull/251

## Testing

_List the environments in which these changes were tested._

### Tested on:

  Rocket

### Test description:

_See the linked PR_

## Risks and Mitigations

_See the linked PR_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

