### PR TITLE
CRAYSAT-1920: Backport `sat bmccreds` improvements to SAT 2.6/CSM 1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.25.15] - 2024-10-09
+
+### Changed
+- Remove the restrictions on the passwords that can be set with `sat bmccreds`
+  to allow for more complex passwords.
+- Improve the password generation logic in `sat bmccreds` to support generating
+  more complex passwords.
+
 ## [3.25.14] - 2024-07-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,13 +25,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.25.15] - 2024-10-09
+## [3.25.15] - 2024-10-10
 
 ### Changed
 - Remove the restrictions on the passwords that can be set with `sat bmccreds`
   to allow for more complex passwords.
 - Improve the password generation logic in `sat bmccreds` to support generating
   more complex passwords.
+
+### Added
+- Updated the man page to include description of the new options implemented
+  for `sat bmccreds`.
 
 ## [3.25.14] - 2024-07-10
 

--- a/docs/man/sat-bmccreds.8.rst
+++ b/docs/man/sat-bmccreds.8.rst
@@ -7,7 +7,7 @@ Set BMC passwords
 -----------------
 
 :Author: Hewlett Packard Enterprise Development LP.
-:Copyright: Copyright 2021 Hewlett Packard Enterprise Development LP.
+:Copyright: Copyright 2021, 2024 Hewlett Packard Enterprise Development LP.
 :Manual section: 8
 
 SYNOPSIS
@@ -21,20 +21,15 @@ DESCRIPTION
 The bmccreds subcommand sets BMC Redfish access passwords to user-defined or
 randomly generated values.
 
-When providing a user-defined password, the bmccreds subcommand will check
-the password against the following criteria:
-
-- The password is a maximum of 8 characters (this is due to BMC manufacturer
-  limitations).
-- The password consists only of letters, numbers and underscores (this is due
-  to BMC manufacturer limitations).
-
 When generating random passwords, the bmccreds subcommand can set components
 within the same chassis, cabinet or entire system to the same randomly-generated
 password, or it can use a different password for each component. This grouping
-is controlled using the ``--pw-domain`` argument. Randomly-generated
-passwords are 8-character strings made up of uppercase letters, lowercase
-letters, numbers and underscores.
+is controlled using the ``--pw-domain`` argument.
+
+The length of generated passwords and the characters allowed in generated
+passwords can be controlled with the options ``--password-length``,
+``--password-char-sets``, and ``--password-chars``. See below for a full
+description of those options.
 
 It is possible to provide xnames to set the password for specific BMCs, or
 to provide BMC types (e.g. NodeBMC, RouterBMC, ChassisBMC) to act on all BMCs
@@ -57,7 +52,24 @@ OPTIONS
     password. Not valid with **--random-password**.
 
 **--random-password**
-    Generate random BMC password(s). Not valid with **--password**.
+    Generate random BMC password(s). If this option is not specified and
+    **--password** is not given, then the user will be prompted to enter a
+    password.  Not valid with **--password**.
+
+**--password-length**
+    The desired length of the random BMC password. Only valid with
+    **--random-password**.
+
+**--password-char-sets**
+    A comma-separated list of allowed character sets to be used in a randomly
+    generated password. Only valid with **--random-password**.
+    Character sets are as follows: "alpha" includes all uppercase and lowercase
+    ASCII letters, "numeric" includes digits 0-9, and "symbols" includes the symbols
+    "!@#$%^&*".
+
+**--password-chars**
+    Specify explicit list of characters to generate random passwords. Only
+    valid with **--random-password**.
 
 **--pw-domain** *DOMAIN*
     Specify the domain or 'reach' of the password. Only valid with
@@ -166,6 +178,76 @@ Set every BMC password to the same randomly generated value:
   | x3000c0s26b3 | NodeBMC   | Random, domain: system | 200         | OK             |
   | x3000c0s28b2 | NodeBMC   | Random, domain: system | 200         | OK             |
   | x3000c0s15b0 | NodeBMC   | Random, domain: system | 200         | OK             |
