### PR TITLE
CRAYSAT-1999: Resolve image_customization_error for `debug_on_failure`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.35.15] - 2025-06-16
+
+### Fixed
+- Fixed `create_image_customization_session ` error for unexpected
+  key word `debug_on_failure`
+
 ## [3.35.14] - 2025-06-11
 
 ### Fixed


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

Resolved create_image_customization error due to unexpected keyword 'debug_on_failure'` in cfs v3
`TypeError: create_image_customization_session() got an unexpected keyword argument 'debug_on_failure'`

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CRAYSAT-1999](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1999)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * fanta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Run `sat bootprep` to check all the test cases both with cfs v2 and v3,  with and without `debug_on_failure`

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_Low


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

