### PR TITLE
CRAYSAT-1923: Update `sat bootsys` to support CFS v2 or v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,12 +25,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.33.3] - 2024-11-26
+## [3.33.4] - 2024-12-11
+
+### Added
+- Added support for using either the CFS v2 or v3 API in `sat bootsys`,
+  depending on the value of the `--cfs-version` command-line option or the
+  `cfs.api_version` config-file option.
+
+## [3.33.3] - 2024-12-10
 
 ### Added
 -  Added the ability to sort reports by multiple fields
 
-## [3.33.2] - 2024-11-26
+## [3.33.2] - 2024-12-10
 
 ### Fixed
 -  Added error message and system exit when token file is not found.

--- a/docs/man/sat-bootsys.8.rst
+++ b/docs/man/sat-bootsys.8.rst
@@ -159,6 +159,9 @@ These options apply to both the ``shutdown`` and ``boot`` actions.
 **--bos-version BOS_VERSION**
         The version of the BOS API to use when launching BOS sessions.
 
+**--cfs-version CFS_VERSION**
+        The version of the CFS API to use when launching CFS sessions.
+
 **--cle-bos-template** *CLE_BOS_TEMPLATE*
         The name of the BOS session template for shutdown or boot of
         COS (formerly known as CLE) compute nodes. If not specified, no

--- a/docs/man/sat-bootsys.8.rst
+++ b/docs/man/sat-bootsys.8.rst
@@ -160,7 +160,7 @@ These options apply to both the ``shutdown`` and ``boot`` actions.
         The version of the BOS API to use when launching BOS sessions.
 
 **--cfs-version CFS_VERSION**
-        The version of the CFS API to use when launching CFS sessions.
+        The version of the CFS API to use when querying CFS sessions.
 
 **--cle-bos-template** *CLE_BOS_TEMPLATE*
         The name of the BOS session template for shutdown or boot of

--- a/sat/cli/bootsys/parser.py
+++ b/sat/cli/bootsys/parser.py
@@ -285,6 +285,12 @@ def add_bootsys_subparser(subparsers):
         help='The version of the BOS API to use for BOS operations',
     )
 
+    bootsys_parser.add_argument(
+        '--cfs-version',
+        choices=['v2', 'v3'],
+        help='The version of the CFS API to use for CFS operations',
+    )
+
     actions_subparsers = bootsys_parser.add_subparsers(
         metavar='action', dest='action', help='The action to perform.'
     )

--- a/sat/cli/bootsys/service_activity.py
+++ b/sat/cli/bootsys/service_activity.py
@@ -383,9 +383,9 @@ class CFSActivityChecker(ServiceActivityChecker):
         Raises:
             ServiceCheckError: if unable to get the active CFS sessions.
         """
-        cfs_client = CFSClientBase.get_cfs_client(SATSession(), 'v2')
+        cfs_client = CFSClientBase.get_cfs_client(SATSession(), get_config_value('cfs.api_version'))
         try:
-            sessions = cfs_client.get('sessions').json()
+            sessions = cfs_client.get_sessions()
         except (APIError, ValueError) as err:
             raise self.get_err(str(err))
 

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -313,7 +313,7 @@ class TestReport(unittest.TestCase):
 
         data = json.loads(json_s)
         for expected, actual in zip(self.entries, data):
-            self.assertEquals(expected, list(actual.values()))
+            self.assertEqual(expected, list(actual.values()))
 
     def test_get_formatted_report_json_with_xnames(self):
         """Json dumps should encode XName datatypes as strings.
@@ -326,7 +326,7 @@ class TestReport(unittest.TestCase):
 
         json_s = report.get_formatted_report('json')
         data = json.loads(json_s)
-        self.assertEquals(xname_s, data[0][header_s])
+        self.assertEqual(xname_s, data[0][header_s])
 
     def test_print_report(self):
         """str(report) should depend on the format instance variable.


### PR DESCRIPTION
## Summary and Scope

_Update `sat bootsys` to support CFS v2 or v3_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CRAYSAT-1923](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1923)
* Resolves [CRAYSAT-1847](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1847)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  fanta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

Test `sat bootsys` for both cfs v2 and cfs v3 version including the paging property

## Risks and Mitigations

_Low_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

