### PR TITLE
CRAYSAT-1941: add validation to check for existence of rootfs_provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.32.13] - 2024-11-25
+
+### Fixed
+- Added validation to `sat bootprep` to verify that `rootfs_provider` and
+  `rootfs_provider_passthrough` exist before checking for empty string values.
+
 ## [3.32.12] - 2024-11-21
 
 ### Fixed

--- a/sat/cli/bootprep/input/session_template.py
+++ b/sat/cli/bootprep/input/session_template.py
@@ -117,7 +117,7 @@ class InputSessionTemplate(BaseInputItem):
             InputItemValidateError: if the rootfs_provider is an empty string
         """
         for boot_set_name, boot_set_data in self.boot_sets.items():
-            if not boot_set_data['rootfs_provider']:
+            if 'rootfs_provider' in boot_set_data and not boot_set_data['rootfs_provider']:
                 raise InputItemValidateError(f'The value of rootfs_provider for boot set '
                                              f'{boot_set_name} cannot be an empty string')
 
@@ -129,7 +129,8 @@ class InputSessionTemplate(BaseInputItem):
             InputItemValidateError: if the rootfs_provider_passthrough is an empty string
         """
         for boot_set_name, boot_set_data in self.boot_sets.items():
-            if not boot_set_data['rootfs_provider_passthrough']:
+            if ('rootfs_provider_passthrough' in boot_set_data
+                    and not boot_set_data['rootfs_provider_passthrough']):
                 raise InputItemValidateError(f'The value of rootfs_provider_passthrough for boot set '
                                              f'{boot_set_name} cannot be an empty string')
 

--- a/tests/cli/bootprep/input/test_session_template.py
+++ b/tests/cli/bootprep/input/test_session_template.py
@@ -207,6 +207,16 @@ class TestInputSessionTemplateV2(unittest.TestCase):
         with self.assertRaisesRegex(InputItemValidateError, err_regex):
             input_session_template.validate_rootfs_provider_has_value()
 
+    def test_validate_no_rootfs_provider(self):
+        """Test that validate_rootfs_provider passes with good data"""
+        input_data, _ = self.get_input_and_expected_bos_data()
+        del input_data['bos_parameters']['boot_sets']['compute']['rootfs_provider']
+        input_session_template = self.simplified_session_template_v2(
+            input_data, self.input_instance, 0, self.jinja_env,
+            self.bos_client, self.cfs_client, self.ims_client
+        )
+        input_session_template.validate_rootfs_provider_has_value()
+
     def test_validate_rootfs_provider_passthrough_good(self):
         """Test that validate_rootfs_provider_passthrough passes with good data"""
         input_data, _ = self.get_input_and_expected_bos_data()
@@ -253,6 +263,15 @@ class TestInputSessionTemplateV2(unittest.TestCase):
         with self.assertRaisesRegex(InputItemValidateError, err_regex):
             input_session_template.validate_rootfs_provider_passthrough_has_value()
 
+    def test_validate_no_rootfs_provider_passthrough(self):
+        """Test that validate_rootfs_provider_passthrough passes with good data"""
+        input_data, _ = self.get_input_and_expected_bos_data()
+        del input_data['bos_parameters']['boot_sets']['compute']['rootfs_provider_passthrough']
+        input_session_template = self.simplified_session_template_v2(
+            input_data, self.input_instance, 0, self.jinja_env,
+            self.bos_client, self.cfs_client, self.ims_client
+        )
+        input_session_template.validate_rootfs_provider_passthrough_has_value()
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/cli/bootprep/input/test_session_template.py
+++ b/tests/cli/bootprep/input/test_session_template.py
@@ -273,5 +273,6 @@ class TestInputSessionTemplateV2(unittest.TestCase):
         )
         input_session_template.validate_rootfs_provider_passthrough_has_value()
 
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary and Scope

Add validation to check for existence of rootfs_provider and rootfs_provider_passthrough before checking for empty string.


## Issues and Related PRs

* Resolves [CRAYSAT-1941](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1941)

## Testing

### Tested on:

  * Local development environment


### Test description:

Tests added to verify functionality

## Risks and Mitigations

None


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

