### PR TITLE
Backport release 3.32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.32.8] - 2024-10-21
+
+### Fixed
+- Fix unused code in `get_config_value` for handling infinite BOS timeouts.
+
 ## [3.32.7] - 2024-10-15
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.32.7] - 2024-10-15
+
+### Fixed
+- Remove the ability to read VCS password from a file which is no longer necessary in `sat bootprep`.
+
 ## [3.32.6] - 2024-10-08
 
 ### Changed

--- a/requirements-dev.lock.txt
+++ b/requirements-dev.lock.txt
@@ -11,10 +11,10 @@ cffi==1.15.0
 charset-normalizer==2.0.12
 click==8.0.4
 coverage==6.3.2
-cray-product-catalog==2.3.1
+cray-product-catalog==2.4.1
 croniter==0.3.37
 cryptography==43.0.1
-csm-api-client==2.2.2
+csm-api-client==2.2.3
 dataclasses-json==0.5.6
 docutils==0.17.1
 google-auth==2.6.0

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -8,10 +8,10 @@ certifi==2024.7.4
 cffi==1.15.0
 charset-normalizer==2.0.12
 click==8.0.4
-cray-product-catalog==2.3.1
+cray-product-catalog==2.4.1
 croniter==0.3.37
 cryptography==43.0.1
-csm-api-client==2.2.2
+csm-api-client==2.2.3
 dataclasses-json==0.5.6
 google-auth==2.6.0
 htmlmin==0.1.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,8 +21,8 @@
 argcomplete
 boto3
 botocore
-cray-product-catalog >= 2.3.1
-csm-api-client >= 2.2.2, <3.0
+cray-product-catalog >= 2.4.1
+csm-api-client >= 2.2.3, <3.0
 croniter >= 0.3, < 1.0
 inflect >= 0.2.5, < 3.0
 Jinja2 >= 3.0, < 4.0

--- a/sat/config.py
+++ b/sat/config.py
@@ -371,9 +371,6 @@ def get_config_value(query_string):
 
     value = CONFIG.get(section, option)
 
-    if option.lower() == 'timeout' and value == '-1':
-        return math.inf
-
     return value
 
 


### PR DESCRIPTION
## Summary and Scope

_Backport `sat-container` image to 3.32.8_

## Issues and Related PRs

- [CRAYSAT-1913](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1913): https://github.com/Cray-HPE/python-csm-api-client/pull/43, https://github.com/Cray-HPE/sat/pull/276
- [CRAYSAT-1916](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1916): https://github.com/Cray-HPE/sat/pull/277

## Testing

_See the linked PRs._

## Risks and Mitigations

_See the linked PRs._


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

