### PR TITLE
CRAYSAT-1948: Fix traceback in `sat swap blade`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.33.8] - 2024-12-18
+
+### Fixed
+- Fixed a traceback that occurs in `sat swap blade` when the node classes
+  reported by HSM includes both "Mountain" and "Hill" for a single blade.
+
 ## [3.33.7] - 2024-12-18
 
 ### Fixed


### PR DESCRIPTION
## Summary and Scope

Fix a traceback that occurs in `sat swap blade` when the node classes reported by HSM includes both "Mountain" and "Hill" for a single blade.

This probably indicates some sort of configuration problem in HSM, but the behavior of `sat swap blade` is the same for both Mountain and Hill, so we can log a warning and proceed in this case.

## Issues and Related PRs

* Resolves CRAYSAT-1948

## Testing

### Tested on:

  * Local development environment

### Test description:

Unit tested only so far.

## Risks and Mitigations

Introduces some risk to the `sat swap blade` command, but unit tests are pretty good for the modified `blade_class` property.

Still needs to be tested on a system.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
