### PR TITLE
Backport CRAYSAT-1974 Bump jinja2 from 3.1.4 to 3.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.33.10] - 2025-01-09
+
+### Fixed
+- Update the version of jinja2 from 3.1.4 to 3.1.5 to resolve
+  CVE-2024-56201, and CVE-2024-56326
+
 ## [3.33.9] - 2024-12-11
 
 ### Removed

--- a/requirements-dev.lock.txt
+++ b/requirements-dev.lock.txt
@@ -22,7 +22,7 @@ htmlmin==0.1.12
 idna==3.7
 imagesize==1.3.0
 inflect==2.1.0
-Jinja2==3.1.4
+Jinja2==3.1.5
 jmespath==0.10.0
 json-schema-for-humans==0.40
 jsonschema==4.4.0

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -17,7 +17,7 @@ google-auth==2.6.0
 htmlmin==0.1.12
 idna==3.7
 inflect==2.1.0
-Jinja2==3.1.4
+Jinja2==3.1.5
 jmespath==0.10.0
 json-schema-for-humans==0.40
 jsonschema==4.4.0


### PR DESCRIPTION
## Summary and Scope

Bumps [jinja2](https://github.com/pallets/jinja) from 3.1.4 to 3.1.5.
- [Release notes](https://github.com/pallets/jinja/releases)
- [Changelog](https://github.com/pallets/jinja/blob/main/CHANGES.rst)
- [Commits](https://github.com/pallets/jinja/compare/3.1.4...3.1.5)

---
updated-dependencies:
- dependency-name: jinja2 dependency-type: direct:production ...

Signed-off-by: dependabot[bot] <support@github.com>
(cherry picked from commit a5181ef6c699f0068f7de223ce3472e84bd2a1f8)

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves CRAYSAT-1974

## Testing

### Tested on:

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

