### PR TITLE
CRAYSAT-1991: Support `debug_on_failure` of CFS V3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,10 +25,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.35.9] - 2025-05-12
+
+### Added
+- Added support for the `debug_on_failure` parameter when creating CFS V3
+  image customization session
+
 ## [3.35.8] - 2025-05-09
 
 ### Fixed
-- Fixed bug intoduced by 3.35.7: local variable 'skipped_images' 
+- Fixed bug introduced by 3.35.7: local variable `skipped_images` 
   referenced before assignment
 
 ## [3.35.7] - 2025-04-29

--- a/docs/man/sat-bootprep.8.rst
+++ b/docs/man/sat-bootprep.8.rst
@@ -7,7 +7,7 @@ Prepare to boot nodes with images and configurations
 ----------------------------------------------------
 
 :Author: Hewlett Packard Enterprise Development LP.
-:Copyright: Copyright 2021-2024 Hewlett Packard Enterprise Development LP.
+:Copyright: Copyright 2021-2025 Hewlett Packard Enterprise Development LP.
 :Manual section: 8
 
 SYNOPSIS
@@ -129,6 +129,15 @@ These options only apply to the ``run`` action.
         name and commit hash in the layer of the configuration. CFS can use the
         branch name to update the commit hash to the latest HEAD of the branch
         if requested.
+
+**--debug-on-failure**
+        Enable debug-on-failure to keep the IMS job running for debugging purposes
+        if the CFS session fails. When something goes wrong during execution of
+        Ansible code run by Image Customization, any state kept in the file system
+        of the image being created gets deleted immediately when the container is
+        torn down. By default, if ``--debug-on-failure`` is not specified the logs
+        get destroyed when container is torn down.
+        Note that this parameter is supported only with CFS V3.
 
 **--delete-ims-jobs**
         Delete IMS jobs after creating images. Note that deleting IMS jobs makes

--- a/requirements-dev.lock.txt
+++ b/requirements-dev.lock.txt
@@ -14,7 +14,7 @@ coverage==6.3.2
 cray-product-catalog==2.4.1
 croniter==0.3.37
 cryptography==44.0.1
-csm-api-client==2.3.4
+csm-api-client==2.3.5
 dataclasses-json==0.5.6
 docutils==0.17.1
 google-auth==2.6.0

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -11,7 +11,7 @@ click==8.0.4
 cray-product-catalog==2.4.1
 croniter==0.3.37
 cryptography==44.0.1
-csm-api-client==2.3.4
+csm-api-client==2.3.5
 dataclasses-json==0.5.6
 google-auth==2.6.0
 htmlmin==0.1.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ argcomplete
 boto3
 botocore
 cray-product-catalog >= 2.4.1
-csm-api-client >= 2.3.4, <3.0
+csm-api-client >= 2.3.5, <3.0
 croniter >= 0.3, < 1.0
 inflect >= 0.2.5, < 3.0
 Jinja2 >= 3.0, < 4.0

