### PR TITLE
CRAYSAT-1945: Fix traceback error of session checks in CFS v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.33.7] - 2024-12-18
+
+### Fixed
+- Fixed the traceback error encountered during session checks in CFS v2
+  when using a smaller page size.
+
 ## [3.33.6] - 2024-12-12
 
 ### Added

--- a/sat/cli/bootsys/service_activity.py
+++ b/sat/cli/bootsys/service_activity.py
@@ -386,23 +386,24 @@ class CFSActivityChecker(ServiceActivityChecker):
         cfs_client = CFSClientBase.get_cfs_client(SATSession(), get_config_value('cfs.api_version'))
         try:
             sessions = cfs_client.get_sessions()
-        except (APIError, ValueError) as err:
+
+            cfs_session_fields = [
+                self.id_field_name,
+                'status.session.status',
+                'status.session.startTime',
+                'status.session.succeeded',
+                'status.session.job'
+            ]
+
+            return [
+                get_new_ordered_dict(session, cfs_session_fields, MISSING_VALUE)
+                for session in sessions
+                # Possible values are 'pending', 'running', or 'complete'
+                if get_val_by_path(session, 'status.session.status') != 'complete'
+            ]
+
+        except APIError as err:
             raise self.get_err(str(err))
-
-        cfs_session_fields = [
-            self.id_field_name,
-            'status.session.status',
-            'status.session.startTime',
-            'status.session.succeeded',
-            'status.session.job'
-        ]
-
-        return [
-            get_new_ordered_dict(session, cfs_session_fields, MISSING_VALUE)
-            for session in sessions
-            # Possible values are 'pending', 'running', or 'complete'
-            if get_val_by_path(session, 'status.session.status') != 'complete'
-        ]
 
 
 class FirmwareActivityChecker(ServiceActivityChecker):


### PR DESCRIPTION
## Summary and Scope

_Fixed the traceback error encountered during session checks in CFS v2 when using a smaller page size._

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CRAYSAT-1945](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1945)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * starlord
  
### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

Tested cfs v2 and cfs v3 session checks for both lower and higher page size

## Risks and Mitigations

_Low_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

