### PR TITLE
CRAYSAT-1977: Fix `CryptographyDeprecationWarning` message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.34.9] - 2025-04-01
+
+### Fixed
+- Fixed `CryptographyDeprecationWarning` message by upgrading `paramiko`
+  to 3.4.1
+
 ## [3.34.8] - 2025-03-26
 
 ### Added

--- a/requirements-dev.lock.txt
+++ b/requirements-dev.lock.txt
@@ -36,7 +36,7 @@ natsort==8.1.0
 nose2==0.12.0
 oauthlib==3.2.2
 packaging==21.3
-paramiko==3.4.0
+paramiko==3.4.1
 parsec==3.5
 prettytable==0.7.2
 pyasn1==0.4.8

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -29,7 +29,7 @@ marshmallow-enum==1.5.1
 mypy-extensions==0.4.3
 natsort==8.1.0
 oauthlib==3.2.2
-paramiko==3.4.0
+paramiko==3.4.1
 parsec==3.5
 prettytable==0.7.2
 pyasn1==0.4.8


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

Fixed `CryptographyDeprecationWarning` message by upgrading `paramiko` to 3.4.1

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CRAYSAT-1977](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1977)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * drax

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

Test the module where cryptography or paramiko has been used

## Risks and Mitigations

_Low_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

