### PR TITLE
CASMTRIAGE-7272: update-cfs-config and prepare-images stage is failing after hanging during CSM only upgrade using IUF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.32.2] - 2024-09-27
+
+### Fixed
+- Fixed for IUF stuck during `update-cfs-config` and `prepare-images` stage while
+  executing `git ls-remote` fetching the credentials.
+
 ## [3.32.1] - 2024-09-17
 
 ### Changed

--- a/requirements-dev.lock.txt
+++ b/requirements-dev.lock.txt
@@ -14,7 +14,7 @@ coverage==6.3.2
 cray-product-catalog==2.3.1
 croniter==0.3.37
 cryptography==42.0.4
-csm-api-client==2.2.1
+csm-api-client==2.2.2
 dataclasses-json==0.5.6
 docutils==0.17.1
 google-auth==2.6.0

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -11,7 +11,7 @@ click==8.0.4
 cray-product-catalog==2.3.1
 croniter==0.3.37
 cryptography==42.0.4
-csm-api-client==2.2.1
+csm-api-client==2.2.2
 dataclasses-json==0.5.6
 google-auth==2.6.0
 htmlmin==0.1.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ argcomplete
 boto3
 botocore
 cray-product-catalog >= 2.3.1
-csm-api-client >= 2.2.1, <3.0
+csm-api-client >= 2.2.2, <3.0
 croniter >= 0.3, < 1.0
 inflect >= 0.2.5, < 3.0
 Jinja2 >= 3.0, < 4.0


### PR DESCRIPTION
## Summary and Scope

_update-cfs-config and prepare-images stage is failing after hanging during CSM only upgrade using IUF_
_It hangs up when its executing the command "git ls-remote https://crayvcs@api-gw-service-nmn.local/vcs/cray/uss-config-management.git "_
_Tried fetching the credentials from container if present else kubernetes which doesn't get hungs up for long time_

## Issues and Related PRs

_Resolves [CASMTRIAGE-7272](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7272)_
- Fix from csm-api-client: https://github.com/Cray-HPE/python-csm-api-client/pull/40

## Testing

_List the environments in which these changes were tested._

### Tested on:

  fanta

### Test description:

_Tested with IUF which is working without hangs up_

## Risks and Mitigations

_Minimal_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

