### PR TITLE
CRAYSAT-1896: Fix `sat bootprep` to include False `ims_require_dkms`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.33.1] - 2024-12-02
+
+### Fixed
+- Fixed `sat bootprep` to include the value of `ims_require_dkms` in the created
+  CFS configurations, even when explicitly set to `False`.
+
 ## [3.33.0] - 2024-11-25
 
 ### Added

--- a/requirements-dev.lock.txt
+++ b/requirements-dev.lock.txt
@@ -14,7 +14,7 @@ coverage==6.3.2
 cray-product-catalog==2.4.1
 croniter==0.3.37
 cryptography==43.0.1
-csm-api-client==2.3.0
+csm-api-client==2.3.1
 dataclasses-json==0.5.6
 docutils==0.17.1
 google-auth==2.6.0

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -11,7 +11,7 @@ click==8.0.4
 cray-product-catalog==2.4.1
 croniter==0.3.37
 cryptography==43.0.1
-csm-api-client==2.3.0
+csm-api-client==2.3.1
 dataclasses-json==0.5.6
 google-auth==2.6.0
 htmlmin==0.1.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ argcomplete
 boto3
 botocore
 cray-product-catalog >= 2.4.1
-csm-api-client >= 2.3.0, <3.0
+csm-api-client >= 2.3.1, <3.0
 croniter >= 0.3, < 1.0
 inflect >= 0.2.5, < 3.0
 Jinja2 >= 3.0, < 4.0


### PR DESCRIPTION
## Summary and Scope

Fixed `sat bootprep` to include the value of `ims_require_dkms` in the
created CFS configurations, even when explicitly set to `False`.

## Issues and Related PRs

* Resolves CRAYSAT-1896

## Testing

### Tested on:

  * rocket

### Test description:

Tested on rocket with a `bootprep` input file that defines a CFS
configuration that contains two layers, one which sets the
`ims_require_dkms` property to `True` and one which sets it to `False`.
Verified that the resulting CFS configuration contained the value for
the property in both layers. Tested in dry-run mode and regular mode for
both CFS v2 and v3.

## Risks and Mitigations

Low risk change to just support specifying false values in CFS configurations.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable