### PR TITLE
CRAYSAT-1912: Get K8s version from node-images (#273)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.32.6] - 2024-10-08
+
+### Changed
+- Updated the version of `kubectl` included in `cray-sat` container to 1.24 to
+  match the version of Kubernetes included in CSM 1.6.
+
 ## [3.32.5] - 2024-10-03
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,6 +69,7 @@ COPY docs/man docs/man
 COPY tools tools
 
 RUN --mount=type=secret,id=netrc,target=/root/.netrc \
+    --mount=type=bind,source=node-images,target=/tmp/node-images \
     pip3 install --no-cache-dir pip && \
     pip3 install --no-cache-dir --timeout=300 . && \
     ./config-docker-sat.sh

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -45,6 +45,16 @@ pipeline {
     }
 
     stages {
+        stage('Checkout node-images repo for Kubernetes version') {
+            steps {
+                dir("node-images") {
+                    git(
+                        url: "https://github.com/Cray-HPE/node-images", branch: "main",
+                        credentialsId: "jenkins-algol60-cray-hpe-github-integration"
+                    )
+                }
+            }
+	}
         stage('Run Unit Tests') {
             steps {
                 sh 'make unittest'

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -34,13 +34,19 @@ endif
 
 all : unittest codestyle image
 
-unittest:
+# The node-images repo must be cloned to get the Kubernetes version, so we can
+# install the matching version of kubectl in the cray-sat image. In the Jenkins
+# pipeline, this is handled prior to running make
+node-images:
+		git clone --branch main git@github.com:Cray-HPE/node-images.git node-images
+
+unittest: node-images
 		$(DOCKER_BUILD) --target testing --tag $(TEST_TAG)
 		docker run $(TEST_TAG)
 
-codestyle:
+codestyle: node-images
 		$(DOCKER_BUILD) --target codestyle --tag $(CODESTYLE_TAG)
 		docker run $(CODESTYLE_TAG)
 
-image:
+image: node-images
 		$(DOCKER_BUILD) --tag $(DEFAULT_TAG)

--- a/docker_scripts/config-docker-sat.sh
+++ b/docker_scripts/config-docker-sat.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -27,10 +27,8 @@ LOGDIR=/var/log/cray/sat
 
 SATMANDIR=/usr/share/man/man8
 
-METAL_PROVISION_REPO="https://github.com/Cray-HPE/metal-provision.git"
-METAL_PROVISION_DIR="metal-provision"
-METAL_PROVISION_BASE_PACKAGES_PATH="group_vars/all.yml"
-METAL_PROVISION_BRANCH="lts/csm-1.5"
+NODE_IMAGES_DIR="/tmp/node-images"
+NODE_IMAGES_BASE_PACKAGES_PATH="metal-provision/group_vars/all.yml"
 
 # create logging directory
 if [ ! -d "$LOGDIR" ]; then
@@ -61,18 +59,13 @@ register-python-argcomplete sat > /usr/share/bash-completion/completions/sat
 echo "export PATH=$VIRTUAL_ENV/bin:\$PATH" > /etc/profile.d/sat_path.sh
 
 # install kubectl using same version used in ncn image
-cd /sat
-git clone $METAL_PROVISION_REPO $METAL_PROVISION_DIR
-cd $METAL_PROVISION_DIR
-git checkout $METAL_PROVISION_BRANCH
-
 KUBERNETES_PULL_VERSION=$(python3 <<EOF
 import sys
 
 import yaml
 
 
-with open("${METAL_PROVISION_BASE_PACKAGES_PATH}") as pkgs:
+with open("${NODE_IMAGES_DIR}/${NODE_IMAGES_BASE_PACKAGES_PATH}") as pkgs:
     pkgs = yaml.safe_load(pkgs)
     version = pkgs.get("kubernetes_release")
     if version:
@@ -84,7 +77,7 @@ EOF
 )
 
 if [ -z "$KUBERNETES_PULL_VERSION" ]; then
-    echo >&2 "Unable to determine version of kubectl to use from ${METAL_PROVISION_REPO}"
+    echo >&2 "Unable to determine version of kubectl to use from node-images repo"
     exit 1
 fi
 


### PR DESCRIPTION
## Summary and Scope

Update the cray-sat image build process to get the Kubernetes version from its new location in the node-images repository instead of the old version in the deprecated metal-provision repository.

This is more involved than just changing the repository URL and path in the `docker_scripts/config-docker-sat.sh` script because the node-images repository is private in GitHub, but metal-provision was public. Thus we need to authenticate to GitHub when cloning this repository. This is best achieved through a `git` command in the Jenkinsfile.

In order to continue supporting local builds, add a target to the `Makefile` that clones the node-images repository if it does not already exist. Use the `git` protocol instead of `https` to allow it to use the user's configured SSH keypair to authenticate when cloning the repo.

In either case, the node-images repository gets bind-mounted during the `RUN` command, so that it can be accessed by the `config-docker-sat.sh` script.

(cherry picked from commit 040f41cdbd4867fe7b7f15d27bb990815bed89d0)

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves CRAYSAT-1912

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Starlord

### Test description:

Built the image locally using `make image`. Then ran the container and executed `kubectl version` to verify the version of the `kubectl` client that was installed.
Pushed to Jenkins and verified that the Jenkins pipeline worked.

## Risks and Mitigations

minimal

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

