### PR TITLE
CRAYSAT-1887: Resolve repeated libceph errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.34.6] - 2025-03-10
+
+### Fixed
+- Resolved repeated libceph errors which delays shutdown of
+  Kubernetes worker nodes during `sat bootsys`
+
 ## [3.34.5] - 2025-02-28
 
 ### Added

--- a/tests/cli/bootsys/test_mgmt_power.py
+++ b/tests/cli/bootsys/test_mgmt_power.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2021, 2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2021, 2024-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -214,6 +214,8 @@ class TestDoMgmtShutdownPower(unittest.TestCase):
             'sat.cli.bootsys.mgmt_power.do_ceph_unmounts').start()
         self.mock_IPMIConsoleLogger = mock.patch(
             'sat.cli.bootsys.mgmt_power.IPMIConsoleLogger').start()
+        self.mock_unmount_volumes = patch(
+            'sat.cli.bootsys.mgmt_power.unmount_volumes').start()
 
         self.mock_ssh_client = mock.Mock()
         self.mock_get_ssh_client.return_value = self.mock_ssh_client
@@ -247,6 +249,7 @@ class TestDoMgmtShutdownPower(unittest.TestCase):
                                    self.ncn_shutdown_timeout, self.ipmi_timeout)
 
         # Assert calls for worker NCNs
+        self.mock_unmount_volumes.assert_any_call(self.mock_ssh_client, ['ncn-w001', 'ncn-w002'])
         self.mock_set_next_boot_device_to_disk.assert_any_call(self.mock_ssh_client, ['ncn-w001', 'ncn-w002'])
         self.mock_start_shutdown.assert_any_call(['ncn-w001', 'ncn-w002'], self.mock_ssh_client)
         self.mock_finish_shutdown.assert_any_call(['ncn-w001', 'ncn-w002'], self.username, self.password,


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

Resolved repeated libceph errors which delays shutdown of  Kubernetes worker nodes during `sat bootsys`

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CRAYSAT-1887](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1887)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * fanta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

Do the system shutdown and see the console logs that should remove the repeated libceph errors after unmounting ceph/s3fs/rbd devices.
If target is busy, there will be a warning of target is busy. If you want reduce the time you can kill that process too.

## Risks and Mitigations

_Low_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

