### PR TITLE
CRAYSAT-1841: Update `sat status` to support CFS v2 or v3

### DIFF
--- a/requirements-dev.lock.txt
+++ b/requirements-dev.lock.txt
@@ -14,7 +14,7 @@ coverage==6.3.2
 cray-product-catalog==2.3.1
 croniter==0.3.37
 cryptography==42.0.4
-csm-api-client==2.1.0
+csm-api-client==2.2.1
 dataclasses-json==0.5.6
 docutils==0.17.1
 google-auth==2.6.0

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -11,7 +11,7 @@ click==8.0.4
 cray-product-catalog==2.3.1
 croniter==0.3.37
 cryptography==42.0.4
-csm-api-client==2.1.0
+csm-api-client==2.2.1
 dataclasses-json==0.5.6
 google-auth==2.6.0
 htmlmin==0.1.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ argcomplete
 boto3
 botocore
 cray-product-catalog >= 2.3.1
-csm-api-client >= 2.1.0, <3.0
+csm-api-client >= 2.2.1, <3.0
 croniter >= 0.3, < 1.0
 inflect >= 0.2.5, < 3.0
 Jinja2 >= 3.0, < 4.0

--- a/sat/cli/status/parser.py
+++ b/sat/cli/status/parser.py
@@ -97,3 +97,9 @@ def add_status_subparser(subparsers):
         choices=['v1', 'v2'],
         help='The version of the BOS API to use for BOS operations',
     )
+
+    status_parser.add_argument(
+        '--cfs-version',
+        choices=['v2', 'v3'],
+        help='The version of the CFS API to use for CFS operations',
+    )

--- a/sat/cli/status/status_module.py
+++ b/sat/cli/status/status_module.py
@@ -30,7 +30,7 @@ from collections import defaultdict
 import logging
 from urllib.parse import urlparse
 
-from csm_api_client.service.cfs import CFSClient
+from csm_api_client.service.cfs import CFSClientBase
 from csm_api_client.service.gateway import APIError
 from csm_api_client.service.hsm import HSMClient
 
@@ -448,9 +448,13 @@ class CFSStatusModule(StatusModule):
 
     @property
     def rows(self):
-        cfs_client = CFSClient(self.session)
+        cfs_version = get_config_value('cfs.api_version')
+        cfs_client = CFSClientBase.get_cfs_client(self.session, cfs_version)
         try:
-            cfs_response = cfs_client.get('components').json()
+            cfs_response = cfs_client.get_components()
+            for response in cfs_response:
+                yield response
+
         except APIError as err:
             raise StatusModuleException(f'Failed to query CFS for component information: {err}') from err
         except ValueError as err:

--- a/sat/config.py
+++ b/sat/config.py
@@ -95,6 +95,26 @@ def validate_bos_api_version(version):
         )
 
 
+def validate_cfs_api_version(version):
+    """Validates the given CFS API version string
+
+    Args:
+        version (str): the CFS API version string to validate
+
+    Returns:
+        None
+
+    Raises:
+        ConfigValidationError: if `version` is not a valid CFS API version string
+    """
+    valid_cfs_api_versions = {'v2', 'v3'}
+    if not version.lower() in valid_cfs_api_versions:
+        raise ConfigValidationError(
+            f'CFS API Version "{version}" is not one of the valid '
+            f'CFS API versions: {", ".join(valid_cfs_api_versions)}'
+        )
+
+
 SAT_CONFIG_SPEC = {
     'api_gateway': {
         'host': OptionSpec(str, 'api-gw-service-nmn.local', None, None),
@@ -106,6 +126,9 @@ SAT_CONFIG_SPEC = {
     },
     'bos': {
         'api_version': OptionSpec(str, 'v2', validate_bos_api_version, 'bos_version')
+    },
+    'cfs': {
+        'api_version': OptionSpec(str, 'v3', validate_cfs_api_version, 'cfs_version')
     },
     'bootsys': {
         'max_hsn_states': OptionSpec(int, 10, None, None),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2022, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -45,6 +45,7 @@ from sat.config import (
     load_config,
     read_config_value_file,
     validate_bos_api_version,
+    validate_cfs_api_version,
     validate_log_level
 )
 from tests.common import ExtendedTestCase
@@ -84,6 +85,21 @@ class TestValidateBosApiVersion(unittest.TestCase):
             with self.subTest(version=version):
                 with self.assertRaises(ConfigValidationError):
                     validate_bos_api_version(version)
+
+
+class TestValidateCfsApiVersion(unittest.TestCase):
+    """Tests for validate_cfs_api_version function"""
+
+    def test_validate_cfs_api_version_v2(self):
+        """Test that "v2" is a valid CFS API version"""
+        validate_cfs_api_version('v2')
+
+    def test_validate_invalid_cfs_api_version(self):
+        """Test that invalid CFS versions are not allowed"""
+        for version in ['v5', 'foo', '', '1', '2']:
+            with self.subTest(version=version):
+                with self.assertRaises(ConfigValidationError):
+                    validate_cfs_api_version(version)
 
 
 class TestOptionValue(unittest.TestCase):


### PR DESCRIPTION
## Summary and Scope

_Update sat to use the new version of `csm-api-client` implemented in [CRAYSAT-1840](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1840)_

- _Update the `sat status` to support both cfs v2 and v3_

## Issues and Related PRs

_Resolves [CRAYSAT-1841](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1841)._

## Testing

_List the environments in which these changes were tested._

### Tested on:

YTT

### Test description:

_Test the `sat status` with cfs v2 and v3 and without cfs field to test the default._
_Possibly will try to change the page size and test cfs v3_


## Risks and Mitigations

_Risks might be depend on cfs v3 introduction_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

