### PR TITLE
CRAYSAT-1985: Fix build failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.34.7] - 2025-03-19
+
+### Fixed
+- Fixed build failure due to change in location of `kubectl` version file.
+
 ## [3.34.6] - 2025-03-10
 
 ### Fixed

--- a/docker_scripts/config-docker-sat.sh
+++ b/docker_scripts/config-docker-sat.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -81,6 +81,6 @@ if [ -z "$KUBERNETES_PULL_VERSION" ]; then
     exit 1
 fi
 
-curl -fLO "https://storage.googleapis.com/kubernetes-release/release/v${KUBERNETES_PULL_VERSION#v}/bin/linux/amd64/kubectl"
+curl -fLO "https://dl.k8s.io/release/v${KUBERNETES_PULL_VERSION#v}/bin/linux/amd64/kubectl"
 chmod +x ./kubectl
 mv ./kubectl /usr/bin


### PR DESCRIPTION
## Summary and Scope

_Fixed build failure due to change in location of `kubectl` version file._

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CRAYSAT-1985](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1985)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  wasp ( CSM 1.7.0)

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

Built the container image, downloaded to wasp, and ran the
CoreV1Api.list_node method in a Python interpreter in the sat bash
shell.

Also ran sat bootprep run against a simple input file that defined a
single CFS configuration, built an image from a recipe, and then
configured that image with CFS. This was just to ensure that nothing
using the K8s API in that code path was impacted.

## Risks and Mitigations

_Low_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

