### PR TITLE
CRAYSAT-1849: Update Python k8s version to the latest one supported in CSM 1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.32.5] - 2024-10-03
+
+### Added
+- Update the Python kubernetes version to the latest one supported in CSM 1.6
+
 ## [3.32.4] - 2024-09-27
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/requirements-dev.lock.txt
+++ b/requirements-dev.lock.txt
@@ -14,7 +14,7 @@ coverage==6.3.2
 cray-product-catalog==2.3.1
 croniter==0.3.37
 cryptography==43.0.1
-csm-api-client==2.2.2
+csm-api-client==2.2.3
 dataclasses-json==0.5.6
 docutils==0.17.1
 google-auth==2.6.0
@@ -26,7 +26,7 @@ Jinja2==3.1.4
 jmespath==0.10.0
 json-schema-for-humans==0.40
 jsonschema==4.4.0
-kubernetes==22.6.0
+kubernetes==24.2.0
 markdown2==2.4.2
 MarkupSafe==2.1.0
 marshmallow==3.14.1

--- a/requirements-dev.lock.txt
+++ b/requirements-dev.lock.txt
@@ -14,7 +14,7 @@ coverage==6.3.2
 cray-product-catalog==2.3.1
 croniter==0.3.37
 cryptography==43.0.1
-csm-api-client==2.2.3
+csm-api-client==2.2.2
 dataclasses-json==0.5.6
 docutils==0.17.1
 google-auth==2.6.0

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -11,7 +11,7 @@ click==8.0.4
 cray-product-catalog==2.3.1
 croniter==0.3.37
 cryptography==43.0.1
-csm-api-client==2.2.3
+csm-api-client==2.2.2
 dataclasses-json==0.5.6
 google-auth==2.6.0
 htmlmin==0.1.12

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -11,7 +11,7 @@ click==8.0.4
 cray-product-catalog==2.3.1
 croniter==0.3.37
 cryptography==43.0.1
-csm-api-client==2.2.2
+csm-api-client==2.2.3
 dataclasses-json==0.5.6
 google-auth==2.6.0
 htmlmin==0.1.12
@@ -21,7 +21,7 @@ Jinja2==3.1.4
 jmespath==0.10.0
 json-schema-for-humans==0.40
 jsonschema==4.4.0
-kubernetes==22.6.0
+kubernetes==24.2.0
 markdown2==2.4.2
 MarkupSafe==2.1.0
 marshmallow==3.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,13 +22,13 @@ argcomplete
 boto3
 botocore
 cray-product-catalog >= 2.3.1
-csm-api-client >= 2.2.2, <3.0
+csm-api-client >= 2.2.3, <3.0
 croniter >= 0.3, < 1.0
 inflect >= 0.2.5, < 3.0
 Jinja2 >= 3.0, < 4.0
 json-schema-for-humans
 jsonschema >= 4.0, < 5.0
-kubernetes >= 22.0, < 23.0
+kubernetes >= 24.0, < 25.0
 paramiko >= 2.11.0
 parsec == 3.5.0
 prettytable >= 0.7.2, < 1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ argcomplete
 boto3
 botocore
 cray-product-catalog >= 2.3.1
-csm-api-client >= 2.2.3, <3.0
+csm-api-client >= 2.2.2, <3.0
 croniter >= 0.3, < 1.0
 inflect >= 0.2.5, < 3.0
 Jinja2 >= 3.0, < 4.0


### PR DESCRIPTION
## Summary and Scope

_Update the version of the Python kubernetes client package which compatible to the version of Kubernetes running in CSM 1.6_
_Also update the version of csm-api-client, which has been updated along with the kubernetes version_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CRAYSAT-1849](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1849)
* Merge after https://github.com/Cray-HPE/python-csm-api-client/pull/42

## Testing

_List the environments in which these changes were tested._

### Tested on:

  starlord

### Test description:

_Built the container image, downloaded to odin, and ran the
CoreV1Api.list_node method in a Python interpreter in the sat bash
shell._


## Risks and Mitigations

_This should be low risk. It is aligning the version of the kubernetes Python package with the version of the Kubernetes cluster in CSM 1.6._


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

