### PR TITLE
CRAYSAT-1902: Update `sat bootprep` with new changes of cfs v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.32.1] - 2024-09-17
+
+### Changed
+- Changed `sat bootprep` and `sat bootsys` to use the CFS.V2 updated classes from `csm-api-client`
+
 ## [3.32.0] - 2024-09-11
 
 ### Added

--- a/sat/apiclient/__init__.py
+++ b/sat/apiclient/__init__.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -26,7 +26,7 @@ Client for querying the API gateway.
 """
 # Import these names so that they can still be imported from the apiclient package directly
 
-from csm_api_client.service.cfs import CFSClient
+from csm_api_client.service.cfs import CFSClientBase
 from csm_api_client.service.gateway import APIError, APIGatewayClient, ReadTimeout
 from csm_api_client.service.hsm import HSMClient
 

--- a/sat/cli/bootprep/image.py
+++ b/sat/cli/bootprep/image.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -330,7 +330,7 @@ def validate_image_configurations(input_images, cfs_client, input_config_names, 
     Args:
         input_images (list of sat.cli.bootprep.input.image.InputImage): the
             IMSImages which should have their configurations validated.
-        cfs_client (csm_api_client.service.cfs.CFSClient): the CFS client to query to
+        cfs_client (csm_api_client.service.cfs.CFSClientBase): the CFS client to query to
             determine whether the configuration for the image exists.
         input_config_names (list of str): the list of configuration names that
             are defined in the input file
@@ -423,7 +423,7 @@ def validate_images(instance, args, cfs_client):
             against the schema.
         args: The argparse.Namespace object containing the parsed arguments
             passed to the bootprep subcommand.
-        cfs_client (csm_api_client.service.cfs.CFSClient): the CFS API client to make
+        cfs_client (csm_api_client.service.cfs.CFSClientBase): the CFS API client to make
             requests to the CFS API
 
     Returns: None

--- a/sat/cli/bootprep/input/configuration.py
+++ b/sat/cli/bootprep/input/configuration.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -371,7 +371,7 @@ class InputConfiguration(BaseInputItem):
             index (int): the index of the item in the collection in the instance
             jinja_env (jinja2.Environment): the Jinja2 environment in which
                 fields supporting Jinja2 templating should be rendered.
-            cfs_client (csm_api_client.service.cfs.CFSClient): the CFS API client
+            cfs_client (csm_api_client.service.cfs.CFSClientBase): the CFS API client
             product_catalog (cray_product_catalog.query.ProductCatalog):
                 the product catalog object
             **kwargs: additional keyword arguments
@@ -466,7 +466,7 @@ class InputConfigurationCollection(BaseInputItemCollection):
                 fields supporting Jinja2 templating should be rendered.
             request_dumper (sat.cli.bootprep.output.RequestDumper): the dumper
                 for dumping request data to files.
-            cfs_client (csm_api_client.service.cfs.CFSClient): the CFS API client
+            cfs_client (csm_api_client.service.cfs.CFSClientBase): the CFS API client
             **kwargs: additional keyword arguments
         """
         super().__init__(items_data, instance, jinja_env, request_dumper,

--- a/sat/cli/bootprep/input/image.py
+++ b/sat/cli/bootprep/input/image.py
@@ -55,7 +55,7 @@ class BaseInputImage(DependencyGroupMember, ABC):
         image_data (dict): the data for an image from the bootprep input file
         ims_client (sat.apiclient.IMSClient): the IMSClient to make requests to
             the IMS API
-        cfs_client (csm_api_client.service.cfs.CFSClient): the CFSClient to make requests to
+        cfs_client (csm_api_client.service.cfs.CFSClientBase): the CFSClient to make requests to
             the CFS API
         public_key_id (str): the id of the public key in IMS to use when
             building the image
@@ -94,7 +94,7 @@ class BaseInputImage(DependencyGroupMember, ABC):
                 the product catalog object
             ims_client (sat.apiclient.IMSClient): the IMS API client to make
                 requests to the IMS API
-            cfs_client (csm_api_client.service.cfs.CFSClient): the CFS API client to make
+            cfs_client (csm_api_client.service.cfs.CFSClientBase): the CFS API client to make
                 requests to the CFS API
         """
         super().__init__()

--- a/sat/cli/bootprep/input/instance.py
+++ b/sat/cli/bootprep/input/instance.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -45,7 +45,7 @@ class InputInstance:
                 the instance has already been validated against the schema.
             request_dumper (sat.cli.bootprep.output.RequestDumper): the dumper
                 for dumping request data to files.
-            cfs_client (csm_api_client.service.cfs.CFSClient): the CFS API client to make
+            cfs_client (csm_api_client.service.cfs.CFSClientBase): the CFS API client to make
                 requests to the CFS API
             ims_client (sat.apiclient.IMSClient): the IMS API client to make
                 requests to the IMS API

--- a/sat/cli/bootprep/input/session_template.py
+++ b/sat/cli/bootprep/input/session_template.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -52,7 +52,7 @@ class InputSessionTemplate(BaseInputItem):
             requests to the BOS API
         ims_client (sat.apiclient.IMSClient): the IMS API client to make
             requests to the IMS API
-        cfs_client (csm_api_client.service.cfs.CFSClient): the CFS API client to make
+        cfs_client (csm_api_client.service.cfs.CFSClientBase): the CFS API client to make
             requests to the CFS API
     """
     description = 'BOS session template'
@@ -70,7 +70,7 @@ class InputSessionTemplate(BaseInputItem):
             jinja_env (jinja2.Environment): the Jinja2 environment in which
                 fields supporting Jinja2 templating should be rendered.
             bos_client (sat.apiclient.BOSClientCommon): the BOS API client
-            cfs_client (csm_api_client.service.cfs.CFSClient): the CFS API client
+            cfs_client (csm_api_client.service.cfs.CFSClientBase): the CFS API client
             ims_client (sat.apiclient.IMSClient): the IMS API client
             **kwargs: additional keyword arguments
         """
@@ -398,7 +398,7 @@ class InputSessionTemplateCollection(BaseInputItemCollection):
             request_dumper (sat.cli.bootprep.output.RequestDumper): the dumper
                 for dumping request data to files.
             bos_client (sat.apiclient.BOSClientCommon): the BOS API client
-            cfs_client (csm_api_client.service.cfs.CFSClient): the CFS API client
+            cfs_client (csm_api_client.service.cfs.CFSClientBase): the CFS API client
             ims_client (sat.apiclient.IMSClient): the IMS API client
             **kwargs: additional keyword arguments
         """

--- a/sat/cli/bootprep/main.py
+++ b/sat/cli/bootprep/main.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -32,7 +32,7 @@ import inflect
 from jinja2.sandbox import SandboxedEnvironment
 import yaml
 
-from sat.apiclient import CFSClient, IMSClient
+from sat.apiclient import CFSClientBase, IMSClient
 from sat.apiclient.bos import BOSClientCommon
 from sat.cli.bootprep.errors import (
     BootPrepDocsError,
@@ -210,7 +210,7 @@ def do_bootprep_run(schema_validator, args):
     LOGGER.info('Input file successfully validated against schema')
 
     session = SATSession()
-    cfs_client = CFSClient(session)
+    cfs_client = CFSClientBase.get_cfs_client(session, 'v2')
     ims_client = IMSClient(session)
     # CASMTRIAGE-4288: IMS can be extremely slow to return DELETE requests for
     # large images, so this IMSClient will not use a timeout on HTTP requests

--- a/sat/cli/bootsys/service_activity.py
+++ b/sat/cli/bootsys/service_activity.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -38,7 +38,7 @@ from paramiko.ssh_exception import SSHException
 
 from sat.apiclient import (
     APIError,
-    CFSClient,
+    CFSClientBase,
     NMDClient
 )
 from sat.apiclient.bos import BOSClientCommon
@@ -383,7 +383,7 @@ class CFSActivityChecker(ServiceActivityChecker):
         Raises:
             ServiceCheckError: if unable to get the active CFS sessions.
         """
-        cfs_client = CFSClient(SATSession())
+        cfs_client = CFSClientBase.get_cfs_client(SATSession(), 'v2')
         try:
             sessions = cfs_client.get('sessions').json()
         except (APIError, ValueError) as err:

--- a/tests/cli/bootprep/input/test_configuration.py
+++ b/tests/cli/bootprep/input/test_configuration.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -34,7 +34,7 @@ from cray_product_catalog.query import ProductCatalogError
 from csm_api_client.service.vcs import VCSError
 from jinja2.sandbox import SandboxedEnvironment
 
-from csm_api_client.service.cfs import CFSClient
+from csm_api_client.service.cfs import CFSClientBase
 from sat.cli.bootprep.errors import InputItemCreateError
 from sat.cli.bootprep.input.configuration import (
     AdditionalInventory,
@@ -617,7 +617,7 @@ class TestInputConfiguration(unittest.TestCase):
         self.mock_instance = Mock(spec=InputInstance)
         # Fake index of configuration data in an input file
         self.index = 0
-        self.mock_cfs_client = Mock(spep=CFSClient)
+        self.mock_cfs_client = Mock(spep=CFSClientBase)
 
     def tearDown(self):
         patch.stopall()

--- a/tests/cli/bootprep/input/test_image.py
+++ b/tests/cli/bootprep/input/test_image.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -26,7 +26,7 @@ import unittest
 from unittest.mock import Mock, patch
 
 from cray_product_catalog.query import InstalledProductVersion, ProductCatalog
-from csm_api_client.service.cfs import CFSClient
+from csm_api_client.service.cfs import CFSClientBase
 from jinja2 import Environment
 
 from sat.apiclient.ims import IMSClient
@@ -64,7 +64,7 @@ class TestProductInputImage(unittest.TestCase):
 
         self.jinja_env = Environment()
         self.jinja_env.globals = {self.product_name: {'version': self.product_version}}
-        self.mock_cfs_client = Mock(spec=CFSClient)
+        self.mock_cfs_client = Mock(spec=CFSClientBase)
         self.mock_ims_client = Mock(spec=IMSClient)
 
         # The IMS resources should have the same info as in the product catalog entries

--- a/tests/cli/bootprep/test_main.py
+++ b/tests/cli/bootprep/test_main.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -131,7 +131,7 @@ class TestDoBootprepRun(unittest.TestCase):
         self.mock_input_instance_cls = patch('sat.cli.bootprep.main.InputInstance').start()
         self.mock_input_instance = self.mock_input_instance_cls.return_value
         self.mock_sat_session = patch('sat.cli.bootprep.main.SATSession').start()
-        self.mock_cfs_client = patch('sat.cli.bootprep.main.CFSClient').start().return_value
+        self.mock_cfs_client = patch('sat.cli.bootprep.main.CFSClientBase.get_cfs_client').start().return_value
         self.mock_ims_client = patch('sat.cli.bootprep.main.IMSClient').start().return_value
         self.mock_bos_client = patch('sat.cli.bootprep.main.BOSClientCommon.get_bos_client').start().return_value
         self.mock_configurations = self.mock_input_instance.input_configurations

--- a/tests/cli/bootsys/test_service_activity.py
+++ b/tests/cli/bootsys/test_service_activity.py
@@ -508,7 +508,7 @@ class TestCFSActivityChecker(unittest.TestCase):
 
         patch('sat.cli.bootsys.service_activity.SATSession').start()
         self.mock_cfs_client = patch(
-            'sat.cli.bootsys.service_activity.CFSClient').start()
+            'sat.cli.bootsys.service_activity.CFSClientBase.get_cfs_client').start()
         self.mock_cfs_client.return_value.get = mock_cfs_get
 
     def tearDown(self):


### PR DESCRIPTION
## Summary and Scope

_Update `sat bootprep` and `sat bootsys` to use cfs v2 and should not break any changes._


## Issues and Related PRs

- Resolves [CRAYSAT-1902](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1902)

## Testing

### Tested on:

  drax

### Test description:

_Test with `sat bootprep` where the CFS configurations get created and can validate `session_checks` for service_acitivity of `sat bootsys`._


## Risks and Mitigations

_Minimal_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

