### PR TITLE
CRAYSAT-1706: To stop waiting if BOS session is deleted 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.30.2] - 2024-08-14
+
+### Fixed
+- Log an error message and stop waiting on BOS sessions that have been deleted
+  in the `bos-operations` stage of `sat bootsys`.
+
 ## [3.30.1] - 2024-08-13
 
 ### Fixed

--- a/sat/apiclient/bos.py
+++ b/sat/apiclient/bos.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -144,29 +144,6 @@ class BOSClientCommon(APIGatewayClient):
             # TODO (CRAYSAT-898): update default hostname for authoritative DNS changes
             'rootfs_provider_passthrough': 'dvs:api-gw-service-nmn.local:300:nmn0'
         }
-
-    def get_session_status(self, session_id):
-        """Get the status of a BOS session.
-
-        Args:
-            session_id (str): the ID of the session
-
-        Returns:
-            dict: the session status information from BOS
-
-        Raises:
-            APIError: if there is a problem retrieving session status BOS, or if
-                the returned JSON is invalid.
-        """
-        try:
-            return self.get(self.session_path, session_id, 'status').json()
-        except APIError as err:
-            raise APIError(f'Failed to get BOS session status for session {session_id}: '
-                           f'{err}')
-        except ValueError as err:
-            raise APIError(f'Failed to parse JSON in response from BOS when '
-                           f'getting session status for session {session_id}: '
-                           f'{err}')
 
     def get_session(self, session_id):
         """Get information about a given session.


### PR DESCRIPTION
## Summary and Scope

_Backport cray-sat 3.30.1 through 3.30.2_

## Issues and Related PRs

* Resolves [CRAYSAT-1706](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1706): https://github.com/Cray-HPE/sat/pull/255

## Testing

_List the environments in which these changes were tested._

### Tested on:

  #drax

### Test description:

_See the linked PR_

## Risks and Mitigations

_See the linked PR_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

