### PR TITLE
CRAYSAT-2026: Ensure sorted output for multi-value fields in `sat hwinv`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.36.2] - 2025-09-03
+
+### Fixed
+- Ensure that the values of multi-value fields in the output of `sat hwinv` are
+  printed in sorted order, so that they do not change from one execution to the
+  next.
+
 ## [3.36.1] - 2025-09-02
 
 ### Fixed

--- a/sat/system/component.py
+++ b/sat/system/component.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2021, 2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2021, 2024, 2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -177,8 +177,9 @@ class BaseComponent:
             or the EMPTY_VALUE string if there are no children of this type.
         """
         unique_child_vals = self.get_unique_child_vals(child_type, field_name)
+        # Ensure deterministic ordering by sorting the values
         return (EMPTY_VALUE if not unique_child_vals
-                else ', '.join(str(val) for val in unique_child_vals))
+                else ', '.join(str(val) for val in sorted(unique_child_vals)))
 
     @cached_property
     def type(self):

--- a/tests/system/test_component.py
+++ b/tests/system/test_component.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2020, 2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -378,25 +378,46 @@ class TestBaseComponentChildren(ExtendedTestCase):
     def test_get_unique_child_vals_str_unique(self):
         actual_str = self.component.get_unique_child_vals_str(ChildComponent,
                                                               'serial_number')
-        self.assertEqual(sorted(actual_str.split(', ')), self.children_ser_nums)
+        self.assertEqual(self.children_ser_nums, sorted(actual_str.split(', ')))
 
     def test_get_unique_child_vals_str_all_same(self):
         expected_str = self.children_model
         actual_str = self.component.get_unique_child_vals_str(ChildComponent,
                                                               'model')
-        self.assertEqual(actual_str, expected_str)
+        self.assertEqual(expected_str, actual_str)
 
     def test_get_unique_child_vals_str_int_val(self):
         expected_str = str(self.children_sku)
         actual_str = self.component.get_unique_child_vals_str(ChildComponent,
                                                               'sku')
-        self.assertEqual(actual_str, expected_str)
+        self.assertEqual(expected_str, actual_str)
 
     def test_get_unique_child_vals_str_unknown(self):
         """Test get_child_vals on an unknown child type."""
         # The SampleComponent type does not have any children of type SampleComponent
         actual_vals = self.component.get_unique_child_vals_str(SampleComponent, 'xname')
-        self.assertEqual(actual_vals, EMPTY_VALUE)
+        self.assertEqual(EMPTY_VALUE, actual_vals)
+
+    def test_get_unique_child_vals_str_sorted_order(self):
+        """Test that get_unique_child_vals_str returns sorted values for multiple children."""
+        # Manufacturers in non-sorted order
+        manufacturers = ['Samsung', 'SK Hynix', 'HPE']
+        # Create children with manufacturers in the given non-sorted order
+        children = [
+            ChildComponent(get_component_raw_data(
+                hsm_type=ChildComponent.hsm_type,
+                manufacturer=manu,
+                xname=f"x1000c0s0b0d{idx}",
+                serial_number=str(1000 + idx),
+                sku=12345
+            )) for idx, manu in enumerate(manufacturers)
+        ]
+        component = SampleComponent(get_component_raw_data())
+        for child in children:
+            component.add_child_object(child)
+        # The string should always be in deterministic sorted order
+        actual_str = component.get_unique_child_vals_str(ChildComponent, 'manufacturer')
+        self.assertEqual(', '.join(sorted(manufacturers)), actual_str)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary and Scope

Ensure that multi-value fields in the output of `sat hwinv` are printed in
sorted order, so the output remains consistent across executions. Updated
unit tests to verify that multi-value fields are sorted as expected in the
output.

Also swapped order of arguments in several other calls to `assertEqual`
since the order is supposed to be (expected, actual).

## Issues and Related PRs

* Resolves CRAYSAT-2026

## Testing

### Tested on:

  * wasp

### Test description:

Tested by pulling new cray-sat image and running `sat hwinv
--summarize-nodes` on wasp where both the memory manufacturer and memory
device type fields have multiple values on a couple nodes. Ensured the
comma-separated list of values was always sorted.

## Risks and Mitigations

Pretty low-risk isolated change to `sat hwinv` summary behavior.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

