### PR TITLE
CRAYSAT-1936: add ability to sort reports by multiple fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.33.3] - 2024-11-26
+
+### Added
+-  Added the ability to sort reports by multiple fields
+
 ## [3.33.2] - 2024-11-26
 
 ### Fixed

--- a/docs/man/_sat-format-opts.rst
+++ b/docs/man/_sat-format-opts.rst
@@ -15,7 +15,13 @@ These options govern the format of the output.
         Reverses the sorting order.
 
 **--sort-by HEADING**
-        Sort by the selected heading. Can also accept a 0-based column index.
+        Sort by the selected heading or comma-separated list of headings.
+        Can also accept a 0-based column index or comma-separated list
+        of 0-based column indexes.
+        E.g. "--sort-by product_name,product_version" will sort
+        results by product name and then by product version. Can accept a column
+        name or a 0-based index. Enclose the column name in
+        double quotes if it contains a space.
 
 **--show-empty**
         Show values for columns even if every value is ``EMPTY``. By default,

--- a/sat/cli/showrev/main.py
+++ b/sat/cli/showrev/main.py
@@ -64,8 +64,13 @@ def do_showrev(args):
     """
     reports = []
 
+    # The `showrev` command sets the default of `--sort-by` to None, so we can use that to
+    # determine if the user explicitly set the value, and use a special default if not.
+    if args.sort_by is None:
+        sort_by = ['product_name', 'product_version']
+    else:
+        sort_by = args.sort_by
     # report formatting
-    sort_by = args.sort_by
     reverse = args.reverse
     no_headings = get_config_value('format.no_headings')
     no_borders = get_config_value('format.no_borders')

--- a/sat/cli/showrev/parser.py
+++ b/sat/cli/showrev/parser.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2020, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -39,7 +39,7 @@ def add_showrev_subparser(subparsers):
         None
     """
 
-    format_options = sat.parsergroups.create_format_options()
+    format_options = sat.parsergroups.create_format_options(sort_by_default=None)
     filter_options = sat.parsergroups.create_filter_options()
 
     showrev_parser = subparsers.add_parser(

--- a/sat/parsergroups.py
+++ b/sat/parsergroups.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2022, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -36,7 +36,16 @@ from sat.util import set_val_by_path
 LOGGER = logging.getLogger(__name__)
 
 
-def create_format_options():
+def create_format_options(sort_by_default='0'):
+    """Creates a parser containing options for formatting.
+
+    sort_by_default: allows for the value of --sort_by to be set
+        when calling the method. It is set to 0 or the
+        first column of data being sorted.
+
+    Returns: an ArgumentParser object configured with options and help
+        text for formatting.
+    """
     parser = ArgumentParser(add_help=False)
 
     group = parser.add_argument_group(
@@ -64,10 +73,15 @@ def create_format_options():
         default=False, action='store_true')
 
     group.add_argument(
-        '--sort-by', metavar='FIELD', default=0,
-        help=('Select which column to sort by. Can accept a column name '
-              'or a 0-based index. Enclose the column name in double quotes '
-              'if it contains a space.'))
+        '--sort-by', default=sort_by_default,
+        type=lambda v: v.split(','),
+        help=('Sort by the selected heading or comma-separated list of '
+              'headings. Can also accept a 0-based column index or '
+              'comma-separated list of 0-based column indexes.'
+              'E.g. "--sort-by product_name,product_version" will sort '
+              'results by product name and then by product version. Can accept a column '
+              'name or a 0-based index. Enclose the column name in '
+              'double quotes if it contains a space.'))
 
     group.add_argument(
         '--show-empty',

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -390,6 +390,33 @@ class TestReportFormatting(unittest.TestCase):
         for expected, actual in zip(self.entries, pt_s):
             self.assertEqual(expected, actual)
 
+    def test_sorted_list_print(self):
+        """The internal PT should be sorted on the first column and then the second column
+        """
+        report = Report(self.headings, sort_by=[0, 1])
+
+        report.add_rows(self.out_of_order)
+        pt_s = get_report_printed_list(report)
+
+        for expected, actual in zip(self.entries, pt_s):
+            self.assertEqual(expected, actual)
+
+    def test_sorted_list_with_matches_print(self):
+        """Test sort on first and second column when elements are equal in first column
+        """
+        e1 = ['alice', 'mars', 'red']
+        e2 = ['bob', 'venus', 'blue']
+        e3 = ['charlie', 'earth', 'purple']
+        e4 = ['alice', 'earth', 'green']
+        out_of_order = [e1, e3, e2, e4]
+        expected_order = [e4, e1, e2, e3]
+        report = Report(self.headings, sort_by=[0, 1])
+        report.add_rows(out_of_order)
+
+        pt_s = get_report_printed_list(report)
+
+        self.assertEqual(expected_order, pt_s)
+
     def test_sorted_yaml(self):
         """The YAML output list should be sorted as well.
         """
@@ -467,6 +494,19 @@ class TestReportFormatting(unittest.TestCase):
         for expected, actual in zip(self.out_of_order, pt_s):
             self.assertEqual(expected, actual)
 
+    def test_sort_heading_invalid_multiple(self):
+        """The PT should default to not sorting if the heading is not present.
+        """
+        report = Report(self.headings, sort_by=['does-not-exist', 'does-not-exist-two'])
+
+        self.assertEqual(None, report.sort_by)
+
+        report.add_rows(self.out_of_order)
+        pt_s = get_report_printed_list(report)
+
+        for expected, actual in zip(self.out_of_order, pt_s):
+            self.assertEqual(expected, actual)
+
     def test_sort_heading_idx_invalid(self):
         """The PT should not sort if the idx is out-of-range.
         """
@@ -485,7 +525,7 @@ class TestReportFormatting(unittest.TestCase):
         """
         report = Report(self.headings, sort_by='pl')
 
-        self.assertEqual('place', report.sort_by)
+        self.assertEqual(['place'], report.sort_by)
 
         report.add_rows(self.out_of_order)
         pt_s = get_report_printed_list(report)
@@ -497,7 +537,7 @@ class TestReportFormatting(unittest.TestCase):
         """The report should sort on a unique subsequence.
         """
         report = Report(self.headings, sort_by='clr')
-        self.assertEqual('color', report.sort_by)
+        self.assertEqual(['color'], report.sort_by)
 
         report.add_rows(self.out_of_order)
         pt_s = get_report_printed_list(report)
@@ -509,7 +549,7 @@ class TestReportFormatting(unittest.TestCase):
         """The report should sort on the first match.
         """
         report = Report(self.headings, sort_by='ae')
-        self.assertEqual('name', report.sort_by)
+        self.assertEqual(['name'], report.sort_by)
 
         report.add_rows(self.out_of_order)
         pt_s = get_report_printed_list(report)


### PR DESCRIPTION
## Summary and Scope

Added ability to sort reports by multiple fields

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CRAYSAT-1936](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1936)

## Testing

### Tested on:

  * drax
  * Local development environment

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_


- Were continuous integration tests run? If not, why? yes
- Was upgrade tested? If not, why? yes
- Was downgrade tested? If not, why? yes
- Were new tests (or test issues/Jiras) created for this change? yes

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

