### PR TITLE
CRAYSAT-1935: create_image_customization_session() missing `image_name` argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.25.16] - 2024-11-13
+
+### Changed
+- Updated `begin_image_configure` to pass session name generated to address the
+  sat bootprep incorrect logging of 2 session names
+
 ## [3.25.15] - 2024-10-10
 
 ### Changed

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Top-level requirements for sat package to function.
-# (C) Copyright 2019-2023 Hewlett Packard Enterprise Development LP.
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/sat/cli/bootprep/input/image.py
+++ b/sat/cli/bootprep/input/image.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -403,7 +403,7 @@ class BaseInputImage(DependencyGroupMember, ABC):
 
         try:
             self.image_configure_session = self.cfs_client.create_image_customization_session(
-                self.configuration, self.image_id_to_configure, self.configuration_group_names, self.name)
+                session_name, self.configuration, self.image_id_to_configure, self.configuration_group_names, self.name)
         except APIError as err:
             raise ImageCreateError(f'Failed to launch image customization CFS session: {err}')
 


### PR DESCRIPTION
## Summary and Scope

Traceback Error - "TypeError: create_image_customization_session() missing 1 required positional argument: 'image_name'" has been observed with the latest stable build of `release/3.25`

To fix this, Backport `CRAYSAT-1747: Allow passing CFS session name` to SAT 2.6 / CSM 1.5 as a solution

Incorrect logging is observed in sat bootprep logs SAT is also generating a session name, which is conflicting with session name generated in create_image_customization_session

Hence updating the `begin_image_configure` to pass session name to address sat bootprep incorrect logging

(cherry picked from commit e35ac289cfac844d98727f715c742248ce9239e7)

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CRAYSAT-1935](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1935)
* This PR backports the changes from [CRAYSAT-1747](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1747): https://github.com/Cray-HPE/sat/pull/203

## Testing

_List the environments in which these changes were tested._

### Tested on:

#rocket 

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

Test the unstable build to create the images successfully from `sat bootprep` command without any Traceback error

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

