### PR TITLE
CRAYSAT-1913: Remove the ability to read VCS password from a file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.32.7] - 2024-10-15
+
+### Fixed
+- Remove the ability to read VCS password from a file which is no longer necessary in `sat bootprep`.
+
 ## [3.32.6] - 2024-10-08
 
 ### Changed

--- a/requirements-dev.lock.txt
+++ b/requirements-dev.lock.txt
@@ -11,10 +11,10 @@ cffi==1.15.0
 charset-normalizer==2.0.12
 click==8.0.4
 coverage==6.3.2
-cray-product-catalog==2.3.1
+cray-product-catalog==2.4.1
 croniter==0.3.37
 cryptography==43.0.1
-csm-api-client==2.2.2
+csm-api-client==2.2.3
 dataclasses-json==0.5.6
 docutils==0.17.1
 google-auth==2.6.0

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -8,10 +8,10 @@ certifi==2024.7.4
 cffi==1.15.0
 charset-normalizer==2.0.12
 click==8.0.4
-cray-product-catalog==2.3.1
+cray-product-catalog==2.4.1
 croniter==0.3.37
 cryptography==43.0.1
-csm-api-client==2.2.2
+csm-api-client==2.2.3
 dataclasses-json==0.5.6
 google-auth==2.6.0
 htmlmin==0.1.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,8 +21,8 @@
 argcomplete
 boto3
 botocore
-cray-product-catalog >= 2.3.1
-csm-api-client >= 2.2.2, <3.0
+cray-product-catalog >= 2.4.1
+csm-api-client >= 2.2.3, <3.0
 croniter >= 0.3, < 1.0
 inflect >= 0.2.5, < 3.0
 Jinja2 >= 3.0, < 4.0


### PR DESCRIPTION
## Summary and Scope

_Remove the ability to read VCS password from a file which is no longer necessary._

## Issues and Related PRs

_Resolves [CRAYSAT-1913](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1913)._
_Merge this after https://github.com/Cray-HPE/python-csm-api-client/pull/43_

## Testing

_List the environments in which these changes were tested._

### Tested on:

  Yet to be tested on the system where it upgrades from CSM 1.5.x to 1.6.1

### Test description:

_Since we didn't get system to test the changes when CSM upgrade from 1.5.x to 1.6.0,  Test this on update-cfs-config stage and prepare images stage when upgrading from CSM 1.5.x to 1.6.1 in future_

## Risks and Mitigations

_Risk is low as we are removing only the code redundancy_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable