### PR TITLE
Backport sat-container to 3.32.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.32.2] - 2024-09-27
+
+### Fixed
+- Fixed for IUF stuck during `update-cfs-config` and `prepare-images` stage while
+  executing `git ls-remote` fetching the credentials.
+
 ## [3.32.1] - 2024-09-17
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.32.3] - 2024-09-27
+
+### Added
+- Update man-page of `sat status`, `sat bootprep`, `sat bootsys` after introduction of
+  CFS V2-V3.
+
+### Security
+- Update the version of cryptography from 42.0.4 to 43.0.1 to resolve
+  CVE-2024-6119
+
 ## [3.32.2] - 2024-09-27
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.32.4] - 2024-09-27
+
+### Added
+- Add jinja rendering of rootfs_provider_passthrough value for the boot_set to create session 
+  template with iSCSI values.
+
 ## [3.32.3] - 2024-09-27
 
 ### Added

--- a/docs/man/sat-bootprep.8.rst
+++ b/docs/man/sat-bootprep.8.rst
@@ -7,7 +7,7 @@ Prepare to boot nodes with images and configurations
 ----------------------------------------------------
 
 :Author: Hewlett Packard Enterprise Development LP.
-:Copyright: Copyright 2021-2023 Hewlett Packard Enterprise Development LP.
+:Copyright: Copyright 2021-2024 Hewlett Packard Enterprise Development LP.
 :Manual section: 8
 
 SYNOPSIS
@@ -18,7 +18,7 @@ SYNOPSIS
 DESCRIPTION
 ===========
 
-The bootprep command creates CFS configurations, builds IMS images, customizes
+The bootprep command creates CFS configurations(currently supported only cfs/v2), builds IMS images, customizes
 IMS images with CFS configurations, and creates BOS session templates which can
 then be used to boot nodes in the system, such as compute and application nodes.
 

--- a/docs/man/sat-bootsys.8.rst
+++ b/docs/man/sat-bootsys.8.rst
@@ -36,7 +36,7 @@ file.
 
 In the ``session-checks`` stage, it checks for any active sessions across
 multiple different services in the system, including the Boot Orchestration
-Service (BOS), the Configuration Framework Service (CFS), the Compute Rolling
+Service (BOS), the Configuration Framework Service (CFS)(currently supported only cfs/v2), the Compute Rolling
 Upgrade Service (CRUS), the Firmware Action Service (FAS), the Node Memory Dump
 (NMD) service, and the System Dump Utility (SDU). If any active sessions are
 found, it will print information about those sessions and exit with exit code 1.

--- a/docs/man/sat-status.8.rst
+++ b/docs/man/sat-status.8.rst
@@ -7,7 +7,7 @@ Show node status
 ----------------
 
 :Author: Hewlett Packard Enterprise Development LP.
-:Copyright: Copyright 2019-2022 Hewlett Packard Enterprise Development LP.
+:Copyright: Copyright 2019-2022, 2024 Hewlett Packard Enterprise Development LP.
 :Manual section: 8
 
 SYNOPSIS
@@ -81,6 +81,10 @@ These options must be specified after the subcommand.
 **--bos-version BOS_VERSION**
         The version of the BOS API to use when looking up BOS template boot
         sets or querying BOS boot status.
+
+**--cfs-version CFS_VERSION**
+        The version of the CFS API to use when querying CFS configuration status
+        and desired configuration for all the components in the system.
 
 .. include:: _sat-format-opts.rst
 .. include:: _sat-filter-opts.rst

--- a/requirements-dev.lock.txt
+++ b/requirements-dev.lock.txt
@@ -14,7 +14,7 @@ coverage==6.3.2
 cray-product-catalog==2.3.1
 croniter==0.3.37
 cryptography==42.0.4
-csm-api-client==2.2.1
+csm-api-client==2.2.2
 dataclasses-json==0.5.6
 docutils==0.17.1
 google-auth==2.6.0

--- a/requirements-dev.lock.txt
+++ b/requirements-dev.lock.txt
@@ -13,7 +13,7 @@ click==8.0.4
 coverage==6.3.2
 cray-product-catalog==2.3.1
 croniter==0.3.37
