### PR TITLE
CRAYSAT-1930: Drop the `Arch` field from `sat status`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-(C) Copyright 2020-2024 Hewlett Packard Enterprise Development LP
+(C) Copyright 2020-2025 Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -24,6 +24,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [3.34.0] - 2025-01-08
+
+### Changed
+- Dropped the `Arch` field from `sat status` for all the components
+  except for Node type.
 
 ## [3.33.9] - 2024-12-11
 

--- a/sat/cli/status/status_module.py
+++ b/sat/cli/status/status_module.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022, 2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022, 2024-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -370,7 +370,7 @@ class HSMStatusModule(StatusModule):
 
     @staticmethod
     def include_heading(heading, *, component_type, **_):
-        return component_type == 'Node' or heading not in ['NID', 'Role', 'SubRole']
+        return component_type == 'Node' or heading not in ['NID', 'Role', 'SubRole', 'Arch']
 
     @property
     def rows(self):

--- a/tests/cli/status/test_status_module.py
+++ b/tests/cli/status/test_status_module.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022, 2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022, 2024-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -34,9 +34,11 @@ from csm_api_client.service.gateway import APIError
 import sat.cli.status.status_module as status_module_module
 from sat.cli.status.status_module import (
     BOSStatusModule,
+    HSMStatusModule,
     StatusModule,
     StatusModuleException,
 )
+from sat.cli.status.constants import COMPONENT_TYPES, DEFAULT_TYPE
 from sat.constants import MISSING_VALUE
 
 
@@ -451,3 +453,32 @@ class TestBOSStatusModule(BaseStatusModuleTestCase):
             'Most Recent BOS Session': self.bos_session,
             'Most Recent Image': self.img_id,
         })
+
+
+class TestHSMStatusModule(BaseStatusModuleTestCase):
+    """Tests for the HSMStatusModule class"""
+
+    def test_include_heading_node_type(self):
+        """Test that include_heading returns true for any heading for the Node type"""
+        for heading in HSMStatusModule.headings:
+            with self.subTest(heading=heading):
+                self.assertTrue(HSMStatusModule.include_heading(heading, component_type='Node'))
+
+    def test_include_heading_other_types(self):
+        """Test that include_heading for non-Node component types."""
+        for component_type in COMPONENT_TYPES:
+            if component_type == 'Node':
+                continue
+            else:
+                for heading in HSMStatusModule.headings:
+                    with self.subTest(component_type=component_type, heading=heading):
+                        if heading in ['NID', 'Role', 'SubRole', 'Arch']:
+                            self.assertFalse(HSMStatusModule.include_heading(heading, component_type=component_type))
+                        else:
+                            self.assertTrue(HSMStatusModule.include_heading(heading, component_type=component_type))
+
+    def test_include_heading_default_type(self):
+        """Test that include_heading returns true for any heading when using default type"""
+        for heading in HSMStatusModule.headings:
+            with self.subTest(heading=heading):
+                self.assertTrue(HSMStatusModule.include_heading(heading, component_type=DEFAULT_TYPE))


### PR DESCRIPTION
## Summary and Scope

_Drop the `Arch` field from `sat status`_

_When displaying the `sat status` of the components, do not include `Arch` field as it is hardcoded to X86 and thus meaningless or misleading to the end user for all the types except for `Node` type._

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CRAYSAT-1930](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1930)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Tyr

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

Tested `sat status` command for all the types which should drop `Arch` field except for Node type as it is distinguishing the Arch type

## Risks and Mitigations

_Minimal_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

