### PR TITLE
CRAYSAT-1893: Make default BOS timeouts infinite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.31.1] - 2024-09-02
+
+### Changed
+- Changed `sat bootsys` to enable default timeouts to infinite for BOS boot, shutdown, and reboot.
+
 ## [3.31.0] - 2024-08-21
 
 ### Fixed 

--- a/docs/man/sat-bootsys.8.rst
+++ b/docs/man/sat-bootsys.8.rst
@@ -7,7 +7,7 @@ Perform boot, shutdown, or reboot actions on the system
 -------------------------------------------------------
 
 :Author: Hewlett Packard Enterprise Development LP.
-:Copyright: Copyright 2020-2023 Hewlett Packard Enterprise Development LP.
+:Copyright: Copyright 2020-2024 Hewlett Packard Enterprise Development LP.
 :Manual section: 8
 
 SYNOPSIS
@@ -243,7 +243,7 @@ These options set the timeouts of various parts of the stages of the
 **--bos-shutdown-timeout** *BOS_SHUTDOWN_TIMEOUT*
         Timeout, in seconds, to wait until compute and
         application nodes have completed their BOS shutdown.
-        Defaults to 600. Overrides the option
+        No default timeout is set. It is infinite. Overrides the option
         bootsys.bos_shutdown_timeout in the config file.
 
 **--ncn-shutdown-timeout** *NCN_SHUTDOWN_TIMEOUT*
@@ -297,7 +297,7 @@ These options set the timeouts of various parts of the stages of the
 **--bos-boot-timeout** *BOS_BOOT_TIMEOUT*
         Timeout, in seconds, to wait until compute and
         application nodes have completed their BOS boot.
-        Defaults to 900. Overrides the option
+        No default timeout is set. It is infinite. Overrides the option
         bootsys.bos_boot_timeout in the config file.
 
 REBOOT TIMEOUT OPTIONS
@@ -309,7 +309,7 @@ These options set the timeouts of various parts of the stages of the
 **--bos-shutdown-timeout** *BOS_SHUTDOWN_TIMEOUT*
         Timeout, in seconds, to wait until compute and
         application nodes have completed their BOS shutdown.
-        Defaults to 600. Overrides the option
+        No default timeout is set. It is infinite. Overrides the option
         bootsys.bos_shutdown_timeout in the config file.
 
         For a reboot, the --bos-shutdown-timeout and
@@ -318,7 +318,7 @@ These options set the timeouts of various parts of the stages of the
 **--bos-boot-timeout** *BOS_BOOT_TIMEOUT*
         Timeout, in seconds, to wait until compute and
         application nodes have completed their BOS boot.
-        Defaults to 900. Overrides the option
+        No default timeout is set. It is infinite. Overrides the option
         bootsys.bos_boot_timeout in the config file.
 
         For a reboot, the --bos-shutdown-timeout and

--- a/sat/cli/bootsys/parser.py
+++ b/sat/cli/bootsys/parser.py
@@ -51,9 +51,9 @@ TIMEOUT_SPECS = [
                 'BGP routes report that they are established on management switches.'),
     TimeoutSpec('hsn', ['boot'], 300,
                 'the high-speed network (HSN) has returned to its pre-shutdown state.'),
-    TimeoutSpec('bos-shutdown', ['shutdown', 'reboot'], 600,
+    TimeoutSpec('bos-shutdown', ['shutdown', 'reboot'], -1,
                 'compute and application nodes have completed their BOS shutdown.'),
-    TimeoutSpec('bos-boot', ['boot', 'reboot'], 900,
+    TimeoutSpec('bos-boot', ['boot', 'reboot'], -1,
                 'compute and application nodes have completed their BOS boot.'),
     TimeoutSpec('ncn-shutdown', ['shutdown'], 900,
                 'management NCNs have completed a graceful shutdown and have reached '

--- a/sat/config.py
+++ b/sat/config.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -30,6 +30,7 @@ import getpass
 import logging
 import os
 from textwrap import dedent, indent
+import math
 
 import toml
 
@@ -342,13 +343,18 @@ def get_config_value(query_string):
     if len(parts) != EXPECTED_LEVELS:
         raise ValueError("Wrong number of levels in query string passed to get_config_value(). "
                          "(Should be {}, was {}.)".format(EXPECTED_LEVELS, len(parts)))
-    else:
-        section, option = parts
-        if not section or not option:
-            raise ValueError("Improperly formatted query string supplied to get_config_value(). "
-                             "(Got '{}'.)".format(query_string))
-        else:
-            return CONFIG.get(section, option)
+
+    section, option = parts
+    if not section or not option:
+        raise ValueError("Improperly formatted query string supplied to get_config_value(). "
+                         "(Got '{}'.)".format(query_string))
+
+    value = CONFIG.get(section, option)
+
+    if option.lower() == 'timeout' and value == '-1':
+        return math.inf
+
+    return value
 
 
 def read_config_value_file(query_string):


### PR DESCRIPTION
## Summary and Scope

_Changed `sat bootsys` to enable default timeouts to infinite for BOS boot, shutdown, and reboot._
_Updated the man page appropriately_

## Issues and Related PRs

_Resolves [CRAYSAT-1893](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1893)._

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * drax

### Test description:

_Will test by doing shutdown, boot and reboot of `bos-operations` stage with and without timeout options_

## Risks and Mitigations

_Minimal_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

