### PR TITLE
CRAYSAT-2032: Fix `NoneType` object error from get_ssh_client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.36.1] - 2025-09-02
+
+### Fixed
+- Skip unparsable known_hosts entries in `get_ssh_client` to prevent a traceback
+  with message "AttributeError: `NoneType` object has no attribute `hostnames`"
+
 ## [3.36.0] - 2025-08-13
 
 ### Fixed

--- a/sat/cli/bootsys/hostkeys.py
+++ b/sat/cli/bootsys/hostkeys.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023, 2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -65,6 +65,9 @@ class FilteredHostKeys(HostKeys):
                 tempfile.NamedTemporaryFile(mode='w+') as tmp_known_hosts:
             for line in known_hosts:
                 entry = HostKeyEntry.from_line(line)
+                # skip any unparsable or empty entries
+                if entry is None:
+                    continue
                 if any(hn in entry.hostnames for hn in self.hostnames):
                     tmp_known_hosts.write(entry.to_line())
             tmp_known_hosts.flush()


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

Skip unparsable known_hosts entries in get_ssh_client to prevent "`NoneType` object has no attribute `hostnames` from get_ssh_client"

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CRAYSAT-2032](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-2032), [CAST-38540](https://jira-pro.it.hpe.com:8443/browse/CAST-38540)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * rocket

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

Test the FilteredHostKeys by taking valid and invalid entries from known_host file. It should skip the None objects if there any in the known_host

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_Low


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

