### PR TITLE
CRAYSAT-1994: fixed local variable 'skipped_images' referenced before assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.35.8] - 2025-05-09
+
+### Fixed
+- Fixed bug intoduced by 3.35.7: local variable 'skipped_images' 
+  referenced before assignment
+
 ## [3.35.7] - 2025-04-29
 
 ### Added

--- a/sat/cli/bootprep/main.py
+++ b/sat/cli/bootprep/main.py
@@ -287,6 +287,7 @@ def do_bootprep_run(schema_validator, args):
 
     created_images = []
     failed_images = []
+    skipped_images = []
     if IMAGES_KEY in args.limit:
         created_images, skipped_images, failed_images = create_images(instance, args, ims_client)
     else:


### PR DESCRIPTION
## Summary and Scope

Fixed bug introduced in CRAYSAT-1652 local variable 'skipped_images' referenced before assignment

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

* Resolves CRAYSAT-1994

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Local development environment
  * Gamora
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Yes
- Were continuous integration tests run? If not, why? yes
- Was upgrade tested? If not, why? yes
- Was downgrade tested? If not, why? yes
- Were new tests (or test issues/Jiras) created for this change? yes

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_ No


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