+  ...
+
+
+Set every BMC password to the same randomly generated value of desired length:
+
+::
+
+  # sat bmccreds --random-password --password-length 20
+  +--------------+-----------+------------------------+-------------+----------------+
+  | xname        | Type      | Password Type          | Status Code | Status Message |
+  +--------------+-----------+------------------------+-------------+----------------+
+  | x3000c0s4b0  | NodeBMC   | Random, domain: system | 200         | OK             |
+  | x3000c0s18b0 | NodeBMC   | Random, domain: system | 200         | OK             |
+  | x3000c0s17b0 | NodeBMC   | Random, domain: system | 200         | OK             |
+  ...
+
+
+Set every BMC password to the same randomly generated value of desired char-sets:
+
+::
+
+  # sat bmccreds --random-password --password-char-sets alpha
+  +--------------+-----------+------------------------+-------------+----------------+
+  | xname        | Type      | Password Type          | Status Code | Status Message |
+  +--------------+-----------+------------------------+-------------+----------------+
+  | x3000c0s23b0 | NodeBMC   | Random, domain: system | 200         | OK             |
+  | x3000c0s29b0 | NodeBMC   | Random, domain: system | 200         | OK             |
+  | x3000c0s10b0 | NodeBMC   | Random, domain: system | 200         | OK             |
+  ...
+
+
+Set every BMC password to the same randomly generated value of desired length and char-sets:
+
+::
+
+  # sat bmccreds --random-password --password-length 10 --password-char-sets alpha,numeric,symbols
+  +--------------+-----------+------------------------+-------------+----------------+
+  | xname        | Type      | Password Type          | Status Code | Status Message |
+  +--------------+-----------+------------------------+-------------+----------------+
+  | x3000c0s27b0 | NodeBMC   | Random, domain: system | 200         | OK             |
+  | x3000c0s5b0  | NodeBMC   | Random, domain: system | 200         | OK             |
+  | x3000c0s9b0  | NodeBMC   | Random, domain: system | 200         | OK             |
+  ...
+
+
+Set every BMC password to the same randomly generated value with explicit characters:
+
+::
+
+  # sat bmccreds --random-password --password-chars 'abcd12134!@#'
+  +--------------+-----------+------------------------+-------------+----------------+
+  | xname        | Type      | Password Type          | Status Code | Status Message |
+  +--------------+-----------+------------------------+-------------+----------------+
+  | x3000c0s5b0  | NodeBMC   | Random, domain: system | 200         | OK             |
+  | x3000c0s24b0 | NodeBMC   | Random, domain: system | 200         | OK             |
+  | x3000c0s2b0  | NodeBMC   | Random, domain: system | 200         | OK             |
+  ...
+
+
+Set every BMC password to the same randomly generated value of desired length with explicit characters:
+
+::
+
+  # sat bmccreds --random-password --password-length 10 --password-chars '123abcd$^&*'
+  +--------------+-----------+------------------------+-------------+----------------+
+  | xname        | Type      | Password Type          | Status Code | Status Message |
+  +--------------+-----------+------------------------+-------------+----------------+
+  | x3000c0s23b0 | NodeBMC   | Random, domain: system | 200         | OK             |
+  | x3000c0s4b0  | NodeBMC   | Random, domain: system | 200         | OK             |
+  | x3000c0s10b0 | NodeBMC   | Random, domain: system | 200         | OK             |
   ...
 
 

--- a/sat/cli/bmccreds/constants.py
+++ b/sat/cli/bmccreds/constants.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -24,7 +24,6 @@
 """
 Constant values for the bmccreds subcommand.
 """
-
 import string
 
 # The username that bmccreds will always use
@@ -39,5 +38,10 @@ MAX_XNAMES_TO_DISPLAY = 20
 # The length of randomly-generated passwords
 RANDOM_PASSWORD_LENGTH = 8
 
-# The set of valid BMC password characters
-VALID_BMC_PASSWORD_CHARACTERS = string.ascii_letters + string.digits + '_'
+VALID_CHAR_SETS = {
+    'alpha': string.ascii_letters,
+    'numeric': string.digits,
+    'symbols': '!@#$%^&*'
+}
+
+VALID_CHAR_SETS_STRING = ''.join(VALID_CHAR_SETS.values())

--- a/tests/cli/bmccreds/test_creds_manager.py
+++ b/tests/cli/bmccreds/test_creds_manager.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -30,7 +30,7 @@ import unittest
 from unittest.mock import call, Mock, patch
 
 from sat.apiclient import APIError
-from sat.cli.bmccreds.constants import BMC_USERNAME
+from sat.cli.bmccreds.constants import BMC_USERNAME, RANDOM_PASSWORD_LENGTH, VALID_CHAR_SETS_STRING
 from sat.cli.bmccreds.creds_manager import BMCCredsException, BMCCredsManager
 from tests.common import ExtendedTestCase
 
@@ -51,9 +51,12 @@ class TestBMCCredsManager(unittest.TestCase):
         self.domain = None
         self.force = False
         self.report_format = 'pretty'
+        self.length = RANDOM_PASSWORD_LENGTH
+        self.allowed_chars = VALID_CHAR_SETS_STRING
 
         self.random_passwords = [
-            BMCCredsManager._generate_random_password_string() for _ in range(len(self.xnames))
+            BMCCredsManager._generate_random_password_string(self)
+            for _ in range(len(self.xnames))
         ]
         self.generate_random_password_string = patch.object(
             BMCCredsManager, '_generate_random_password_string', side_effect=self.random_passwords
@@ -70,7 +73,9 @@ class TestBMCCredsManager(unittest.TestCase):
             xnames=self.xnames,
             domain=self.domain,
             force=self.force,
-            report_format=self.report_format
+            report_format=self.report_format,
+            length=self.length,
+            allowed_chars=self.allowed_chars
         )
 
     def test_set_xnames_with_password(self):


### PR DESCRIPTION
IM: CRAYSAT-1920
Reviewer: Ryan

(cherry picked from commit d428ea727913a12529b893a290613f20ea194000)

## Summary and Scope

_This backports `sat bmccreds` improvements to release/3.25 for inclusion in CSM 1.5 and SAT 2.6._
- https://github.com/Cray-HPE/sat/pull/202

## Issues and Related PRs

_Resolves [CRAYSAT-1920](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1920)._

## Testing

_See linked PR._

## Risks and Mitigations

_See linked PR._


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

