### PR TITLE
CRAYSAT-1884: Updating cray-product-catalog & csm-api-client to latest versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.31.0] - 2024-08-21
+
+### Fixed 
+- Updating the cray-product-catalog & python-csm-api-client to latest versions.
+
 ## [3.30.2] - 2024-08-14
 
 ### Fixed

--- a/requirements-dev.lock.txt
+++ b/requirements-dev.lock.txt
@@ -11,10 +11,10 @@ cffi==1.15.0
 charset-normalizer==2.0.12
 click==8.0.4
 coverage==6.3.2
-cray-product-catalog==1.6.0
+cray-product-catalog==2.3.1
 croniter==0.3.37
 cryptography==42.0.4
-csm-api-client==2.0.0
+csm-api-client==2.1.0
 dataclasses-json==0.5.6
 docutils==0.17.1
 google-auth==2.6.0

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -8,10 +8,10 @@ certifi==2024.7.4
 cffi==1.15.0
 charset-normalizer==2.0.12
 click==8.0.4
-cray-product-catalog==1.6.0
+cray-product-catalog==2.3.1
 croniter==0.3.37
 cryptography==42.0.4
-csm-api-client==2.0.0
+csm-api-client==2.1.0
 dataclasses-json==0.5.6
 google-auth==2.6.0
 htmlmin==0.1.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,8 +21,8 @@
 argcomplete
 boto3
 botocore
-cray-product-catalog >= 1.6.0
-csm-api-client >= 2.0.0, <3.0
+cray-product-catalog >= 2.3.1
+csm-api-client >= 2.1.0, <3.0
 croniter >= 0.3, < 1.0
 inflect >= 0.2.5, < 3.0
 Jinja2 >= 3.0, < 4.0


### PR DESCRIPTION
## Summary and Scope

Updating cray-product-catalog & csm-api-client to latest versions

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CRAYSAT-1884](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1884)


## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Rocket,Gamora,Surtur

### Test description:

Test the below SAT utilities
sat showrev --products
sat bootprep
cfs-config-util

## Risks and Mitigations

Minimal

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

