### PR TITLE
CRAYSAT-1784: Support for `drop_branches` in CFS v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.34.2] - 2025-02-07
+
+### Fixed
+- Added support for the `drop_branches` parameter in CFS v3 configurations.
+  This allows CFS to drop branch names from the CFS layers after resolving them to commit hashes when creating or updating configurations.
+
 ## [3.34.1] - 2025-01-09
 
 ### Fixed

--- a/requirements-dev.lock.txt
+++ b/requirements-dev.lock.txt
@@ -14,7 +14,7 @@ coverage==6.3.2
 cray-product-catalog==2.4.1
 croniter==0.3.37
 cryptography==43.0.1
-csm-api-client==2.3.2
+csm-api-client==2.3.3
 dataclasses-json==0.5.6
 docutils==0.17.1
 google-auth==2.6.0

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -11,7 +11,7 @@ click==8.0.4
 cray-product-catalog==2.4.1
 croniter==0.3.37
 cryptography==43.0.1
-csm-api-client==2.3.2
+csm-api-client==2.3.3
 dataclasses-json==0.5.6
 google-auth==2.6.0
 htmlmin==0.1.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ argcomplete
 boto3
 botocore
 cray-product-catalog >= 2.4.1
-csm-api-client >= 2.3.2, <3.0
+csm-api-client >= 2.3.3, <3.0
 croniter >= 0.3, < 1.0
 inflect >= 0.2.5, < 3.0
 Jinja2 >= 3.0, < 4.0


### PR DESCRIPTION
## Summary and Scope

_Stop resolving branch names to commit hashes from `sat bootprep` in cfs v3. Use `drop_branches` parameter supported by cfs for v3_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CRAYSAT-1784](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1784)
* Will merge this after merging https://github.com/Cray-HPE/python-csm-api-client/pull/53

## Testing

_List the environments in which these changes were tested._

### Tested on:

  rocket

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

Test with `sat bootprep` command for both cfs v2 and v3. v3 should resolve the branch using `drop_branches` parameter. v2 will resolve the branches from `sat bootprep` logic.


## Risks and Mitigations

_Risk is minimal as resolving the branch for v3 depends on cfs `drop_branches` option_

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

