### PR TITLE
CRAYSAT-2032: Fix `NoneType` object error from get_ssh_client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-(C) Copyright 2020-2024 Hewlett Packard Enterprise Development LP
+(C) Copyright 2020-2025 Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -24,6 +24,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [3.33.11] - 2025-09-02
+
+### Fixed
+- Skip unparsable known_hosts entries in `get_ssh_client` to prevent a traceback
+  with message "AttributeError: `NoneType` object has no attribute `hostnames`"
 
 ## [3.33.10] - 2025-01-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Skip unparsable known_hosts entries in `get_ssh_client` to prevent a traceback
   with message "AttributeError: `NoneType` object has no attribute `hostnames`"
+- Fixed build failure due to change in location of `kubectl` version file.
 
 ## [3.33.10] - 2025-01-09
 

--- a/docker_scripts/config-docker-sat.sh
+++ b/docker_scripts/config-docker-sat.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -81,6 +81,6 @@ if [ -z "$KUBERNETES_PULL_VERSION" ]; then
     exit 1
 fi
 
-curl -fLO "https://storage.googleapis.com/kubernetes-release/release/v${KUBERNETES_PULL_VERSION#v}/bin/linux/amd64/kubectl"
+curl -fLO "https://dl.k8s.io/release/v${KUBERNETES_PULL_VERSION#v}/bin/linux/amd64/kubectl"
 chmod +x ./kubectl
 mv ./kubectl /usr/bin

--- a/sat/cli/bootsys/hostkeys.py
+++ b/sat/cli/bootsys/hostkeys.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023, 2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -65,6 +65,9 @@ class FilteredHostKeys(HostKeys):
                 tempfile.NamedTemporaryFile(mode='w+') as tmp_known_hosts:
             for line in known_hosts:
                 entry = HostKeyEntry.from_line(line)
+                # skip any unparsable or empty entries
+                if entry is None:
+                    continue
                 if any(hn in entry.hostnames for hn in self.hostnames):
                     tmp_known_hosts.write(entry.to_line())
             tmp_known_hosts.flush()


### PR DESCRIPTION
(cherry picked from commit 8a9535efcc0acb00d451053504bbb3137aefe7f6)
(cherry picked from commit 45c2e0821fd07b178b3d271e2dfd5211cf416a34)

Backport of https://github.com/Cray-HPE/sat/pull/371
Backport of https://github.com/Cray-HPE/sat/pull/327

