### PR TITLE
CRAYSAT-1942: Drop internal default values for rootfs_provider{,passthrough} from sat bootprep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.33.9] - 2024-12-11
+
+### Removed
+- Removed internal default values for rootfs_provider{,passthrough} 
+  from sat bootprep
+
 ## [3.33.8] - 2024-12-18
 
 ### Fixed

--- a/sat/apiclient/bos.py
+++ b/sat/apiclient/bos.py
@@ -132,19 +132,6 @@ class BOSClientCommon(APIGatewayClient):
 
         return bos_client_cls(session, **kwargs)
 
-    @staticmethod
-    def get_base_boot_set_data():
-        """Get the base boot set data to use as a starting point.
-
-        Returns:
-            dict: the base data to use as a starting point for a boot set
-        """
-        return {
-            'rootfs_provider': 'cpss3',
-            # TODO (CRAYSAT-898): update default hostname for authoritative DNS changes
-            'rootfs_provider_passthrough': 'dvs:api-gw-service-nmn.local:300:nmn0'
-        }
-
     def get_session(self, session_id):
         """Get information about a given session.
 

--- a/sat/cli/bootprep/input/session_template.py
+++ b/sat/cli/bootprep/input/session_template.py
@@ -188,7 +188,7 @@ class InputSessionTemplate(BaseInputItem):
 
         for boot_set_name, boot_set_data in self.boot_sets.items():
             # Must deepcopy to avoid every boot set sharing the same dict
-            boot_set_api_data = deepcopy(self.bos_client.get_base_boot_set_data())
+            boot_set_api_data = {}
             try:
                 image_record = self.image_record
             except InputItemValidateError as err:

--- a/tests/apiclient/test_bos.py
+++ b/tests/apiclient/test_bos.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2022, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -84,51 +84,3 @@ class TestBOSClientCommon(BOSClientTestCase):
                     BOSClientCommon.get_bos_client(MagicMock(), version=None),
                     client_cls
                 )
-
-
-class TestBOSV1BaseBootSetData(BOSClientTestCase):
-    """Test BOSV1Client.get_base_boot_set_data() """
-
-    def setUp(self):
-        super().setUp()
-        self.mock_get_config.return_value = 'v1'
-
-    def test_bos_v1_client_has_correct_keys(self):
-        """Test that the BOS v1 base boot set data has the correct keys"""
-        expected_keys = {
-            'rootfs_provider',
-            'rootfs_provider_passthrough'
-        }
-        actual_keys = set(
-            BOSClientCommon.get_bos_client(MagicMock())
-            .get_base_boot_set_data()
-            .keys()
-        )
-        self.assertTrue(expected_keys.issubset(actual_keys))
-
-
-class TestBOSV2BaseBootSetData(BOSClientTestCase):
-    """Test BOSV2Client.get_base_boot_set_data() """
-
-    def setUp(self):
-        super().setUp()
-        self.mock_get_config.return_value = 'v2'
-
-    def test_bos_v2_client_has_correct_keys(self):
-        """Test that the BOS v2 base boot set data has the correct keys"""
-        expected_keys = {
-            'rootfs_provider',
-            'rootfs_provider_passthrough'
-        }
-        removed_keys = {
-            'boot_ordinal',
-            'network',
-        }
-        actual_keys = set(
-            BOSClientCommon.get_bos_client(MagicMock())
-            .get_base_boot_set_data()
-            .keys()
-        )
-
-        self.assertTrue(expected_keys.issubset(actual_keys))
-        self.assertTrue(removed_keys.isdisjoint(actual_keys))


### PR DESCRIPTION
## Summary and Scope

Drop internal default values for rootfs_provider{,passthrough} from sat bootprep

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CRAYSAT-1942](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1942)

## Testing

### Tested on:

  * drax
  * Local development environment

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

