### PR TITLE
CRAYSAT-1929: Fix CFS fields in `sat status` for CFS v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.32.9] - 2024-10-29
+
+### Fixed
+- Fix missing CFS fields in `sat status` when using CFS v3.
+
 ## [3.32.8] - 2024-10-21
 
 ### Fixed


### PR DESCRIPTION
## Summary and Scope

The `CFSStatusModule` still had hard-coded property names for the properties of a CFS component, and these property names were only valid for CFS v2, so `sat status` only showed CFS fields when CFS v2 was used. Update the mapping so that it correctly maps CFS properties to the `sat status` column names for both CFS v2 and v3.

## Issues and Related PRs

* Resolves CRAYSAT-1929

## Testing

### Tested on:

  * noname

### Test description:

Built `cray-sat` image and tested on `noname` with both CFS versions, that is:

* `sat status --cfs-version v2`
* `sat status --cfs-version v3`

## Risks and Mitigations

Low risk change which only affects `sat status`.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
