### PR TITLE
CRAYSAT-1584: Add HSM lock status to output of `sat status`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.35.10] - 2025-05-14
+
+### Added
+- Added HSM lock status to output of `sat status`
+
 ## [3.35.9] - 2025-05-12
 
 ### Added

--- a/sat/cli/status/status_module.py
+++ b/sat/cli/status/status_module.py
@@ -353,7 +353,8 @@ class HSMStatusModule(StatusModule):
     This is the primary status module since it retrieves the list of xnames on the system.
     """
 
-    headings = ['xname', 'Type', 'NID', 'State', 'Flag', 'Enabled', 'Arch', 'Class', 'Role', 'SubRole', 'Net Type']
+    headings = ['xname', 'Type', 'NID', 'State', 'Flag', 'Enabled', 'Arch', 'Class', 'Role', 'SubRole', 'Net Type',
+                'Locked']
     source_name = 'HSM'
     primary = True
 


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

_Add HSM lock status to output of `sat status`_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CRAYSAT-1584](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1584)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Gamora
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

Test the `sat status` command that should give lock status field also with this change.

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_
NO


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