-cryptography==42.0.4
+cryptography==43.0.1
 csm-api-client==2.2.2
 dataclasses-json==0.5.6
 docutils==0.17.1

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -11,7 +11,7 @@ click==8.0.4
 cray-product-catalog==2.3.1
 croniter==0.3.37
 cryptography==42.0.4
-csm-api-client==2.2.1
+csm-api-client==2.2.2
 dataclasses-json==0.5.6
 google-auth==2.6.0
 htmlmin==0.1.12

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -10,7 +10,7 @@ charset-normalizer==2.0.12
 click==8.0.4
 cray-product-catalog==2.3.1
 croniter==0.3.37
-cryptography==42.0.4
+cryptography==43.0.1
 csm-api-client==2.2.2
 dataclasses-json==0.5.6
 google-auth==2.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ argcomplete
 boto3
 botocore
 cray-product-catalog >= 2.3.1
-csm-api-client >= 2.2.1, <3.0
+csm-api-client >= 2.2.2, <3.0
 croniter >= 0.3, < 1.0
 inflect >= 0.2.5, < 3.0
 Jinja2 >= 3.0, < 4.0

--- a/sat/cli/bootprep/input/base.py
+++ b/sat/cli/bootprep/input/base.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -241,6 +241,11 @@ class BaseInputItem(Validatable, ABC):
         # The 'name' property is required by the schema for all types of input
         # items that inherit from BaseInputItem.
         return self.data['name']
+
+    @property
+    def boot_set(self):
+        """Return the full boot_sets dictionary."""
+        return self.data.get('bos_parameters', {}).get('boot_sets', {})
 
     def __str__(self):
         # Since the name can be rendered, and when unrendered, it does not need

--- a/sat/cli/bootprep/input/session_template.py
+++ b/sat/cli/bootprep/input/session_template.py
@@ -186,6 +186,12 @@ class InputSessionTemplate(BaseInputItem):
             boot_set_api_data.update(boot_set_data)
             api_data['boot_sets'][boot_set_name] = boot_set_api_data
 
+            # Fetch full boot sets
+            boot_sets = self.boot_set
+            # Render the rootfs_provider_passthrough using Jinja2
+            rendered_rootfs = self.jinja_env.from_string(
+                        boot_sets[boot_set_name]['rootfs_provider_passthrough']).render(self.data)
+            api_data['boot_sets'][boot_set_name]['rootfs_provider_passthrough'] = rendered_rootfs
         return api_data
 
     def get_image_record_by_id(self, ims_image_id):

--- a/tests/cli/bootprep/input/test_session_template.py
+++ b/tests/cli/bootprep/input/test_session_template.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -92,10 +92,12 @@ class TestInputSessionTemplateV2(unittest.TestCase):
         bos_payload_bootsets = {}
         for boot_set_name, boot_set_arch in arch_by_bootset.items():
             input_bootsets[boot_set_name] = {
-                'node_roles_groups': ['Compute']
+                'node_roles_groups': ['Compute'],
+                'rootfs_provider_passthrough': "dvs:api-gw-service-nmn.local:300:hsn0,nmn0:0"
             }
             bos_payload_bootsets[boot_set_name] = {
                 'node_roles_groups': ['Compute'],
+                'rootfs_provider_passthrough': "dvs:api-gw-service-nmn.local:300:hsn0,nmn0:0",
                 'path': self.mock_path,
                 'etag': self.mock_etag,
                 'type': self.mock_image_type


### PR DESCRIPTION
## Summary and Scope

_Backport the sat container to 3.32.4_

## Issues and Related PRs

_This backports the following fixes._

1. [CASMTRIAGE-7272](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7272):
-  https://github.com/Cray-HPE/python-csm-api-client/pull/40
-  https://github.com/Cray-HPE/sat/pull/267

2. [CRAYSAT-1843](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1843), [CRAYSAT-1899](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1899): 
- https://github.com/Cray-HPE/sat/pull/268

3. [CRAYSAT-1900](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1900): https://github.com/Cray-HPE/sat/pull/265


## Testing

_See the linked PRS._

## Risks and Mitigations

_See the linked PRs_

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

