### PR TITLE
CRAYSAT-1916: Fix unused code in `get_config_value` for handling infinite BOS timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.32.8] - 2024-10-21
+
+### Fixed
+- Fix unused code in `get_config_value` for handling infinite BOS timeouts.
+
 ## [3.32.7] - 2024-10-15
 
 ### Fixed

--- a/sat/config.py
+++ b/sat/config.py
@@ -371,9 +371,6 @@ def get_config_value(query_string):
 
     value = CONFIG.get(section, option)
 
-    if option.lower() == 'timeout' and value == '-1':
-        return math.inf
-
     return value
 
 


### PR DESCRIPTION
## Summary and Scope

_Fix unused code in `get_config_value` for handling infinite BOS timeouts_

## Issues and Related PRs

_Resolves [CRAYSAT-1913](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1913)._

## Testing

_List the environments in which these changes were tested._

### Tested on:

 Fanta

### Test description:

_Test the changes with shutdown/boot/reboot with bos-operations_

## Risks and Mitigations

_Minimal_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

