### PR TITLE
CRAYSAT-1875: Add new HSM types to `sat status`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.33.6] - 2024-12-12
+
+### Added
+- Added support to new HSM Types, namely `CabinetPDU`, `CabinetPDUController`,
+  `CabinetPDUPowerConnector` and `MgmtSwitch` in `sat status`
+
 ## [3.33.5] - 2024-12-11
 
 ### Fixed

--- a/docs/man/sat-status.8.rst
+++ b/docs/man/sat-status.8.rst
@@ -32,7 +32,8 @@ These options must be specified after the subcommand.
         The types that may be specified are...
 
             all, Chassis, ChassisBMC, ComputeModule, HSNBoard, Node, NodeBMC,
-            NodeEnclosure, RouterBMC, RouterModule
+            NodeEnclosure, RouterBMC, RouterModule, CabinetPDU, CabinetPDUController,
+            CabinetPDUPowerConnector, MgmtSwitch
 
         If "all" is specified, then all types will be queried.
 
@@ -196,7 +197,8 @@ The following fields are displayed in the output of **sat status**
 |
 |   The Type of the component in HSM. Possible values are as follows:
 |
-|   Chassis, ChassisBMC, ComputeModule, HSNBoard, Node, NodeBMC, NodeEnclosure, RouterBMC, RouterModule
+|   Chassis, ChassisBMC, ComputeModule, HSNBoard, Node, NodeBMC, NodeEnclosure, RouterBMC, RouterModule,
+|   CabinetPDU, CabinetPDUController, CabinetPDUPowerConnector, MgmtSwitch
 |
 | *NID*
 |

--- a/sat/cli/status/constants.py
+++ b/sat/cli/status/constants.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -36,6 +36,10 @@ COMPONENT_TYPES = [
     'NodeEnclosure',
     'RouterBMC',
     'RouterModule',
+    'CabinetPDU',
+    'CabinetPDUController',
+    'CabinetPDUPowerConnector',
+    'MgmtSwitch',
 ]
 
 DEFAULT_TYPE = 'Node'


### PR DESCRIPTION
## Summary and Scope

_Add new HSM Types, namely `CabinetPDU`, `CabinetPDUController`, `CabinetPDUPowerConnector` and
  `MgmtSwitch` in `sat status`_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CRAYSAT-1875](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1875)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Odin

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

Tested with `sat status` command for all the types including  `CabinetPDU`, `CabinetPDUController`, `CabinetPDUPowerConnector` and  `MgmtSwitch` 

## Risks and Mitigations

_Low_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

