### PR TITLE
CASMTRIAGE-1900: Add jinja render to rootfs_provider_passthrough to support iSCSI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.32.4] - 2024-09-27
+
+### Added
+- Add jinja rendering of rootfs_provider_passthrough value for the boot_set to create session 
+  template with iSCSI values.
+
 ## [3.32.3] - 2024-09-27
 
 ### Added

--- a/sat/cli/bootprep/input/base.py
+++ b/sat/cli/bootprep/input/base.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -241,6 +241,11 @@ class BaseInputItem(Validatable, ABC):
         # The 'name' property is required by the schema for all types of input
         # items that inherit from BaseInputItem.
         return self.data['name']
+
+    @property
+    def boot_set(self):
+        """Return the full boot_sets dictionary."""
+        return self.data.get('bos_parameters', {}).get('boot_sets', {})
 
     def __str__(self):
         # Since the name can be rendered, and when unrendered, it does not need

--- a/sat/cli/bootprep/input/session_template.py
+++ b/sat/cli/bootprep/input/session_template.py
@@ -186,6 +186,12 @@ class InputSessionTemplate(BaseInputItem):
             boot_set_api_data.update(boot_set_data)
             api_data['boot_sets'][boot_set_name] = boot_set_api_data
 
+            # Fetch full boot sets
+            boot_sets = self.boot_set
+            # Render the rootfs_provider_passthrough using Jinja2
+            rendered_rootfs = self.jinja_env.from_string(
+                        boot_sets[boot_set_name]['rootfs_provider_passthrough']).render(self.data)
+            api_data['boot_sets'][boot_set_name]['rootfs_provider_passthrough'] = rendered_rootfs
         return api_data
 
     def get_image_record_by_id(self, ims_image_id):

--- a/tests/cli/bootprep/input/test_session_template.py
+++ b/tests/cli/bootprep/input/test_session_template.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -92,10 +92,12 @@ class TestInputSessionTemplateV2(unittest.TestCase):
         bos_payload_bootsets = {}
         for boot_set_name, boot_set_arch in arch_by_bootset.items():
             input_bootsets[boot_set_name] = {
-                'node_roles_groups': ['Compute']
+                'node_roles_groups': ['Compute'],
+                'rootfs_provider_passthrough': "dvs:api-gw-service-nmn.local:300:hsn0,nmn0:0"
             }
             bos_payload_bootsets[boot_set_name] = {
                 'node_roles_groups': ['Compute'],
+                'rootfs_provider_passthrough': "dvs:api-gw-service-nmn.local:300:hsn0,nmn0:0",
                 'path': self.mock_path,
                 'etag': self.mock_etag,
                 'type': self.mock_image_type


### PR DESCRIPTION
Reviewer: Annapoorna

## Summary and Scope

In order to suport iSCSI in CSM 1.6. jinja rendering of the rootfs_provider_passthrough value is necessary. Hence the functionality to render the value has been added. 
For both UAN & Compute support has been added for the input yaml to be handled.

## Issues and Related PRs

* Resolves [CRAYSAT-1900](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1900)


## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `<Gamora>`


### Test description:

The modified input yaml file consisting of both iSCSI and DVS was considered for testing sat bootprep to create the session templates. It successfully was able to create all the type of templates.


## Risks and Mitigations

minimal

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

