### PR TITLE
CRAYSAT-1961: Add output when there is no inconsistencies from `slscheck`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.35.6] - 2025-04-25
+
+### Added
+- Added INFO-level log message to output of `sat slscheck` when there is no
+  inconsistencies.
+
 ## [3.35.5] - 2025-04-22
 
 ### Added

--- a/sat/cli/slscheck/main.py
+++ b/sat/cli/slscheck/main.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021, 2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -413,6 +413,10 @@ def do_slscheck(args):
         hsm_components,
         hsm_redfish_endpoints
     )
+
+    # Log an info message if no inconsistencies are found
+    if not crosscheck_results:
+        LOGGER.info('No inconsistencies found between SLS and HSM.')
 
     report = Report(
         HEADERS, None,


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

_Add INFO-level log message to output of `sat slscheck` when consistent_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CRAYSAT-1961](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1961)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * development system
  * fanta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Tested `sat slscheck` command before and after changes with various options where there are no inconsistencies. It should print info messages

## Risks and Mitigations

_N/A_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

