### PR TITLE
CRAYSAT-1944: Update cray-product-catalog and use shallow load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.35.18] - 2025-07-28
+
+### Changed
+- Improved performance of `sat bootprep` and `sat showrev` commands by pulling
+  in newer version of `cray-product-catalog` library and using shallow loading
+  mode in `sat bootprep`.
+
 ## [3.35.17] - 2025-06-26
 
 ### Security

--- a/requirements-dev.lock.txt
+++ b/requirements-dev.lock.txt
@@ -11,7 +11,7 @@ cffi==1.15.0
 charset-normalizer==2.0.12
 click==8.0.4
 coverage==6.3.2
-cray-product-catalog==2.4.1
+cray-product-catalog==2.8.0
 croniter==0.3.37
 cryptography==44.0.1
 csm-api-client==2.3.6

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -8,7 +8,7 @@ certifi==2024.7.4
 cffi==1.15.0
 charset-normalizer==2.0.12
 click==8.0.4
-cray-product-catalog==2.4.1
+cray-product-catalog==2.8.0
 croniter==0.3.37
 cryptography==44.0.1
 csm-api-client==2.3.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@
 argcomplete
 boto3
 botocore
-cray-product-catalog >= 2.4.1
+cray-product-catalog >= 2.8.0, < 3.0
 csm-api-client >= 2.3.6, <3.0
 croniter >= 0.3, < 1.0
 inflect >= 0.2.5, < 3.0

--- a/sat/cli/bootprep/main.py
+++ b/sat/cli/bootprep/main.py
@@ -222,7 +222,8 @@ def do_bootprep_run(schema_validator, args):
 
     LOGGER.debug("Loading product catalog data")
     try:
-        product_catalog = ProductCatalog()
+        # Only the data from the main config map is needed, so do a shallow load to improve performance
+        product_catalog = ProductCatalog(shallow=True)
     except ProductCatalogError as err:
         LOGGER.warning(f'Failed to load product catalog data. Creation of any input items '
                        f'that require data from the product catalog will fail. ({err})')

--- a/sat/cli/showrev/products.py
+++ b/sat/cli/showrev/products.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2023, 2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -58,6 +58,8 @@ def get_product_versions():
     headers = [product_key, version_key, image_key, recipe_key]
 
     try:
+        # We do not use any of the component_versions data in the separate ConfigMaps, but do not
+        # do a shallow load because some product versions may exist only in the separate ConfigMaps.
         product_catalog = ProductCatalog()
     except ProductCatalogError as err:
         LOGGER.error(f'Unable to obtain product version information from product catalog: {err}')


### PR DESCRIPTION
## Summary and Scope
A new version of cray-product-catalog is available that greatly improves
performance of loading the product catalog when instantiating a
`ProductCatalog` instance. It also adds a `shallow` boolean parameter
that causes it to only load the data from the main ConfigMap. This
ConfigMap contains all the data used by `sat bootprep`, so update `sat
bootprep` to pass `shallow=True` to further improve performance.
## Issues and Related PRs

* Resolves CRAYSAT-1944

## Testing

### Tested on:

  * rocket

### Test description:

Tested by running SAT functional tests on rocket with this new cray-sat
image.

Also tested `sat showrev` by comparing the output before this change to
the output after this change.

## Risks and Mitigations

There is some risk because the cray-product-catalog code was significantly refactored. However, this is being tested well via automated SAT functional tests.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