--- a/sat/cli/bootprep/input/instance.py
+++ b/sat/cli/bootprep/input/instance.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -37,7 +37,7 @@ class InputInstance:
 
     def __init__(self, instance_dict, request_dumper,
                  cfs_client, ims_client, bos_client,
-                 jinja_env, product_catalog, dry_run, limit):
+                 jinja_env, product_catalog, dry_run, limit, debug_on_failure=False):
         """Create a new InputInstance from the validated contents of an input file.
 
         Args:
@@ -68,6 +68,7 @@ class InputInstance:
         self.product_catalog = product_catalog
         self.dry_run = dry_run
         self.limit = limit
+        self.debug_on_failure = debug_on_failure
 
     @cached_property
     def input_configurations(self):
@@ -85,7 +86,7 @@ class InputInstance:
     def input_images(self):
         """list of InputImages: the images in the input instance"""
         return [BaseInputImage.get_image(image, index, self, self.jinja_env, self.product_catalog,
-                                         self.ims_client, self.cfs_client)
+                                         self.ims_client, self.cfs_client, debug_on_failure=self.debug_on_failure)
                 for index, image in enumerate(self.instance_dict.get(IMAGES_KEY, []))]
 
     @cached_property

--- a/sat/cli/bootprep/main.py
+++ b/sat/cli/bootprep/main.py
@@ -241,7 +241,7 @@ def do_bootprep_run(schema_validator, args):
     jinja_env.globals = var_context.vars
 
     instance = InputInstance(instance_data, request_dumper, cfs_client, ims_client, bos_client,
-                             jinja_env, product_catalog, args.dry_run, args.limit)
+                             jinja_env, product_catalog, args.dry_run, args.limit, args.debug_on_failure)
 
     # This is kind of an odd way to pass this through, but it works
     InputConfigurationLayerBase.resolve_branches = args.resolve_branches

--- a/sat/cli/bootprep/parser.py
+++ b/sat/cli/bootprep/parser.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -248,6 +248,11 @@ def _add_bootprep_run_subparser(subparsers):
         '--no-resolve-branches', action='store_false', dest='resolve_branches',
         help='Do not resolve branch names to corresponding commit hashes before '
              'creating CFS configurations.'
+    )
+    run_subparser.add_argument(
+        '--debug-on-failure', action='store_true', dest='debug_on_failure',
+        help='Enable debug-on-failure to keep the IMS job running for debugging '
+             'purposes if the CFS session fails.'
     )
     run_subparser.add_argument(
         '--delete-ims-jobs', '-D', action='store_true',

--- a/tests/cli/bootprep/test_main.py
+++ b/tests/cli/bootprep/test_main.py
@@ -122,7 +122,7 @@ class TestDoBootprepRun(unittest.TestCase):
                               dry_run=self.dry_run, view_input_schema=False, generate_schema_docs=False,
                               bos_version='v1', recipe_version=None, vars_file=None, vars=None,
                               output_dir='.', save_files=True, resolve_branches=True,
-                              format='json', limit=None)
+                              debug_on_failure=False, format='json', limit=None)
         self.schema_file = 'schema.yaml'
         self.mock_multireport_cls = patch('sat.cli.bootprep.main.MultiReport').start()
         self.mock_validator_cls = MagicMock()
@@ -165,7 +165,7 @@ class TestDoBootprepRun(unittest.TestCase):
         self.mock_input_instance_cls.assert_called_once_with(
             self.validated_data, self.mock_request_dumper, self.mock_cfs_client, self.mock_ims_client,
             self.mock_bos_client, self.mock_sandboxed_environment, self.mock_product_catalog,
-            self.dry_run, ALL_KEYS
+            self.dry_run, ALL_KEYS, self.args.debug_on_failure
         )
         self.mock_configurations.handle_existing_items.assert_called_once_with(
             self.overwrite_configs, self.skip_existing_configs
@@ -201,7 +201,7 @@ class TestDoBootprepRun(unittest.TestCase):
         self.mock_input_instance_cls.assert_called_once_with(
             self.validated_data, self.mock_request_dumper, self.mock_cfs_client, self.mock_ims_client,
             self.mock_bos_client, self.mock_sandboxed_environment, self.mock_product_catalog,
-            self.dry_run, ALL_KEYS
+            self.dry_run, ALL_KEYS, self.args.debug_on_failure
         )
         self.mock_configurations.handle_existing_items.assert_called_once_with(
             self.overwrite_configs, self.skip_existing_configs
@@ -269,7 +269,7 @@ class TestDoBootprepRun(unittest.TestCase):
         self.mock_input_instance_cls.assert_called_once_with(
             self.validated_data, self.mock_request_dumper, self.mock_cfs_client, self.mock_ims_client,
             self.mock_bos_client, self.mock_sandboxed_environment, self.mock_product_catalog,
-            self.dry_run, ALL_KEYS
+            self.dry_run, ALL_KEYS, self.args.debug_on_failure
         )
         self.mock_configurations.handle_existing_items.assert_called_once_with(
             self.overwrite_configs, self.skip_existing_configs
@@ -300,7 +300,7 @@ class TestDoBootprepRun(unittest.TestCase):
         self.mock_input_instance_cls.assert_called_once_with(
             self.validated_data, self.mock_request_dumper, self.mock_cfs_client, self.mock_ims_client,
             self.mock_bos_client, self.mock_sandboxed_environment, self.mock_product_catalog,
-            self.dry_run, ALL_KEYS
+            self.dry_run, ALL_KEYS, self.args.debug_on_failure
         )
         self.mock_configurations.handle_existing_items.assert_called_once_with(
             self.overwrite_configs, self.skip_existing_configs


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

_Support `debug-on-failure` of cfs v3 in `sat bootprep`_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CRAYSAT-1991](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1991)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * fanta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Tested with `sat bootprep run` command by adding `--debug-on-failure` which should update the cfs session debug-on-failure to true to get logs even when container torned. Without adding `--debug-on-failure`, the cfs session updates debug-on-failure as false by default which means the logs may lost if container torned off.

## Risks and Mitigations

_Low_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

