### PR TITLE
CRAYSAT-1895: add empty string handling for rootfs_provider key of boot_set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.32.11] - 2024-11-12
+
+### Fixed
+- Added validation to `sat bootprep` to prohibit empty strings in `rootfs_provider` and
+  `rootfs_provider_passthrough` keys of `boot_sets`
+
 ## [3.32.10] - 2024-11-04
 
 ### Fixed

--- a/sat/cli/bootprep/input/session_template.py
+++ b/sat/cli/bootprep/input/session_template.py
@@ -110,6 +110,30 @@ class InputSessionTemplate(BaseInputItem):
         """dict: the image record from IMS for this session template"""
 
     @Validatable.validation_method()
+    def validate_rootfs_provider_has_value(self, **_):
+        """Validate that the rootfs_provider is not an empty string
+
+        Raises:
+            InputItemValidateError: if the rootfs_provider is an empty string
+        """
+        for boot_set_name, boot_set_data in self.boot_sets.items():
+            if not boot_set_data['rootfs_provider']:
+                raise InputItemValidateError(f'The value of rootfs_provider for boot set '
+                                             f'{boot_set_name} cannot be an empty string')
+
+    @Validatable.validation_method()
+    def validate_rootfs_provider_passthrough_has_value(self, **_):
+        """Validate that the rootfs_provider_passthrough is not an empty string
+
+        Raises:
+            InputItemValidateError: if the rootfs_provider_passthrough is an empty string
+        """
+        for boot_set_name, boot_set_data in self.boot_sets.items():
+            if not boot_set_data['rootfs_provider_passthrough']:
+                raise InputItemValidateError(f'The value of rootfs_provider_passthrough for boot set '
+                                             f'{boot_set_name} cannot be an empty string')
+
+    @Validatable.validation_method()
     def validate_configuration_exists(self, **_):
         """Validate that the configuration specified for this session template exists.
 

--- a/tests/cli/bootprep/input/test_session_template.py
+++ b/tests/cli/bootprep/input/test_session_template.py
@@ -161,6 +161,98 @@ class TestInputSessionTemplateV2(unittest.TestCase):
         self.assertEqual(expected_bos_data,
                          input_session_template.get_create_item_data())
 
+    def test_validate_rootfs_provider_good(self):
+        """Test that validate_rootfs_provider passes with good data"""
+        input_data, _ = self.get_input_and_expected_bos_data()
+        input_session_template = self.simplified_session_template_v2(
+            input_data, self.input_instance, 0, self.jinja_env,
+            self.bos_client, self.cfs_client, self.ims_client
+        )
+        input_session_template.validate_rootfs_provider_has_value()
+
+    def test_validate_rootfs_provider_bad(self):
+        """Test that validate_rootfs_provider fails with bad data"""
+        input_data, _ = self.get_input_and_expected_bos_data()
+        input_data['bos_parameters']['boot_sets']['compute']['rootfs_provider'] = ''
+        input_session_template = self.simplified_session_template_v2(
+            input_data, self.input_instance, 0, self.jinja_env,
+            self.bos_client, self.cfs_client, self.ims_client
+        )
+        err_regex = 'The value of rootfs_provider for boot set compute cannot be an empty string'
+        with self.assertRaisesRegex(InputItemValidateError, err_regex):
+            input_session_template.validate_rootfs_provider_has_value()
+
+    def test_validate_rootfs_provider_multiple_good(self):
+        """Test that validate_rootfs_provider passes with good data in multiple boot sets"""
+        input_data, _ = self.get_input_and_expected_bos_data()
+        compute_boot_set = input_data['bos_parameters']['boot_sets']['compute']
+        input_data['bos_parameters']['boot_sets']['compute_two'] = compute_boot_set
+        input_session_template = self.simplified_session_template_v2(
+            input_data, self.input_instance, 0, self.jinja_env,
+            self.bos_client, self.cfs_client, self.ims_client
+        )
+        input_session_template.validate_rootfs_provider_has_value()
+
+    def test_validate_rootfs_provider_multiple_bad(self):
+        """Test that validate_rootfs_provider fails with bad data in multiple boot sets"""
+        input_data, _ = self.get_input_and_expected_bos_data()
+        input_data['bos_parameters']['boot_sets']['compute']['rootfs_provider'] = ''
+        compute_boot_set = input_data['bos_parameters']['boot_sets']['compute']
+        input_data['bos_parameters']['boot_sets']['compute_two'] = compute_boot_set
+        input_session_template = self.simplified_session_template_v2(
+            input_data, self.input_instance, 0, self.jinja_env,
+            self.bos_client, self.cfs_client, self.ims_client
+        )
+        err_regex = 'The value of rootfs_provider for boot set compute cannot be an empty string'
+        with self.assertRaisesRegex(InputItemValidateError, err_regex):
+            input_session_template.validate_rootfs_provider_has_value()
+
+    def test_validate_rootfs_provider_passthrough_good(self):
+        """Test that validate_rootfs_provider_passthrough passes with good data"""
+        input_data, _ = self.get_input_and_expected_bos_data()
+        input_session_template = self.simplified_session_template_v2(
+            input_data, self.input_instance, 0, self.jinja_env,
+            self.bos_client, self.cfs_client, self.ims_client
+        )
+        input_session_template.validate_rootfs_provider_passthrough_has_value()
+
+    def test_validate_rootfs_provider_passthrough_bad(self):
+        """Test that validate_rootfs_provider_passthrough fails with bad data"""
+        input_data, _ = self.get_input_and_expected_bos_data()
+        input_data['bos_parameters']['boot_sets']['compute']['rootfs_provider_passthrough'] = ''
+        input_session_template = self.simplified_session_template_v2(
+            input_data, self.input_instance, 0, self.jinja_env,
+            self.bos_client, self.cfs_client, self.ims_client
+        )
+        err_regex = 'The value of rootfs_provider_passthrough for boot set compute cannot be an empty string'
+        with self.assertRaisesRegex(InputItemValidateError, err_regex):
+            input_session_template.validate_rootfs_provider_passthrough_has_value()
+
+    def test_validate_rootfs_provider_passthrough_multiple_good(self):
+        """Test that validate_rootfs_provider_passthrough passes with good data in multiple boot sets"""
+        input_data, _ = self.get_input_and_expected_bos_data()
+        compute_boot_set = input_data['bos_parameters']['boot_sets']['compute']
+        input_data['bos_parameters']['boot_sets']['compute_two'] = compute_boot_set
+        input_session_template = self.simplified_session_template_v2(
+            input_data, self.input_instance, 0, self.jinja_env,
+            self.bos_client, self.cfs_client, self.ims_client
+        )
+        input_session_template.validate_rootfs_provider_passthrough_has_value()
+
+    def test_validate_rootfs_provider_passthrough_multiple_bad(self):
+        """Test that validate_rootfs_provider_passthrough fails with bad data in multiple boot sets"""
+        input_data, _ = self.get_input_and_expected_bos_data()
+        input_data['bos_parameters']['boot_sets']['compute']['rootfs_provider_passthrough'] = ''
+        compute_boot_set = input_data['bos_parameters']['boot_sets']['compute']
+        input_data['bos_parameters']['boot_sets']['compute_two'] = compute_boot_set
+        input_session_template = self.simplified_session_template_v2(
+            input_data, self.input_instance, 0, self.jinja_env,
+            self.bos_client, self.cfs_client, self.ims_client
+        )
+        err_regex = 'The value of rootfs_provider_passthrough for boot set compute cannot be an empty string'
+        with self.assertRaisesRegex(InputItemValidateError, err_regex):
+            input_session_template.validate_rootfs_provider_passthrough_has_value()
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary and Scope

This PR adds validation to check that rootfs_provider and rootfs_provider_passthrough are not empty strings

## Issues and Related PRs


* Resolves [CRAYSAT-1895](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1895)


## Testing

### Tested on:

  * drax

### Test description:

Changes were successful, output of testing on drax: https://gist.github.com/ethanholen-hpe/7069d94e25dc06c59ba84c05c04cfb07#file-gistfile1-txt


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

