### PR TITLE
CRAYSAT-1649: add error logging when unable to find token file path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.33.2] - 2024-11-26
+
+### Fixed
+-  Added error message and system exit when token file is not found.
+
 ## [3.33.1] - 2024-12-02
 
 ### Fixed

--- a/requirements-dev.lock.txt
+++ b/requirements-dev.lock.txt
@@ -14,7 +14,7 @@ coverage==6.3.2
 cray-product-catalog==2.4.1
 croniter==0.3.37
 cryptography==43.0.1
-csm-api-client==2.3.1
+csm-api-client==2.3.2
 dataclasses-json==0.5.6
 docutils==0.17.1
 google-auth==2.6.0

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -11,7 +11,7 @@ click==8.0.4
 cray-product-catalog==2.4.1
 croniter==0.3.37
 cryptography==43.0.1
-csm-api-client==2.3.1
+csm-api-client==2.3.2
 dataclasses-json==0.5.6
 google-auth==2.6.0
 htmlmin==0.1.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ argcomplete
 boto3
 botocore
 cray-product-catalog >= 2.4.1
-csm-api-client >= 2.3.1, <3.0
+csm-api-client >= 2.3.2, <3.0
 croniter >= 0.3, < 1.0
 inflect >= 0.2.5, < 3.0
 Jinja2 >= 3.0, < 4.0

--- a/sat/cli/auth/main.py
+++ b/sat/cli/auth/main.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -53,7 +53,7 @@ def do_auth(args):
         None
     """
 
-    session = SATSession(no_unauth_warn=True)
+    session = SATSession(no_unauth_err=True)
     if session.token and not pester(
                     f'Token already exists for "{session.username}" on "{session.host}". '
                     f'Overwrite?'):

--- a/tests/cli/bootsys/test_bos.py
+++ b/tests/cli/bootsys/test_bos.py
@@ -177,6 +177,7 @@ class TestBOSLimitString(unittest.TestCase):
         self.blade_xname = 'x3000c0s0'
         self.nodes_on_blade_xnames = [f'{self.blade_xname}b0n{node}' for node in range(4)]
         self.mock_hsm_client = patch('sat.cli.bootsys.bos.HSMClient').start()
+        self.mock_sat_session = patch('sat.cli.bootsys.bos.SATSession').start()
         self.mock_get_node_components = self.mock_hsm_client.return_value.get_node_components
         self.mock_get_node_components.return_value = [
             {'ID': xname} for xname in self.nodes_on_blade_xnames
@@ -234,6 +235,7 @@ class TestBOSV2SessionWaiter(unittest.TestCase):
         self.session_id = 'abcdef-012345-678901-fdecba'
 
         self.mock_bos_client = MagicMock()
+        self.mock_sat_session = patch('sat.cli.bootsys.bos.SATSession').start()
         self.mock_bos_client.get.return_value = MagicMock(ok=True, status_code=200, json=MagicMock(return_value={
             'status': 'complete',
             'managed_components_count': 10,

--- a/tests/cli/bootsys/test_service_activity.py
+++ b/tests/cli/bootsys/test_service_activity.py
@@ -401,8 +401,13 @@ class TestBOSV2ActivityChecker(unittest.TestCase):
 
     def setUp(self):
         self.mock_bos_client = MagicMock()
+        self.mock_sat_session = patch('sat.cli.bootsys.service_activity.SATSession').start()
         patch('sat.cli.bootsys.service_activity.BOSClientCommon.get_bos_client',
               return_value=self.mock_bos_client).start()
+
+    def tearDown(self):
+        """Stop mocks at the end of each unit test."""
+        patch.stopall()
 
     def test_finding_no_sessions(self):
         """Test that the BOSV2ServiceChecker returns no sessions when no sessions exist"""
@@ -604,6 +609,7 @@ class TestFirmwareActivityChecker(ExtendedTestCase):
                 return self.fas_actions
 
         self.fw_client = patch('sat.cli.bootsys.service_activity.FASClient').start().return_value
+        self.mock_sat_session = patch('sat.cli.bootsys.service_activity.SATSession').start()
         self.fw_client.get_active_actions.side_effect = mock_get_active_updates
 
     def tearDown(self):

--- a/tests/cli/firmware/test_firmware.py
+++ b/tests/cli/firmware/test_firmware.py
@@ -64,6 +64,9 @@ class TestFirmware(ExtendedTestCase):
         # Fake print
         self.mock_print = mock.patch('sat.cli.firmware.main.print').start()
 
+        # Fake SatSession
+        self.mock_sat_session = mock.patch('sat.cli.firmware.main.SATSession').start()
+
         # Fake get_config_value
         self.fake_config = {
             'format.no_headings': False,

--- a/tests/cli/slscheck/test_slscheck.py
+++ b/tests/cli/slscheck/test_slscheck.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -204,7 +204,7 @@ class TestDoSlscheck(unittest.TestCase):
         self.mock_hsm_client.get_all_components.return_value = self.all_hsm_components
         self.mock_hsm_client.get_bmcs_by_type.return_value = self.all_hsm_redfish_endpoints
 
-        self.mock_sat_session = mock.patch('sat.cli.nid2xname.main.SATSession').start()
+        self.mock_sat_session = mock.patch('sat.cli.slscheck.main.SATSession').start()
         self.mock_print = mock.patch('builtins.print', autospec=True).start()
 
         self.fake_args = Namespace()

--- a/tests/cli/swap/test_ports.py
+++ b/tests/cli/swap/test_ports.py
@@ -127,6 +127,7 @@ class TestGetSwitchPortDataList(unittest.TestCase):
         }
         self.mock_get_switch = mock.patch('sat.cli.swap.ports.PortManager.get_switch',
                                           autospec=True).start()
+        self.mock_sat_session = mock.patch('sat.cli.swap.ports.SATSession').start()
         self.mock_get_switch.side_effect = lambda _, switch_xname: self.mock_switches.get(switch_xname)
         self.pm = PortManager()
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -40,11 +40,11 @@ class TestSessionTenantHandling(unittest.TestCase):
         """Test that the Cray-Tenant-Name header is set from the config"""
         tenant_name = 'some_tenant_name'
         with config({'api_gateway': {'tenant_name': tenant_name}}):
-            s = SATSession()
+            s = SATSession(no_unauth_err=True)
             self.assertEqual(s.session.headers[TENANT_HEADER_NAME], tenant_name)
 
     def test_cray_tenant_name_not_set(self):
         """Test that the Cray-Tenant-Name header is not set when not configured"""
         with config({'api_gateway': {'tenant_name': ''}}):
-            s = SATSession()
+            s = SATSession(no_unauth_err=True)
             self.assertIsNone(s.session.headers.get(TENANT_HEADER_NAME))


### PR DESCRIPTION
## Summary and Scope

add error logging when unable to find token file path and unwrap ~ as home directory

## Issues and Related PRs


* Resolves [CRAYSAT-1649](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1649)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge after https://github.com/Cray-HPE/python-csm-api-client/pull/48

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Rocket
  * Drax
  * Local development environment


### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

