### PR TITLE
CRAYSAT-2000: Fix `EnhancedValidationError.__str__`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support to `sat bootprep` for specifying the commit hash in a
   source-based CFS configuration layer
 
+### Fixed
+- Fixed `sat bootprep` schema validation error handling to correctly handle
+  the case when an input matches more than one subschema in a `oneOf`.
+
 ## [3.35.15] - 2025-06-16
 
 ### Fixed

--- a/sat/data/schema/bootprep_schema.yaml
+++ b/sat/data/schema/bootprep_schema.yaml
@@ -220,11 +220,7 @@ properties:
                   type: string
               oneOf:
                 - required: ['branch']
-                  not:
-                    required: ['commit']
                 - required: ['commit']
-                  not:
-                    required: ['branch']
 
         additional_inventory:
           oneOf:

--- a/tests/cli/bootprep/test_validate.py
+++ b/tests/cli/bootprep/test_validate.py
@@ -1032,8 +1032,8 @@ class TestValidateInstance(ExtendedTestCase):
         }
         instance = self.get_instance_with_config_layer(layer)
         expected_errs = [
-            (('configurations', 0, 'layers', 0), "Not valid under any of the given schemas", 1),
-            (('configurations', 0, 'layers', 0), "Not valid under any of the given schemas", 2),
+            (('configurations', 0, 'layers', 0), NOT_VALID_ANY_OF_MESSAGE, 1),
+            (('configurations', 0, 'layers', 0), NOT_VALID_ANY_OF_MESSAGE, 2),
             (('configurations', 0, 'layers', 0), "'branch' is a required property", 3)
         ]
         self.assert_invalid_instance(instance, expected_errs)
@@ -1049,9 +1049,8 @@ class TestValidateInstance(ExtendedTestCase):
         }
         instance = self.get_instance_with_config_layer(layer)
         expected_errs = [
-            (('configurations', 0, 'layers', 0), "Not valid under any of the given schemas", 1),
-            (('configurations', 0, 'layers', 0), "Not valid under any of the given schemas", 2),
-            (('configurations', 0, 'layers', 0), r"should not be valid under \{'required': \['commit'\]\}", 3)
+            (('configurations', 0, 'layers', 0), NOT_VALID_ANY_OF_MESSAGE, 1),
+            (('configurations', 0, 'layers', 0), 'Valid under more than one of the given schemas', 2),
         ]
         self.assert_invalid_instance(instance, expected_errs)
 


### PR DESCRIPTION


## Summary and Scope

Fix the `__str__` method of `EnhancedValidationError` to properly handle the case where the validation error occurs because the instance object matches more than exactly one subschema in a `oneOf`. When this occurs, the `jsonschema.ValidationError` does not contain any `context`, and the `message` attribute just contains a message to the effect of "<instance> is valid under each of <oneOf subschemas>".

Fix this issue by explicitly checking whether "is valid under each" occurs in the message for the `ValidationError` in the `__str__` method. In addition, if the `context` is empty in the `best_context` method, simply return the empty list because there is no additional context to report.

With this fix, it is no longer necessary to add the `not:` subschemas, so remove them. The schema is more clear without them, but it is clear now that it was a valid workaround because it resulted in neither of the subschemas in the `oneOf` matching the instance instead of both matching.

## Issues and Related PRs

* Required for CRAYSAT-2000

## Testing

### Tested on:

  * Local development environment

### Test description:

Tested on three different bootprep files that each define a CFS configuration with a single source-based layer. When only branch or only commit is specified, it passes validation. When both are specified it fails validation with a clear error.

In addition, generated HTML schema documentation with `sat bootprep generate-docs` and inspected it in the browser.

Finally, also made a temporary modification to `bootprep_schema.yaml` that added a third property, `tag`, which was mutually exclusive with the `branch`, and `commit` properties and could be specified instead of those properties. Verified that an input file that specified two of the three mutually exclusive properties (e.g. `branch` and `commit`), but not the third (e.g. `tag`) was still properly caught.

## Risks and Mitigations

Pretty low risk since unit tests thoroughly test validation logic against many different valid and invalid inputs.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

